### PR TITLE
Fixes issue with primary cron job

### DIFF
--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -41,6 +41,7 @@ class Settings_Screen {
 		$settings['update_pulled_posts']                = ! empty( $raw_settings['update_pulled_posts'] ) ? $raw_settings['update_pulled_posts'] : 'off' ;
 		$settings['push_syndication_max_pull_attempts'] = ! empty( $raw_settings['push_syndication_max_pull_attempts'] ) ? $raw_settings['push_syndication_max_pull_attempts'] : 0 ;
 
+		\Automattic\Syndication\Syndication_Runner::refresh_pull_jobs();
 		return $settings;
 
 	}

--- a/includes/class-syndication-runner.php
+++ b/includes/class-syndication-runner.php
@@ -301,7 +301,7 @@ class Syndication_Runner {
 		$sites         = $site_manager->pull_get_selected_sites();
 		$enabled_sites = $site_manager->get_sites_by_status( 'enabled' );
 		$sites         = array_intersect( $sites, $enabled_sites );
-		$this->schedule_pull_content( $sites );
+		\Automattic\Syndication\Syndication_Runner::schedule_pull_content( $sites );
 	}
 
 	/**


### PR DESCRIPTION
Originally, the primary pull cron job was only initialized or updated
when sites or site groups were modified.  This will now also allow the
primary cron job to be initialized when Syndication settings are saved.