### PR TITLE
Pass the site_ID to the syn_rss_pull_filter_post filter

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -10,6 +10,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
     private $default_comment_status;
     private $default_ping_status;
     private $default_cat_status;
+	protected $site_id;
 
     function __construct( $site_ID ) {
 
@@ -26,6 +27,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
         }
 
         parent::__construct();
+
+	    $this->site_id                  = $site_ID;
 
         $this->set_feed_url( get_post_meta( $site_ID, 'syn_feed_url', true ) );
 

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -202,6 +202,18 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
                 'post_category'     => $taxonomy['cats'],
                 'tags_input'        => $taxonomy['tags']
             );
+
+	        /**
+	         * Exclude or alter posts during an RSS syndication pull
+	         *
+	         * Return an array of post data to save this post. Return false to exclude
+	         * this post.
+	         *
+	         * @param array          $post The post data, as would be passed to wp_insert_post
+	         * @param array          $args
+	         * @param SimplePie_Item $item A Simplepie item object
+	         * @param int            $this->site_id The ID of the post holding the data describing this feed
+	         */
             $post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item, $this->site_id );
             if ( false === $post )
                 continue;

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -202,8 +202,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
                 'post_category'     => $taxonomy['cats'],
                 'tags_input'        => $taxonomy['tags']
             );
-            // This filter can be used to exclude or alter posts during a pull import
-            $post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item );
+            $post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item, $this->site_id );
             if ( false === $post )
                 continue;
             $posts[] = $post;


### PR DESCRIPTION
Addresses #71 

I made the `site_id` property `protected` rather than `private`, because `private` causes issues if you ever need to extend the class and use those properties; but I'm happy to make it `private` for consistency, if required.