### PR TITLE
Fix bug when custom thumbnails being removed on edit from remote site

### DIFF
--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -161,7 +161,35 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		// Delete existing metadata to avoid duplicates
 		$args['custom_fields'] = array();
 		foreach ( $remote_post['custom_fields'] as $custom_field ) {
-			$args['custom_fields'][] = array( 'id' => $custom_field['id'] );
+			$args['custom_fields'][] = array( 
+				'id' => $custom_field['id'],
+				'meta_key_lookup' => $custom_field['key'],
+			);
+
+		}
+
+		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_ID );
+
+		foreach ( $thumbnail_meta_keys as $thumbnail_meta_key ) {
+			$thumbnail_id = get_post_meta( $post_ID, $thumbnail_meta_key, true );
+			$syn_local_meta_key = '_syn_push_thumb_' . $thumbnail_meta_key;
+			$syndicated_thumbnails_by_site = get_post_meta( $post_ID, $syn_local_meta_key, true );
+
+			if ( ! is_array( $syndicated_thumbnails_by_site ) ) {
+				$syndicated_thumbnails_by_site = array();
+			}
+
+			$syndicated_thumbnail_id = isset( $syndicated_thumbnails_by_site[ $this->site_ID ] ) ? $syndicated_thumbnails_by_site[ $this->site_ID ] : false;
+
+			if ( $syndicated_thumbnail_id == $thumbnail_id ) {
+				//need to preserve old meta custom_type_thumbnail_id if it wasn't changed during update
+				//hence we remove ID from the custom_fileds list in order to avoid its deletion
+				foreach ( $args['custom_fields'] as $index => $value ) {
+					if ( $value['meta_key_lookup'] == $thumbnail_meta_key ) {
+						unset( $args['custom_fields'][$index] );
+					}
+				}
+			}
 		}
 		
 		// rearranging arguments


### PR DESCRIPTION
We gather ALL custom meta fields and gather IDs for it in order to remove them all later in remote to prevent duplicates. This was introduced during issue #35 fix.

However if you didn't change images, they will not be processes (skipped because _syn_thumbnails match).
And this results in the removal of thumbnail meta on the remote and not renewing it. That is why after edit/update all images are gone

In order to replicate a bug: create new custom post type, like tale-of-the-tape. Those meta keys come from the custom array filter "syn_xmlrpc_push_thumbnail_metas" in functions.php. 
Add 2 side images: thumb1 and thumb2.
Save/Syndicate.
Remote is identical at this stage.
Now edit original post but do not change anything and update with syndication.
Images were not changed/updated/uploaded hence _syn_thumb1 and _syn_thumb2 still 
matches remote images. They were removed form remote and now remote post has no images.

This commit ads check if images were not changed, then IDs will be removed from the remote meta array and when query is called those meta value will not be removed from the remote
