### PR TITLE
Ensure that the value 'off' is properly read as a false boolean.

### DIFF
--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -191,7 +191,7 @@ class WP_Push_Syndication_Server {
 				break;
 			case 'site_status':
 				$site_status = get_post_meta( $id, 'syn_site_enabled', true );
-				if ( ! $site_status ) {
+				if ( ! filter_var( $site_status, FILTER_VALIDATE_BOOLEAN ) ) {
 					esc_html_e( 'disabled', 'push-syndication' );
 				} else {
 					esc_html_e( 'enabled', 'push-syndication' );


### PR DESCRIPTION
Currently, if a site has the default status of 'off' (disabled), the status in the sites list view shows 'enabled' as the status. This is due to checking if the non-empty string whose value is set to 'off' is falsey, which of course it is not. By running the string through `filter_var()` and using the `FILTER_VALIDATE_BOOLEAN` flag, we are able to ensure that strings are properly converted into booleans if the values are 'on' or 'off'.