### PR TITLE
add a missing include for the WP_XML client

### DIFF
--- a/includes/class-syndication-client-factory.php
+++ b/includes/class-syndication-client-factory.php
@@ -1,6 +1,7 @@
 <?php
 
 include_once( dirname( __FILE__ ) . '/class-syndication-wp-xmlrpc-client.php' );
+include_once( dirname( __FILE__ ) . '/class-syndication-wp-xml-client.php' );
 include_once( dirname( __FILE__ ) . '/class-syndication-wp-rest-client.php' );
 include_once( dirname( __FILE__ ) . '/class-syndication-wp-rss-client.php' );
 


### PR DESCRIPTION
Hi Mo,

I think this include might be necessary to pull content via XML (at least, it fixed the class_exists() error I was getting). Can you check it out and merge if appropriate?

Thanks,

-Vasken
