### PR TITLE
Fixes the "Pull Now" button in Settings Screen

### DIFF
--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -30,7 +30,8 @@ class Settings_Screen {
 	 * @return array              Validated settings.
 	 */
 	public function push_syndicate_settings_validate( $raw_settings ) {
-		if ( isset( $_POST['push_syndicate_pull_now'] ) && 'Pull Now' === $_POST['push_syndicate_pull_now'] ) {
+		vip_dump( $_POST );
+		if ( isset( $_POST['push_syndicate_pull_now'] ) && 'Pull Now & Save Changes' === $_POST['push_syndicate_pull_now'] ) {
 			\Automattic\Syndication\Syndication_Runner::pull_now_job();
 		}
 

--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -102,7 +102,6 @@ class Settings_Screen {
 
 				<?php do_settings_sections( 'push_syndicate_pull_options' ); ?>
 
-				<?php submit_button( '  Pull Now ' ); ?>
 
 				<?php do_settings_sections( 'push_syndicate_post_types' ); ?>
 

--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -30,7 +30,6 @@ class Settings_Screen {
 	 * @return array              Validated settings.
 	 */
 	public function push_syndicate_settings_validate( $raw_settings ) {
-		vip_dump( $_POST );
 		if ( isset( $_POST['push_syndicate_pull_now'] ) && 'Pull Now & Save Changes' === $_POST['push_syndicate_pull_now'] ) {
 			\Automattic\Syndication\Syndication_Runner::pull_now_job();
 		}

--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -30,6 +30,9 @@ class Settings_Screen {
 	 * @return array              Validated settings.
 	 */
 	public function push_syndicate_settings_validate( $raw_settings ) {
+		if ( isset( $_POST['push_syndicate_pull_now'] ) && 'Pull Now' === $_POST['push_syndicate_pull_now'] ) {
+			\Automattic\Syndication\Syndication_Runner::pull_now_job();
+		}
 
 		$settings                                       = array();
 		$settings['client_id']                          = ! empty( $raw_settings['client_id'] ) ? sanitize_text_field( $raw_settings['client_id'] ) : '';
@@ -102,6 +105,7 @@ class Settings_Screen {
 
 				<?php do_settings_sections( 'push_syndicate_pull_options' ); ?>
 
+				<?php submit_button( 'Pull Now & Save Changes', 'primary', 'push_syndicate_pull_now' ); ?>
 
 				<?php do_settings_sections( 'push_syndicate_post_types' ); ?>
 


### PR DESCRIPTION
Previously the “Pull Now” button only saved the settings.  We’re now
hooked into the settings validation (nasty, but a safe place to do it)
and will catch if settings have been saved, or if settings have been
saved and a pull has been requested.

If a pull has been requested, a single cron event for “now” is created
for each enabled site.