### PR TITLE
Pass the simple pie item along to the filter to grab additional data

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -180,7 +180,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
                 'post_guid'         => $item->get_id()
             );
 			// This filter can be used to exclude or alter posts during a pull import
-			$post = apply_filters( 'syn_rss_pull_filter_post', $post, $args );
+			$post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item );
 			if ( false === $post )
 				continue;
 			$posts[] = $post;


### PR DESCRIPTION
This will allow us to check for media elements to side-load as featured images as well as assign appropriate authorship on rss syndication pull.  Referenced in zendesk request https://wordpressvip.zendesk.com/requests/27051
