### PR TITLE
Supply a default array to WP_Push_Syndication_Server::pull_content()

### DIFF
--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -1236,9 +1236,9 @@ class WP_Push_Syndication_Server {
 		return ( $site_a_pull_date < $site_b_pull_date ) ? -1 : 1;
 	}
 
-	public function pull_content( $sites ) {
+	public function pull_content( $sites = array() ) {
 		add_filter( 'http_headers_useragent', array( $this, 'syndication_user_agent' ) );
-	
+
 		if ( empty( $sites ) )
 			$sites = $this->pull_get_selected_sites();
 


### PR DESCRIPTION
The event created in `WP_Push_Syndication_Server::schedule_pull_content()` does not pass an argument, which generates a warning in `pull_content()`.