### PR TITLE
Add ability to register custom transports.

### DIFF
--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -144,7 +144,6 @@ class WP_Push_Syndication_Server {
 	}
 	
     public function admin_init() {
-
         // @TODO define more parameters
 		$name_match = '#class-wp-(.+)-client\.php#';
 		
@@ -163,7 +162,7 @@ class WP_Push_Syndication_Server {
 					}
 			}
 		}
-
+        $this->push_syndicate_transports = apply_filters( 'syn_transports', $this->push_syndicate_transports );
 		// register styles and scripts
         wp_register_style( 'syn_sites', plugins_url( 'css/sites.css', __FILE__ ), array(), $this->version  );
 
@@ -1135,9 +1134,9 @@ class WP_Push_Syndication_Server {
             if( $site_enabled != 'on' )
                 continue;
 
-            $inserted_posts = get_post_meta( $site->ID, 'syn_inserted_posts', true);
-            $transport_type = get_post_meta( $site->ID, 'syn_transport_type', true);
-            $client         = WP_Client_Factory::get_client( $transport_type  ,$site->ID );
+            $inserted_posts = get_post_meta( $site->ID, 'syn_inserted_posts', true );
+            $transport_type = get_post_meta( $site->ID, 'syn_transport_type', true );
+            $client         = WP_Client_Factory::get_client( $transport_type, $site->ID );
             $posts          = $client->get_posts();
 
             if( empty( $posts ) )

--- a/includes/class-wp-rest-client.php
+++ b/includes/class-wp-rest-client.php
@@ -246,19 +246,19 @@ class WP_REST_Client implements WP_Client{
             <label for=site_token><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>
         </p>
         <p>
-            <input type="text" name="site_token" id="site_token" size="100" value="<?php echo esc_attr( $site_token ); ?>" />
+            <input type="text" class="widefat" name="site_token" id="site_token" size="100" value="<?php echo esc_attr( $site_token ); ?>" />
         </p>
         <p>
             <label for=site_id><?php echo esc_html__( 'Enter Blog ID', 'push-syndication' ); ?></label>
         </p>
         <p>
-            <input type="text" name="site_id" id="site_id" size="100" value="<?php echo esc_attr( $site_id ); ?>" />
+            <input type="text" class="widefat" name="site_id" id="site_id" size="100" value="<?php echo esc_attr( $site_id ); ?>" />
         </p>
         <p>
             <label for=site_url><?php echo esc_html__( 'Enter a valid Blog URL', 'push-syndication' ); ?></label>
         </p>
         <p>
-            <input type="text" name="site_url" id="site_url" size="100" value="<?php echo esc_attr( $site_url ); ?>" />
+            <input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_attr( $site_url ); ?>" />
         </p>
 
         <?php

--- a/includes/class-wp-rss-client.php
+++ b/includes/class-wp-rss-client.php
@@ -94,7 +94,7 @@ class WP_RSS_Client extends SimplePie implements WP_Client {
             <label for="feed_url"><?php echo esc_html__( 'Enter feed URL', 'push-syndication' ); ?></label>
         </p>
         <p>
-            <input type="text" name="feed_url" id="feed_url" size="100" value="<?php echo esc_attr( $feed_url ); ?>" />
+            <input type="text" class="widefat" name="feed_url" id="feed_url" size="100" value="<?php echo esc_attr( $feed_url ); ?>" />
         </p>
         <p>
             <label for="default_post_type"><?php echo esc_html__( 'Select post type', 'push-syndication' ); ?></label>

--- a/includes/class-wp-xmlrpc-client.php
+++ b/includes/class-wp-xmlrpc-client.php
@@ -357,19 +357,19 @@ class WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements WP_Client {
 			<label for=site_url><?php echo esc_html__( 'Enter a valid site URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="site_url" id="site_url" size="100" value="<?php echo esc_html( $site_url ); ?>" />
+			<input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_html( $site_url ); ?>" />
 		</p>
 		<p>
 			<label for="site_username"><?php echo esc_html__( 'Enter Username', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="site_username" id="site_username" size="100" value="<?php echo esc_attr( $site_username ); ?>" />
+			<input type="text" class="widefat" name="site_username" id="site_username" size="100" value="<?php echo esc_attr( $site_username ); ?>" />
 		</p>
 		<p>
 			<label><?php echo esc_html__( 'Enter Password', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="password" name="site_password" id="site_password" size="100"  autocomplete="off" value="<?php echo esc_attr( $site_password ); ?>" />
+			<input type="password" class="widefat" name="site_password" id="site_password" size="100"  autocomplete="off" value="<?php echo esc_attr( $site_password ); ?>" />
 		</p>
 
         <?php


### PR DESCRIPTION
Currently this plugin only supports three transport types as defined by class-wp-rest-client.php, class-wp-rss-client.php, and class-wp-xmlrpc-client.php and does not allow for other transport types to be added. I propose adding a hook called syn_transports after the default transport types are added to allow for developers to add their own.
