### PR TITLE
Short term hacks

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -10,6 +10,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
     private $default_comment_status;
     private $default_ping_status;
     private $default_cat_status;
+	protected $site_id;
 
     function __construct( $site_ID ) {
 
@@ -26,6 +27,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
         }
 
         parent::__construct();
+
+	    $this->site_id                  = $site_ID;
 
         $this->set_feed_url( get_post_meta( $site_ID, 'syn_feed_url', true ) );
 
@@ -199,8 +202,19 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
                 'post_category'     => $taxonomy['cats'],
                 'tags_input'        => $taxonomy['tags']
             );
-            // This filter can be used to exclude or alter posts during a pull import
-            $post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item );
+
+	        /**
+	         * Exclude or alter posts during an RSS syndication pull
+	         *
+	         * Return an array of post data to save this post. Return false to exclude
+	         * this post.
+	         *
+	         * @param array          $post The post data, as would be passed to wp_insert_post
+	         * @param array          $args
+	         * @param SimplePie_Item $item A Simplepie item object
+	         * @param int            $this->site_id The ID of the post holding the data describing this feed
+	         */
+            $post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item, $this->site_id );
             if ( false === $post )
                 continue;
             $posts[] = $post;

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -284,25 +284,25 @@ class WP_Push_Syndication_Server {
 
 			<form action="options.php" method="post">
 
-				<?php settings_fields( 'push_syndicate_settings' ); ?>
+				<div class="push-syndicate-settings"><?php settings_fields( 'push_syndicate_settings' ); ?></div>
 
-				<?php do_settings_sections( 'push_syndicate_pull_sitegroups' ); ?>
+				<div class="push-syndicate-pull-sitegroups"><?php do_settings_sections( 'push_syndicate_pull_sitegroups' ); ?></div>
 
-				<?php do_settings_sections( 'push_syndicate_pull_options' ); ?>
+				<div class="push-syndicate-pull-options"><?php do_settings_sections( 'push_syndicate_pull_options' ); ?></div>
 
-				<?php submit_button( '  Pull Now ' ); ?>
+				<div class="pull-now-button"><?php submit_button( '  Pull Now ' ); ?></div>
 
-				<?php do_settings_sections( 'push_syndicate_post_types' ); ?>
+				<div class="push-syndicate-post-types"><?php do_settings_sections( 'push_syndicate_post_types' ); ?></div>
 
-				<?php do_settings_sections( 'delete_pushed_posts' ); ?>
+				<div class="delete-pushed-posts"><?php do_settings_sections( 'delete_pushed_posts' ); ?></div>
 
-				<?php do_settings_sections( 'api_token' ); ?>
+				<div class="api-token-config"><?php do_settings_sections( 'api_token' ); ?></div>
 
-				<?php submit_button(); ?>
+				<div class="submit-button"><?php submit_button(); ?></div>
 
 			</form>
 
-			<?php $this->get_api_token() ?>
+			<div class="api-token"><?php $this->get_api_token() ?></div>
 
 		</div>
 

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -284,21 +284,21 @@ class WP_Push_Syndication_Server {
 
 			<form action="options.php" method="post">
 
-				<div class="push-syndicate-settings"><?php settings_fields( 'push_syndicate_settings' ); ?></div>
+				<div class="syn-push-syndicate-settings"><?php settings_fields( 'push_syndicate_settings' ); ?></div>
 
-				<div class="push-syndicate-pull-sitegroups"><?php do_settings_sections( 'push_syndicate_pull_sitegroups' ); ?></div>
+				<div class="syn-push-syndicate-pull-sitegroups"><?php do_settings_sections( 'push_syndicate_pull_sitegroups' ); ?></div>
 
-				<div class="push-syndicate-pull-options"><?php do_settings_sections( 'push_syndicate_pull_options' ); ?></div>
+				<div class="syn-push-syndicate-pull-options"><?php do_settings_sections( 'push_syndicate_pull_options' ); ?></div>
 
-				<div class="pull-now-button"><?php submit_button( '  Pull Now ' ); ?></div>
+				<div class="syn-pull-now-button"><?php submit_button( '  Pull Now ' ); ?></div>
 
-				<div class="push-syndicate-post-types"><?php do_settings_sections( 'push_syndicate_post_types' ); ?></div>
+				<div class="syn-push-syndicate-post-types"><?php do_settings_sections( 'push_syndicate_post_types' ); ?></div>
 
-				<div class="delete-pushed-posts"><?php do_settings_sections( 'delete_pushed_posts' ); ?></div>
+				<div class="syn-delete-pushed-posts"><?php do_settings_sections( 'delete_pushed_posts' ); ?></div>
 
-				<div class="api-token-config"><?php do_settings_sections( 'api_token' ); ?></div>
+				<div class="syn-api-token-config"><?php do_settings_sections( 'api_token' ); ?></div>
 
-				<div class="submit-button"><?php submit_button(); ?></div>
+				<div class="syn-submit-button"><?php submit_button(); ?></div>
 
 			</form>
 
@@ -648,7 +648,7 @@ class WP_Push_Syndication_Server {
 		// nonce for verification when saving
 		wp_nonce_field( plugin_basename( __FILE__ ), 'site_settings_noncename' );
 
-		echo '<div class="transports">';
+		echo '<div class="syn-transports">';
 		$this->display_transports( $transport_type, $transport_mode );
 		echo '</div>';
 

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -648,7 +648,9 @@ class WP_Push_Syndication_Server {
 		// nonce for verification when saving
 		wp_nonce_field( plugin_basename( __FILE__ ), 'site_settings_noncename' );
 
+		echo '<div class="transports">';
 		$this->display_transports( $transport_type, $transport_mode );
+		echo '</div>';
 
 		try {
 			Syndication_Client_Factory::display_client_settings( $post, $transport_type );


### PR DESCRIPTION
These changes are:

* Store and pass the `site_id` so that developers can retrieve post meta stored on the Site post when using the `syn_rss_pull_filter_post` filter
* Wrap various settings in `div` elements with classes, so they can be hidden if not needed

Example of using these changes (and existing hooks) to restrict Syndication to just WP_RSS transport and make life a bit simpler for users: https://gist.github.com/simonwheatley/a3be131e0118f9bef324