### PR TITLE
Fix gmt post time

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -174,7 +174,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
                 'post_excerpt'      => $item->get_description(),
                 'post_type'         => $this->default_post_type,
                 'post_status'       => $this->default_post_status,
-                'post_date'         => date( 'Y-m-d H:i:s', strtotime( $item->get_date() ) ),
+                'post_date_gmt'     => date( 'Y-m-d H:i:s', strtotime( $item->get_date() ) ),
                 'comment_status'    => $this->default_comment_status,
                 'ping_status'       => $this->default_ping_status,
                 'post_guid'         => $item->get_id()


### PR DESCRIPTION
Setting the post date in this manner fixes the problem of all ingested dates being interpreted as GMT and displaying incorrectly.
