### PR TITLE
adding additional labels for taxonomy

### DIFF
--- a/includes/class-bootstrap.php
+++ b/includes/class-bootstrap.php
@@ -111,6 +111,8 @@ class Bootstrap {
 					'update_item'       => __( 'Update Site Group' ),
 					'add_new_item'      => __( 'Add New Site Group' ),
 					'new_item_name'     => __( 'New Site Group Name' ),
+					'search_items'      => __( 'Search Site Groups' ),
+					'not_found'         => __( 'No Site Groups Found' ),
 				),
 				'public'                => false,
 				'show_ui'               => true,


### PR DESCRIPTION
removes references to "category" on screens