### PR TITLE
Update transport types only if there is a new type

### DIFF
--- a/includes/class-upgrade-tasks.php
+++ b/includes/class-upgrade-tasks.php
@@ -86,8 +86,10 @@ class Upgrade_Tasks {
 						case 'WP_XMLRPC' : $new_transport_type = 'xml_push'; break;
 					endswitch;
 
-					// Update the site's transport type
-					update_post_meta( $site->ID, 'syn_transport_type', $new_transport_type );
+					// Update the site's transport type if there is a new one.
+					if ( $new_transport_type ) {
+						update_post_meta( $site->ID, 'syn_transport_type', $new_transport_type );
+					}
 				endif;
 			endforeach;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
-	require dirname( __FILE__ ) . '/../push-syndication.php';
+	require dirname( __FILE__ ) . '/../syndication.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-upgrade-tasks.php
+++ b/tests/test-upgrade-tasks.php
@@ -1,0 +1,21 @@
+<?php
+namespace Automattic\Syndication;
+
+class Test_Upgrade_Tasks extends \WP_UnitTestCase {
+	function test_upgrade_custom_transport_types_to_3_0_0() {
+		$transport_type = rand_str();
+
+		$site_id = $this->factory->post->create( [
+			'post_type' => 'syn_site',
+			'meta_input' => [
+				'syn_transport_type' => $transport_type,
+			],
+		] );
+
+		( new Upgrade_Tasks() )->upgrade_to_3_0_0();
+
+		$this->assertSame( $transport_type, get_post_meta( $site_id, 'syn_transport_type', true ),
+			'Upgrading to version 3.0.0 should not delete custom tranport type values.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #102. An alternate (or additional) approach might be to filter `$new_transport_type` so it could be changed back to the original string when no update is needed.