### PR TITLE
Support for XML Taxonomy on xml-client

### DIFF
--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -223,7 +223,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 					} else if ( isset($save_location['is_tax']) && $save_location['is_tax'] ) {
 						//for some taxonomies, multiple values may be supplied in the field
 						foreach ( $value_array as $value ) {
-							$tax_data[] = array( 'tax_name' => $save_location['field'], 'tax_value'=> ( string ) $value );
+							$tax_data[$save_location['field']] = ( string ) $value;
 						}
 					} else {
 						$item_fields[$save_location['field']] = (string)$value_array[0];


### PR DESCRIPTION
The current array structure for the xml taxonomy structure was incompatible with  the absolute value taxonomy structure that it is merged with and wp_update_post and therefore does not add the taxonomy value to the pulled post. I updated to match the array strucure from the absolute value taxonomy that does work on line 172.
