### PR TITLE
Disable on failure

### DIFF
--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -30,7 +30,6 @@ class Syndication_Event_Counter {
 		$option_name = $this->_get_safe_option_name( $event_slug, $event_object_id );
 		$count = get_option( $option_name, 0 );
 		$count = $count + 1;
-		var_dump($option_name);
 		update_option( $option_name, $count );
 
 		/**

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -12,7 +12,7 @@ class Syndication_Event_Counter {
 	 */
 	public function __construct() {
 		add_action( 'push_syndication_trigger_event', array( $this, 'count_event' ), 10, 2 );
-		add_action( 'push_syndication_reset_event', array( $this, 'reset_event' ) );
+		add_action( 'push_syndication_reset_event', array( $this, 'reset_event' ), 10, 2 );
 	}
 
 	/**
@@ -76,6 +76,6 @@ class Syndication_Event_Counter {
 	 * @return string
 	 */
 	protected function _get_safe_option_name( $event_slug, $event_object_id ) {
-		return 'push_syndication_event_' . md5( (string) $event_slug . (string) $event_object_id );
+		return 'push_syndication_event_' . md5( $event_slug . $event_object_id );
 	}
 }

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -2,7 +2,7 @@
 /**
  * Event Counter
  *
- * This allows for generic events to be captured and counted. Use the push_syndication_trigger_event and push_syndication_reset_event actions to capture and reset counters.
+ * This allows for generic events to be captured and counted. Use the push_syndication_event and push_syndication_reset_event actions to capture and reset counters. Use push_syndication_after_event to handle events once they've occurred, and to see the number of times the event has occurred.
  */
 
 class Syndication_Event_Counter {
@@ -11,6 +11,7 @@ class Syndication_Event_Counter {
 	 * Setup.
 	 */
 	public function __construct() {
+		add_action( 'push_syndication_event', array( $this, 'count_event' ), 10, 2 );
 		add_action( 'push_syndication_trigger_event', array( $this, 'count_event' ), 10, 2 );
 		add_action( 'push_syndication_reset_event', array( $this, 'reset_event' ), 10, 2 );
 	}
@@ -39,7 +40,7 @@ class Syndication_Event_Counter {
 		 * @param string $event_object_id Event object identifier.
 		 * @param int $count Number of times the event has been fired.
 		 */
-		do_action( 'push_syndication_event', $event_slug, $event_object_id, $count );
+		do_action( 'push_syndication_after_event', $event_slug, $event_object_id, $count );
 
 		/**
 		 * Fires when a syndication event has occurred. Includes the number of times the event has occurred so far.
@@ -49,7 +50,7 @@ class Syndication_Event_Counter {
 		 * @param string $event_object_id Event object identifier.
 		 * @param int $count Number of times the event has been fired.
 		 */
-		do_action( "push_syndication_event_{$event_slug}", $event_object_id, $count );
+		do_action( "push_syndication_after_event_{$event_slug}", $event_object_id, $count );
 	}
 
 	/**
@@ -76,6 +77,6 @@ class Syndication_Event_Counter {
 	 * @return string
 	 */
 	protected function _get_safe_option_name( $event_slug, $event_object_id ) {
-		return 'push_syndication_event_' . md5( $event_slug . $event_object_id );
+		return 'push_syndication_event_counter_' . md5( $event_slug . $event_object_id );
 	}
 }

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -22,6 +22,10 @@ class Syndication_Event_Counter {
 	 * @param string|int $event_object_id An identifier for the object the event is associated with. Should be unique across all objects associated with the given $event_slug.
 	 */
 	public function count_event( $event_slug, $event_object_id = null ) {
+		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
+		$event_slug = (string) $event_slug;
+		$event_object_id = (string) $event_object_id;
+
 		// Increment the event counter.
 		$option_name = $this->_get_safe_option_name( $event_slug, $event_object_id );
 		$count = get_option( $option_name, 0 );
@@ -56,6 +60,10 @@ class Syndication_Event_Counter {
 	 * @param $event_object_id
 	 */
 	public function reset_event( $event_slug, $event_object_id ) {
+		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
+		$event_slug = (string) $event_slug;
+		$event_object_id = (string) $event_object_id;
+
 		delete_option( $this->_get_safe_option_name( $event_slug, $event_object_id ) );
 	}
 
@@ -69,7 +77,6 @@ class Syndication_Event_Counter {
 	 * @return string
 	 */
 	protected function _get_safe_option_name( $event_slug, $event_object_id ) {
-		// Note that we coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
 		return 'push_syndication_event_' . md5( (string) $event_slug . (string) $event_object_id );
 	}
 }

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -37,6 +37,16 @@ class Syndication_Event_Counter {
 		 * @param int $count Number of times the event has been fired.
 		 */
 		do_action( 'push_syndication_event', $event_slug, $event_object_id, $count );
+
+		/**
+		 * Fires when a syndication event has occurred. Includes the number of times the event has occurred so far.
+		 *
+		 * The dynamic portion of the hook name, `$event_slug`, refers to the event slug that triggered the event.
+		 *
+		 * @param string $event_object_id Event object identifier.
+		 * @param int $count Number of times the event has been fired.
+		 */
+		do_action( "push_syndication_event_{$event_slug}", $event_object_id, $count );
 	}
 
 	/**

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -34,7 +34,7 @@ class Syndication_Event_Counter {
 
 		/**
 		 * Fires when a syndication event has occurred. Includes the number of times the event has occurred so far.
-		 *v
+		 *
 		 * @param string $event_slug Event type identifier.
 		 * @param string $event_object_id Event object identifier.
 		 * @param int $count Number of times the event has been fired.

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Event Counter
+ *
+ * This allows for generic events to be captured and counted. Use the push_syndication_trigger_event and push_syndication_reset_event actions to capture and reset counters.
+ */
+
+class Syndication_Event_Counter {
+
+	/**
+	 * Setup.
+	 */
+	public function __construct() {
+		add_action( 'push_syndication_trigger_event', array( $this, 'count_event' ), 10, 2 );
+		add_action( 'push_syndication_reset_event', array( $this, 'reset_event' ) );
+	}
+
+	/**
+	 * Increments an event counter.
+	 *
+	 * @param string $event_slug An identifier for the event.
+	 * @param string|int $event_object_id An identifier for the object the event is associated with. Should be unique across all objects associated with the given $event_slug.
+	 */
+	public function count_event( $event_slug, $event_object_id = null ) {
+		// Increment the event counter.
+		$option_name = $this->_get_safe_option_name( $event_slug, $event_object_id );
+		$count = get_option( $option_name, 0 );
+		$count = $count + 1;
+		var_dump($option_name);
+		update_option( $option_name, $count );
+
+		/**
+		 * Fires when a syndication event has occurred. Includes the number of times the event has occurred so far.
+		 *v
+		 * @param string $event_slug Event type identifier.
+		 * @param string $event_object_id Event object identifier.
+		 * @param int $count Number of times the event has been fired.
+		 */
+		do_action( 'push_syndication_event', $event_slug, $event_object_id, $count );
+	}
+
+	/**
+	 * Resets an event counter.
+	 *
+	 * @param $event_slug
+	 * @param $event_object_id
+	 */
+	public function reset_event( $event_slug, $event_object_id ) {
+		delete_option( $this->_get_safe_option_name( $event_slug, $event_object_id ) );
+	}
+
+	/**
+	 * Creates a safe option name for the event counter options.
+	 *
+	 * The main thing this does is make sure that the option name does not exceed the limit of 64 characters, regardless of the length of $event_slug and $event_object_id. The downside here is that we cannot easily determine which options belong to which slugs when examine the option names directly.
+	 *
+	 * @param $event_slug
+	 * @param $event_object_id
+	 * @return string
+	 */
+	protected function _get_safe_option_name( $event_slug, $event_object_id ) {
+		// Note that we coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
+		return 'push_syndication_event_' . md5( (string) $event_slug . (string) $event_object_id );
+	}
+}

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -13,7 +13,7 @@ class Syndication_Site_Failure_Monitor {
 	 * Setup
 	 */
 	public function __construct() {
-		add_action( 'push_syndication_event_pull_failure', array( $this, 'handle_pull_failure_event' ), 10, 2 );
+		add_action( 'push_syndication_after_event_pull_failure', array( $this, 'handle_pull_failure_event' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Site Failure Moniture
+ *
+ * Watches syndication events and handles site-related failures.
+ *
+ * @uses Syndication_Logger
+ */
+
+class Syndication_Site_Failure_Monitor {
+
+	/**
+	 * Setup
+	 */
+	public function __construct() {
+		add_action( 'push_syndication_event_pull_failure', array( $this, 'handle_pull_failure_event' ), 10, 2 );
+	}
+
+	/**
+	 * Handle the pull failure event. If the number of failures exceeds the maximum attempts set in the options, then disable the site.
+	 *
+	 * @param $site_id
+	 * @param $count
+	 */
+	public function handle_pull_failure_event( $site_id, $count ) {
+		$site_id = (int) $site_id;
+
+		$max_pull_attempts = (int) get_option( 'push_syndication_max_pull_attempts', 0 );
+
+		if ( ! $max_pull_attempts ) {
+			return;
+		}
+
+		if ( $count >= $max_pull_attempts ) {
+			// Disable the site.
+			update_post_meta( $site_id, 'syn_site_enabled', false );
+
+			// Reset the event counter.
+			do_action( 'push_syndication_reset_event', 'pull_failure', $site_id );
+
+			// Log what happened.
+			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( __( 'Site disabled after %d pull failure(s).', 'push-syndication' ), $count ) );
+		}
+	}
+}

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -248,7 +248,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Could not reach feed at: %s | Error: %s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
 
 			// Track the event.
-			do_action( 'push_syndication_trigger_event', 'pull_failure', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
 
 			return array();
 		} else {
@@ -262,7 +262,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
 
 			// Track the event.
-			do_action( 'push_syndication_trigger_event', 'pull_failure', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
 
 			return array();
 		}

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -246,6 +246,10 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$site_post = get_post( $this->site_ID );
 		if ( is_wp_error( $feed ) ) {
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Could not reach feed at: %s | Error: %s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
+
+			// Track the event.
+			do_action( 'push_syndication_trigger_event', 'pull_failure', $this->site_ID );
+
 			return array();
 		} else {
 			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $feed ) ), $log_time = null, $extra = array() );
@@ -256,6 +260,10 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 		if ( false === $xml ) {
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
+
+			// Track the event.
+			do_action( 'push_syndication_trigger_event', 'pull_failure', $this->site_ID );
+
 			return array();
 		}
 		

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -367,14 +367,25 @@ class WP_Push_Syndication_Server {
 	}
 
 	/**
-	 * Valide the push_syndication_max_pull_attempts option.
+	 * Validate the push_syndication_max_pull_attempts option.
 	 *
 	 * @param $val
 	 * @return int
 	 */
 	public function validate_max_pull_attempts( $val ) {
-		// Ensure a value between 0 and 100.
-		return min( 100, max( 0, (int) $val ) );
+		/**
+		 * Filter the maximum value that can be used for the
+		 * push_syndication_max_pull_attempts option. This only takes effect when the
+		 * option is set. Use the pre_option_push_syndication_max_pull_attempts or
+		 * option_push_syndication_max_pull_attempts filters to modify values that
+		 * have already been set.
+		 *
+		 * @param int $upper_limit Maximum value that can be used. Defaults to 100.
+		 */
+		$upper_limit = apply_filters( 'push_syndication_max_pull_attempts_upper_limit', 100 );
+
+		// Ensure a value between zero and the upper limit.
+		return min( $upper_limit, max( 0, (int) $val ) );
 	}
 
 	public function display_update_pulled_posts_selection() {

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -216,6 +216,7 @@ class WP_Push_Syndication_Server {
 
 		// register settings
 		register_setting( 'push_syndicate_settings', 'push_syndicate_settings', array( $this, 'push_syndicate_settings_validate' ) );
+		register_setting( 'push_syndicate_settings', 'push_syndication_max_pull_attempts', array( $this, 'validate_max_pull_attempts' ) );
 
 		// Maybe run upgrade
 		$this->upgrade();
@@ -260,6 +261,7 @@ class WP_Push_Syndication_Server {
 
 		add_settings_section( 'push_syndicate_pull_options', esc_html__( 'Pull Options' , 'push-syndication' ), array( $this, 'display_pull_options_description' ), 'push_syndicate_pull_options' );
 		add_settings_field( 'pull_time_interval', esc_html__( 'Specify time interval in seconds', 'push-syndication' ), array( $this, 'display_time_interval_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
+		add_settings_field( 'max_pull_attempts', esc_html__( 'Maximum pull attempts', 'push-syndication' ), array( $this, 'display_max_pull_attempts' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 		add_settings_field( 'update_pulled_posts', esc_html__( 'update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 
 		add_settings_section( 'push_syndicate_post_types', esc_html__( 'Post Types' , 'push-syndication' ), array( $this, 'display_push_post_types_description' ), 'push_syndicate_post_types' );
@@ -352,6 +354,27 @@ class WP_Push_Syndication_Server {
 
 	public function display_time_interval_selection() {
 		echo '<input type="text" size="10" name="push_syndicate_settings[pull_time_interval]" value="' . esc_attr( $this->push_syndicate_settings['pull_time_interval'] ) . '"/>';
+	}
+
+	/**
+	 * Display the form field for the push_syndication_max_pull_attempts option.
+	 */
+	public function display_max_pull_attempts() {
+		?>
+		<input type="text" size="10" name="push_syndication_max_pull_attempts" value="<?php echo esc_attr( get_option( 'push_syndication_max_pull_attempts', 0 ) ); ?>" />
+		<p><?php echo esc_html__( 'Site will be disabled after failure threshold is reached. Set to 0 to disable.', 'push-syndication' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Valide the push_syndication_max_pull_attempts option.
+	 *
+	 * @param $val
+	 * @return int
+	 */
+	public function validate_max_pull_attempts( $val ) {
+		// Ensure a value between 0 and 100.
+		return min( 100, max( 0, (int) $val ) );
 	}
 
 	public function display_update_pulled_posts_selection() {

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -30,3 +30,7 @@ $push_syndication_server = new WP_Push_Syndication_Server;
 // Create the event counter.
 require __DIR__ . '/includes/class-syndication-event-counter.php';
 new Syndication_Event_Counter();
+
+// Create the site failure monitor.
+require __DIR__ . '/includes/class-syndication-site-failure-monitor.php';
+new Syndication_Site_Failure_Monitor();

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -26,3 +26,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI )
 	require_once( dirname( __FILE__ ) . '/includes/class-wp-cli.php' );
 
 $push_syndication_server = new WP_Push_Syndication_Server;
+
+// Create the event counter.
+require __DIR__ . '/includes/class-syndication-event-counter.php';
+new Syndication_Event_Counter();


### PR DESCRIPTION
Disable pull sites when they fail more than the specified number of times. To accomplish this we created an event counting layer to count failures, an event monitoring layer to watch for events that happen a certain number of times, and an option field for setting the threshold.  This should address #20 