### PR TITLE
Adds Category (and tag) Mapping

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -224,15 +224,15 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
                     $ids['cats'][] = $result->term_id;
                 }
             } elseif ( $result = get_term_by( 'name', $cat->term, 'post_tag' ) ) {
-				if ( isset( $result->term_id ) ) {
-					$ids['tags'][] = $result->term_id;
-				}                    
+                if ( isset( $result->term_id ) ) {
+                    $ids['tags'][] = $result->term_id;
+                }                    
             } else {
-				// creates if not
-				$result = wp_insert_term( $cat->term, 'category' );
-				if ( isset( $result->term_id ) ) {
-					$ids['cats'][] = $result->term_id;
-				}
+                // creates if not
+                $result = wp_insert_term( $cat->term, 'category' );
+                if ( isset( $result->term_id ) ) {
+                    $ids['cats'][] = $result->term_id;
+                }
             }
         }
 


### PR DESCRIPTION
Notes on the patch:
Simplepie doesn't pull attributes, so there is no real way to
differentiate currently between categories and tags. My solution was to
check first for existing categories, if not exist, tags, if not exist
create as a category.
