### PR TITLE
Remove surplus nested `form` element

### DIFF
--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -667,7 +667,6 @@ class WP_Push_Syndication_Server {
 	public function display_transports( $transport_type, $mode ) {
 
 		echo '<p>' . esc_html__( 'Select a transport type', 'push-syndication' ) . '</p>';
-		echo '<form action="">';
 		// TODO: add direction
 		echo '<select name="transport_type" onchange="this.form.submit()">';
 
@@ -678,7 +677,6 @@ class WP_Push_Syndication_Server {
 			echo '<option value="' . esc_html( $key ) . '"' . selected( $key, $transport_type ) . '>' . sprintf( esc_html__( '%s (%s)' ), $value['name'], $mode ) . '</option>';
 		}
 		echo '</select>';
-		echo '</form>';
 
 	}
 


### PR DESCRIPTION
See #75 

This branch removes the nested `form` element, and order is restored to IE9's world.