### PR TITLE
Security

### DIFF
--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -96,7 +96,7 @@ class Syndication_Logger_Admin_Notice {
 			foreach( $message_values as $message_key => $message_data ) {
 				$dismiss_nonce = wp_create_nonce( esc_attr( $message_key ) );
 				printf( '<div class="%s"><p>', esc_attr( $message_data['class'] ) );
-				printf( __('%1$s : %2$s <a href="%3$s">Hide Notice</a>'), esc_html( $message_type ), wp_kses_post( $message_data['message_text'] ), add_query_arg( array( self::$dismiss_parameter => esc_attr( $message_key ), 'syn_dismiss_nonce' => esc_attr( $dismiss_nonce ) ) ) );
+				printf( __( '%1$s : %2$s <a href="%3$s">Hide Notice</a>', 'push-syndication' ), esc_html( $message_type ), wp_kses_post( $message_data['message_text'] ), esc_url( add_query_arg( array( self::$dismiss_parameter => esc_attr( $message_key ), 'syn_dismiss_nonce' => esc_attr( $dismiss_nonce ) ) ) ) );
 				printf( '</p></div>' );
 			}
 		}
@@ -114,7 +114,7 @@ class Syndication_Logger_Admin_Notice {
 			$dismiss_key = esc_attr( $_GET[self::$dismiss_parameter] );
 			$dismiss_nonce = esc_attr( $_GET['syn_dismiss_nonce'] );
 			if ( ! wp_verify_nonce( $dismiss_nonce, $dismiss_key ) ) {
-				wp_die( __( "Invalid security check" ) );
+				wp_die( esc_html__( 'Invalid security check', 'push-syndication' ) );
 			}
 			$messages = get_option( self::$notice_option );
 			$notice_bundles = get_option( self::$notice_bundles_option );
@@ -147,10 +147,10 @@ class Syndication_Logger_Admin_Notice {
 
 add_filter( 'syn_message_text_multiple', 'syn_handle_multiple_error_notices', 10, 2 );
 function syn_handle_multiple_error_notices( $message, $message_data ) {
-	return __( 'There have been multiple errors. Please validate your syndication logs' );
+	return esc_html__( 'There have been multiple errors. Please validate your syndication logs', 'push-syndication' );
 }
 
 add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10, 2 );
 function syn_add_site_disabled_notice( $site_id, $count ) {
-	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( __( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
+	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( esc_html__( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
 }

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -20,9 +20,9 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		global $status, $page;
 
 		parent::__construct( array(
-			'singular'  => __( 'log', 'push-syndication' ),
-			'plural'    => __( 'logs', 'push-syndication' ),
-			'ajax'      => false
+			'singular' => esc_html__( 'log', 'push-syndication' ),
+			'plural'   => esc_html__( 'logs', 'push-syndication' ),
+			'ajax'     => false
 		) );
 
 		add_action( 'admin_head', array( $this, 'admin_header' ) );
@@ -46,7 +46,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	}
 
 	public function no_items() {
-		_e( 'No log entries found.' );
+		esc_html_e( 'No log entries found.', 'push-syndication' );
 	}
 
 	public function column_default( $item, $column_name ) {
@@ -78,12 +78,12 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 
 	public function get_columns(){
 		$columns = array(
-			'object_id'	=> __( 'Object ID', 'push-syndication' ),
-			'log_id'	=> __( 'Log ID', 	'push-syndication' ),
-			'time'		=> __( 'Time', 		'push-syndication' ),
-			'msg_type'	=> __( 'Type', 		'push-syndication' ),
-			'status'	=> __( 'Status', 	'push-syndication' ),
-			'message'	=> __( 'Message', 	'push-syndication' ),
+			'object_id' => esc_html__( 'Object ID', 'push-syndication' ),
+			'log_id'    => esc_html__( 'Log ID', 'push-syndication' ),
+			'time'      => esc_html__( 'Time', 'push-syndication' ),
+			'msg_type'  => esc_html__( 'Type', 'push-syndication' ),
+			'status'    => esc_html__( 'Status', 'push-syndication' ),
+			'message'   => esc_html__( 'Message', 'push-syndication' ),
 			);
 		return $columns;
 	}
@@ -195,7 +195,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 				$this->_create_months_dropdown();
 				$this->_create_types_dropdown();
 
-				submit_button( __( 'Filter' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+				submit_button( esc_html__( 'Filter', 'push-syndication' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
 			}
 
 			?>
@@ -206,9 +206,9 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	private function create_log_id_dropdown() {
 		$requested_log_id = isset( $_REQUEST['log_id'] ) ? esc_attr( $_REQUEST['log_id'] ) : 0;
 		?>
-		<label class="screen-reader-text" for="filter-by-log-id"><?php _e( 'Filter by Log ID' ); ?></label>
+		<label class="screen-reader-text" for="filter-by-log-id"><?php esc_html_e( 'Filter by Log ID', 'push-syndication' ); ?></label>
 		<select name="log_id" id="filter-by-log-id">
-			<option<?php selected( $requested_log_id, 0 ); ?> value="0"><?php _e( 'All logs' ); ?></option>
+			<option<?php selected( $requested_log_id, 0 ); ?> value="0"><?php esc_html_e( 'All logs', 'push-syndication' ); ?></option>
 			<?php
 			$log_ids = array();
 			foreach ( $this->prepared_data as $row ) {
@@ -294,7 +294,7 @@ class Syndication_Logger_Viewer {
 
 	public function render_list_page(){
 		?>
-		<div class="wrap"><h2><?php _e( "Syndication Logs", "syndication" ); ?></h2>
+		<div class="wrap"><h2><?php esc_html_e( 'Syndication Logs', 'push-syndication' ); ?></h2>
 			<?php
 			$this->syndication_logger_table->prepare_items();
 			?>

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -180,10 +180,10 @@ class Syndication_Logger {
 			} else {
 				$message = 'fail';
 			}
-			Syndication_Logger::log_post_error( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			Syndication_Logger::log_post_error( $site->ID, $status = esc_attr( $event ), $message, $log_time, $extra );
 		} else {
 			$message = sprintf( '%s,%d', sanitize_text_field( $post['post_guid'] ), intval( $result ) );
-			Syndication_Logger::log_post_success( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			Syndication_Logger::log_post_success( $site->ID, $status = esc_attr( $event ), $message, $log_time, $extra );
 		}
 	}
 
@@ -297,12 +297,12 @@ class Syndication_Logger {
 			if ( 'post' == $object_type ) {
 
 				if ( ! is_integer( $object_id ) ) {
-					return new WP_Error( 'logger_no_post_id', __( 'You need to provide a valid post_id or use log_option instead', 'push-syndication' ) );
+					return new WP_Error( 'logger_no_post_id', esc_html__( 'You need to provide a valid post_id or use log_option instead', 'push-syndication' ) );
 				}
 
 				$post = get_post( $object_id );
 				if ( ! $post ) {
-					return new WP_Error( 'logger_no_post', __( 'The post_id provided does not exist.', 'push-syndication' ) );
+					return new WP_Error( 'logger_no_post', esc_html__( 'The post_id provided does not exist.', 'push-syndication' ) );
 				}
 
 				$log = get_post_meta( $post->ID, 'syn_log', true);

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -91,7 +91,7 @@ class Failed_Syndication_Auto_Retry {
 					// Run in one minute by default
 					$auto_retry_interval = apply_filters( 'syndication_failure_auto_retry_interval', $time_now + MINUTE_IN_SECONDS );
 
-					Syndication_Logger::log_post_info( $site->ID, $status = 'start_auto_retry', $message = sprintf( __( 'Connection retry %d of %d to %s in %s..', 'push-syndication' ), $site_auto_retry_count + 1, $auto_retry_limit, $site_url, human_time_diff( $time_now, $auto_retry_interval ) ), $log_time, $extra = array() );
+					Syndication_Logger::log_post_info( $site->ID, $status = 'start_auto_retry', $message = sprintf( esc_html__( 'Connection retry %d of %d to %s in %s..', 'push-syndication' ), $site_auto_retry_count + 1, $auto_retry_limit, $site_url, human_time_diff( $time_now, $auto_retry_interval ) ), $log_time, $extra = array() );
 
 					// Schedule a pull retry for one minute in the future
 					wp_schedule_single_event(
@@ -125,7 +125,7 @@ class Failed_Syndication_Auto_Retry {
 				// Remove the auto retry if there was one
 				delete_post_meta( $site->ID, 'syn_failed_auto_retry_attempts' );
 
-				Syndication_Logger::log_post_error( $site->ID, $status = 'end_auto_retry', $message = sprintf( __( 'Failed %d times to reconnect to %s', 'push-syndication' ), $site_auto_retry_count, $site_url ), $log_time, $extra = array() );
+				Syndication_Logger::log_post_error( $site->ID, $status = 'end_auto_retry', $message = sprintf( esc_html__( 'Failed %d times to reconnect to %s', 'push-syndication' ), $site_auto_retry_count, $site_url ), $log_time, $extra = array() );
 			}
 		}
 	}

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -39,7 +39,7 @@ class Syndication_Site_Failure_Monitor {
 			do_action( 'push_syndication_reset_event', 'pull_failure', $site_id );
 
 			// Log what happened.
-			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( __( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ) );
+			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( esc_html__( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ) );
 
 			do_action( 'push_syndication_site_disabled', $site_id, $count );
 		}

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -221,7 +221,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		<p>
 			<?php echo esc_html__( 'To generate the following information automatically please visit the ', 'push-syndication' ); ?>
-			<a href="<?php echo get_admin_url(); ?>/options-general.php?page=push-syndicate-settings" target="_blank"><?php echo esc_html__( 'settings page', 'push-syndication' ); ?></a>
+			<a href="<?php echo esc_url( get_admin_url() ); ?>/options-general.php?page=push-syndicate-settings" target="_blank"><?php esc_html_e( 'settings page', 'push-syndication' ); ?></a>
 		</p>
 		<p>
 			<label for=site_token><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -185,12 +185,12 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		$rss_init = $this->init();
 
 		if ( false === $rss_init ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = isset( $site_post->postmeta['is_update'] ) ? $site_post->postmeta['is_update'] : null, $extra = array( 'error' => $this->error() ) );
+			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( esc_html__( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = isset( $site_post->postmeta['is_update'] ) ? $site_post->postmeta['is_update'] : null, $extra = array( 'error' => $this->error() ) );
 
 			// Track the event.
 			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
 		} else {
-			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $this->get_raw_data() ) ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( esc_html__( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $this->get_raw_data() ) ), $log_time = null, $extra = array() );
 
 			// Track the event.
 			do_action( 'push_syndication_event', 'pull_success', $this->site_ID );

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -121,7 +121,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		if ( parse_url( $url ) ) {
 			$this->feed_url = $url;
 		} else {
-			$this->error_message = sprintf( __( 'Feed URL not set for this feed: %s', 'push-syndication' ), $this->site_ID );
+			$this->error_message = sprintf( esc_html__( 'Feed URL not set for this feed: %s', 'push-syndication' ), $this->site_ID );
 		}
 	}
 
@@ -238,14 +238,14 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		// TODO: kill feed client if too many failures
 		$site_post = get_post( $this->site_ID );
 		if ( is_wp_error( $feed ) ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Could not reach feed at: %s | Error: %s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( esc_html__( 'Could not reach feed at: %s | Error: %s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = null, $extra = array() );
 
 			// Track the event.
 			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
 
 			return array();
 		} else {
-			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $feed ) ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( esc_html__( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $feed ) ), $log_time = null, $extra = array() );
 
 			// Track the event.
 			do_action( 'push_syndication_event', 'pull_success', $this->site_ID );
@@ -255,7 +255,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$xml = simplexml_load_string( $feed, null, 0, $namespace, false );
 
 		if ( false === $xml ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
+			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( esc_html__( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
 
 			// Track the event.
 			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
@@ -294,10 +294,10 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$items         = $xml->xpath( $post_root );
 
 		if ( empty( $items ) ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = printf( __( 'No post nodes found using XPath "%s" in feed', 'push-syndication' ), $post_root ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
+			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( esc_html__( 'No post nodes found using XPath "%s" in feed', 'push-syndication' ), $post_root ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
 			return array();
 		} else {
-			Syndication_Logger::log_post_info( $this->site_ID, $status = 'simplexml_load_string', $message = sprintf( __( 'parsed feed, received %d items', 'push-syndication' ), count( $items ) ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_info( $this->site_ID, $status = 'simplexml_load_string', $message = sprintf( esc_html__( 'parsed feed, received %d items', 'push-syndication' ), count( $items ) ), $log_time = null, $extra = array() );
 		}
 
 		foreach ( $items as $item ) {
@@ -375,7 +375,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			$post_position++;
 		}
 
-		Syndication_Logger::log_post_info( $this->site_ID, $status = 'posts_received', $message = sprintf( __( '%d posts were prepared', 'push-syndication' ), count( $posts ) ), $log_time = null, $extra = array() );
+		Syndication_Logger::log_post_info( $this->site_ID, $status = 'posts_received', $message = sprintf( esc_html__( '%d posts were prepared', 'push-syndication' ), count( $posts ) ), $log_time = null, $extra = array() );
 
 		return $posts;
 
@@ -492,7 +492,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<label for="feed_url"><?php esc_html_e( 'Enter feed URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="feed_url" id="feed_url" size="100" value="<?php esc_attr_e( $feed_url ); ?>" />
+			<input type="text" name="feed_url" id="feed_url" size="100" value="<?php echo esc_url( $feed_url ); ?>" />
 		</p>
 		<p>
 			<label for="default_post_type"><?php esc_html_e( 'Select post type', 'push-syndication' ); ?></label>
@@ -504,7 +504,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			foreach ( $post_types as $post_type ) {
 				?>
-				<option value="<?php esc_attr_e( $post_type ); ?>" <?php selected( $post_type, $default_post_type ); ?>><?php esc_html_e( $post_type ); ?></option>
+				<option value="<?php echo esc_attr( $post_type ); ?>" <?php selected( $post_type, $default_post_type ); ?>><?php echo esc_html( $post_type ); ?></option>
 			<?php } ?>
 			</select>
 		</p>
@@ -518,7 +518,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			foreach ( $post_statuses as $key => $value ) {
 				?>
-				<option value="<?php esc_attr_e( $key ); ?>" <?php selected( $key, $default_post_status ); ?>><?php esc_html_e( $key ); ?></option>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $default_post_status ); ?>><?php echo esc_html( $key ); ?></option>
 			<?php } ?>
 			</select>
 		</p>
@@ -527,8 +527,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		</p>
 		<p>
 			<select name="default_comment_status" id="default_comment_status">
-			<option value="open" <?php selected( 'open', $default_comment_status ); ?>><?php _e( 'open', 'push-syndication' ); ?></option>
-			<option value="closed" <?php selected( 'closed', $default_comment_status ); ?>><?php _e( 'closed', 'push-syndication' ); ?></option>
+			<option value="open" <?php selected( 'open', $default_comment_status ); ?>><?php esc_html_e( 'open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_comment_status ); ?>><?php esc_html_e( 'closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 		<p>
@@ -536,8 +536,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		</p>
 		<p>
 			<select name="default_ping_status" id="default_ping_status">
-			<option value="open" <?php selected( 'open', $default_ping_status ); ?>><?php _e( 'open', 'push-syndication' ); ?></option>
-			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?>><?php _e( 'closed', 'push-syndication' ); ?></option>
+			<option value="open" <?php selected( 'open', $default_ping_status ); ?>><?php esc_html_e( 'open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?>><?php esc_html_e( 'closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 
@@ -545,35 +545,35 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<label for="namespace"><?php esc_html_e( 'Enter XML namespace', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" size="75" name="namespace" id="namespace" value="<?php esc_attr_e( $namespace ); ?>" />
+			<input type="text" size="75" name="namespace" id="namespace" value="<?php echo esc_attr( $namespace ); ?>" />
 		</p>
 
 		<p>
 			<label for="post_root"><?php esc_html_e( 'Enter XPath to post root', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="post_root" id="post_root" value="<?php esc_attr_e( $post_root ); ?>" />
+			<input type="text" name="post_root" id="post_root" value="<?php echo esc_attr( $post_root ); ?>" />
 		</p>
 
 		<p>
 			<label for="id_field"><?php esc_html_e( 'Enter post meta key for unique post identifier', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="id_field" id="id_field" value="<?php esc_attr_e( $id_field ); ?>" />
+			<input type="text" name="id_field" id="id_field" value="<?php echo esc_attr( $id_field ); ?>" />
 		</p>
 
 		<p>
 			<label for="enc_parent"><?php esc_html_e( 'Enter parent element for enclosures', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="enc_parent" id="enc_parent" value="<?php esc_attr_e( $enc_parent ); ?>" />
+			<input type="text" name="enc_parent" id="enc_parent" value="<?php echo esc_attr( $enc_parent ); ?>" />
 		</p>
 
 		<p>
 			<label for="enc_field"><?php esc_html_e( 'Enter meta name for enclosures', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="enc_field" id="enc_field" value="<?php esc_attr_e( $enc_field ); ?>" />
+			<input type="text" name="enc_field" id="enc_field" value="<?php echo esc_attr( $enc_field ); ?>" />
 		</p>
 
 		<p>
@@ -601,9 +601,9 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			?>
 		</p>
 
-		<h2><?php _e( 'XPath-to-Data Mapping', 'push-syndication' ); ?></h2>
+		<h2><?php esc_html_e( 'XPath-to-Data Mapping', 'push-syndication' ); ?></h2>
 
-		<p><?php printf( __( '<strong>PLEASE NOTE:</strong> %s are required. If you want a link to another site, %s is required. To include a static string, enclose the string as "%s(your_string_here)" &mdash; no quotes.', 'push-syndication' ), 'post_title, post_guid, guid', 'is_permalink', 'string' ); ?></p>
+		<p><?php printf( esc_html__( '<strong>PLEASE NOTE:</strong> %s are required. If you want a link to another site, %s is required. To include a static string, enclose the string as "%s(your_string_here)" &mdash; no quotes.', 'push-syndication' ), 'post_title, post_guid, guid', 'is_permalink', 'string' ); ?></p>
 
 		<ul class='syn-xml-client-xpath-head syn-xml-client-list-head'>
 			<li class="text">
@@ -650,7 +650,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 					<li class="text">
 						<input type="text" name="node[<?php echo (int) $rowcount; ?>][field]" id="node-<?php echo (int) $rowcount; ?>-field" value="<?php echo stripcslashes( $storage_location['field'] ); ?>" />
 					</li>
-					<a href="#" class="syn-delete syn-pull-xpath-delete"><?php _e( 'Delete', 'push-syndication' ); ?></a>
+					<a href="#" class="syn-delete syn-pull-xpath-delete"><?php esc_html_e( 'Delete', 'push-syndication' ); ?></a>
 				<?php endforeach; ?>
 				</ul>
 				<?php
@@ -678,10 +678,10 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<li class="text">
 				<input type="text" name="node[<?php echo (int) $rowcount; ?>][field]" id="node-<?php echo (int) $rowcount; ?>-field" />
 			</li>
-			<a href="#" class="syn-delete syn-pull-xpath-delete"><?php _e( 'Delete', 'push-syndication' ); ?></a>
+			<a href="#" class="syn-delete syn-pull-xpath-delete"><?php esc_html_e( 'Delete', 'push-syndication' ); ?></a>
 		</ul>
 
-		<a href="#" class="syn-pull-xpath-add-new button"><?php _e( 'Add new', 'push-syndication' ); ?></a>
+		<a href="#" class="syn-pull-xpath-add-new button"><?php esc_html_e( 'Add new', 'push-syndication' ); ?></a>
 
 		<script>
 			jQuery( document ).ready( function ( $ ) {

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -169,7 +169,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		$remote_post = $this->get_remote_post( $remote_post_id );
 
 		if ( ! $remote_post ) {
-			return new WP_Error( 'syn-remote-post-not-found', __( 'Remote post doesn\'t exist.', 'syndication' ) );
+			return new WP_Error( 'syn-remote-post-not-found', esc_html__( 'Remote post doesn\'t exist.', 'push-syndication' ) );
 		}
 
 		// Delete existing metadata to avoid duplicates
@@ -553,11 +553,11 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		$thumbnail_alt_text  = $args[7];
 
 		if ( ! $post_ID )
-			return new IXR_Error( 500, __( 'Please specify a valid post_ID.', 'syndication' ) );
+			return new IXR_Error( 500, esc_html__( 'Please specify a valid post_ID.', 'push-syndication' ) );
 
 		$thumbnail_raw = wp_remote_retrieve_body( wp_remote_get( $thumbnail_url ) );
 		if ( ! $thumbnail_raw )
-			return new IXR_Error( 500, __( 'Sorry, the image URL provided was incorrect.', 'syndication' ) );
+			return new IXR_Error( 500, esc_html__( 'Sorry, the image URL provided was incorrect.', 'push-syndication' ) );
 
 		$thumbnail_filename = basename( $thumbnail_url );
 		$thumbnail_type = wp_check_filetype( $thumbnail_filename );
@@ -582,7 +582,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 
 		$thumbnail_id = (int) $image['id'];
 		if( empty( $thumbnail_id ) )
-			return new IXR_Error( 500, __( 'Sorry, looks like the image upload failed.', 'syndication' ) );
+			return new IXR_Error( 500, esc_html__( 'Sorry, looks like the image upload failed.', 'push-syndication' ) );
 
 		if ( '_thumbnail_id' == $meta_key )
 			$thumbnail_set = set_post_thumbnail( $post_ID, $thumbnail_id );
@@ -590,7 +590,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			$thumbnail_set = update_post_meta( $post_ID, $meta_key, $thumbnail_id );
 
 		if ( ! $thumbnail_set )
-			return new IXR_Error( 403, __( 'Could not attach post thumbnail.' ) );
+			return new IXR_Error( 403, esc_html__( 'Could not attach post thumbnail.', 'push-syndication' ) );
 		
 		$args = array(
 			$blog_id,
@@ -630,7 +630,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			return $wp_xmlrpc_server->error;
 
 		if ( ! current_user_can( 'edit_post', $post_ID ) )
-			return new IXR_Error( 401, __( 'Sorry, you are not allowed to post on this site.' ) );
+			return new IXR_Error( 401, esc_html__( 'Sorry, you are not allowed to post on this site.', 'push-syndication' ) );
 
 		if ( '_thumbnail_id' == $meta_key )
 			$result = delete_post_thumbnail( $post_ID );
@@ -638,7 +638,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			$result = delete_post_meta( $post_ID, $meta_key );
 
 		if ( ! $result )
-			return new IXR_Error( 403, __( 'Could not remove post thumbnail.' ) );
+			return new IXR_Error( 403, esc_html__( 'Could not remove post thumbnail.', 'push-syndication' ) );
 
 		return true;
 
@@ -664,7 +664,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 
 		$thumbnail_raw = wp_remote_retrieve_body( wp_remote_get( $thumbnail_url ) );
 		if ( ! $thumbnail_raw ) {
-			return new IXR_Error( 500, __( 'Sorry, the image URL provided was incorrect.', 'syndication' ) );
+			return new IXR_Error( 500, esc_html__( 'Sorry, the image URL provided was incorrect.', 'push-syndication' ) );
 		}
 
 		$thumbnail_filename = basename( $thumbnail_url );
@@ -690,7 +690,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 
 		$thumbnail_id = (int) $image['id'];
 		if ( empty( $thumbnail_id ) ) {
-			return new IXR_Error( 500, __( 'Sorry, looks like the image upload failed.', 'syndication' ) );
+			return new IXR_Error( 500, esc_html__( 'Sorry, looks like the image upload failed.', 'push-syndication' ) );
 		}
 		
 		$args = array(

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -52,7 +52,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$post_id = intval( $assoc_args[ 'post_id' ] );
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			WP_CLI::error( __( 'Invalid post_id', 'push-syndication' ) );
+			WP_CLI::error( esc_html__( 'Invalid post_id', 'push-syndication' ) );
 		}
 
 		$this->_make_em_talk_push();
@@ -61,7 +61,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$sites = $server->get_sites_by_post_ID( $post_id );
 
 		if ( empty( $sites ) ) {
-			WP_CLI::error( __( 'Post has no selected sitegroups / sites', 'push-syndication' ) );
+			WP_CLI::error( esc_html__( 'Post has no selected sitegroups / sites', 'push-syndication' ) );
 		}
 
 		$server->push_content( $sites );

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -87,16 +87,16 @@ class WP_Push_Syndication_Server {
 
 		register_post_type( 'syn_site', array(
 			'labels' => array(
-				'name'              => __( 'Sites' ),
-				'singular_name'     => __( 'Site' ),
-				'add_new'           => __( 'Add Site' ),
-				'add_new_item'      => __( 'Add New Site' ),
-				'edit_item'         => __( 'Edit Site' ),
-				'new_item'          => __( 'New Site' ),
-				'view_item'         => __( 'View Site' ),
-				'search_items'      => __( 'Search Sites' ),
+				'name'              => esc_html__( 'Sites', 'push-syndication' ),
+				'singular_name'     => esc_html__( 'Site', 'push-syndication' ),
+				'add_new'           => esc_html__( 'Add Site', 'push-syndication' ),
+				'add_new_item'      => esc_html__( 'Add New Site', 'push-syndication' ),
+				'edit_item'         => esc_html__( 'Edit Site', 'push-syndication' ),
+				'new_item'          => esc_html__( 'New Site', 'push-syndication' ),
+				'view_item'         => esc_html__( 'View Site', 'push-syndication' ),
+				'search_items'      => esc_html__( 'Search Sites', 'push-syndication' ),
 			),
-			'description'           => __( 'Sites in the network' ),
+			'description'           => esc_html__( 'Sites in the network', 'push-syndication' ),
 			'public'                => false,
 			'show_ui'               => true,
 			'publicly_queryable'    => false,
@@ -114,17 +114,17 @@ class WP_Push_Syndication_Server {
 
 		register_taxonomy( 'syn_sitegroup', 'syn_site', array(
 				'labels' => array(
-					'name'              => __( 'Site Groups' ),
-					'singular_name'     => __( 'Site Group' ),
-					'search_items'      => __( 'Search Site Groups' ),
-					'popular_items'     => __( 'Popular Site Groups' ),
-					'all_items'         => __( 'All Site Groups' ),
-					'parent_item'       => __( 'Parent Site Group' ),
-					'parent_item_colon' => __( 'Parent Site Group' ),
-					'edit_item'         => __( 'Edit Site Group' ),
-					'update_item'       => __( 'Update Site Group' ),
-					'add_new_item'      => __( 'Add New Site Group' ),
-					'new_item_name'     => __( 'New Site Group Name' ),
+					'name'              => esc_html__( 'Site Groups', 'push-syndication' ),
+					'singular_name'     => esc_html__( 'Site Group', 'push-syndication' ),
+					'search_items'      => esc_html__( 'Search Site Groups', 'push-syndication' ),
+					'popular_items'     => esc_html__( 'Popular Site Groups', 'push-syndication' ),
+					'all_items'         => esc_html__( 'All Site Groups', 'push-syndication' ),
+					'parent_item'       => esc_html__( 'Parent Site Group', 'push-syndication' ),
+					'parent_item_colon' => esc_html__( 'Parent Site Group', 'push-syndication' ),
+					'edit_item'         => esc_html__( 'Edit Site Group', 'push-syndication' ),
+					'update_item'       => esc_html__( 'Update Site Group', 'push-syndication' ),
+					'add_new_item'      => esc_html__( 'Add New Site Group', 'push-syndication' ),
+					'new_item_name'     => esc_html__( 'New Site Group Name', 'push-syndication' ),
 
 				),
 				'public'                => false,
@@ -165,11 +165,11 @@ class WP_Push_Syndication_Server {
 	public function add_new_columns( $columns ) {
 		$new_columns = array();
 		$new_columns['cb'] = '<input type="checkbox" />';
-		$new_columns['title'] = _x( 'Site Name', 'column name' );
-		$new_columns['client-type'] = _x( 'Client Type', 'column name' );
-		$new_columns['syn_sitegroup'] = _x( 'Groups', 'column name' );
-		$new_columns['site_status'] = _x( 'Status', 'column name' );
-		$new_columns['date'] = _x('Date', 'column name');
+		$new_columns['title'] = esc_html_x( 'Site Name', 'column name', 'push-syndication' );
+		$new_columns['client-type'] = esc_html_x( 'Client Type', 'column name', 'push-syndication' );
+		$new_columns['syn_sitegroup'] = esc_html_x( 'Groups', 'column name', 'push-syndication' );
+		$new_columns['site_status'] = esc_html_x( 'Status', 'column name', 'push-syndication' );
+		$new_columns['date'] = esc_html_x( 'Date', 'column name', 'push-syndication' );
 		return $new_columns;
 	}
 
@@ -183,7 +183,7 @@ class WP_Push_Syndication_Server {
 					$client_data = $client->get_client_data();
 					echo esc_html( sprintf( '%s (%s)', $client_data['name'], array_shift( $client_data['modes'] ) ) );
 				} catch ( Exception $e ) {
-					printf( __( 'Unknown (%s)', 'push-syndication' ), esc_html( $transport_type ) );
+					printf( esc_html__( 'Unknown (%s)', 'push-syndication' ), esc_html( $transport_type ) );
 				}
 				break;
 			case 'syn_sitegroup':
@@ -573,9 +573,9 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function site_metaboxes() {
-		add_meta_box('sitediv', __(' Site Settings '), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high');
+		add_meta_box('sitediv', esc_html__(' Site Settings ', 'push-syndication'), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high');
 		remove_meta_box('submitdiv', 'syn_site', 'side');
-		add_meta_box( 'submitdiv', __(' Site Status '), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
+		add_meta_box( 'submitdiv', esc_html__(' Site Status ', 'push-syndication'), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
 	}
 
 	public function add_site_status_metabox( $site ) {
@@ -585,30 +585,30 @@ class WP_Push_Syndication_Server {
 			<div id="minor-publishing">
 				<div id="misc-publishing-actions">
 					<div class="misc-pub-section">
-						<label for="post_status"><?php _e( 'Status:', 'push-syndication' ) ?></label>
+						<label for="post_status"><?php esc_html_e( 'Status:', 'push-syndication' ) ?></label>
 						<span id="post-status-display">
 						<?php
 						switch( $site_enabled ) {
 							case 'on':
-								_e( 'Enabled', 'push-syndication' );
+								esc_html_e( 'Enabled', 'push-syndication' );
 								break;
 							case 'off':
 							default:
-								_e( 'Disabled', 'push-syndication' );
+								esc_html_e( 'Disabled', 'push-syndication' );
 								break;
 						}
 						?>
 						</span>
 
-						<a href="#post_status" class="edit-post-status hide-if-no-js" tabindex='4'><?php _e( 'Edit', 'push-syndication' ) ?></a>
+						<a href="#post_status" class="edit-post-status hide-if-no-js" tabindex='4'><?php esc_html_e( 'Edit', 'push-syndication' ) ?></a>
 
 						<div id="post-status-select" class="hide-if-js">
 							<input type="hidden" name="post_status" value="publish" />
 							<select name='site_enabled' id='post_status' tabindex='4'>
-								<option<?php selected( $site_enabled, 'on' ); ?> value='on'><?php _e('Enabled', 'push-syndication' ) ?></option>
-								<option<?php selected( $site_enabled, 'off' ); ?> value='off'><?php _e('Disabled', 'push-syndication' ) ?></option>
+								<option<?php selected( $site_enabled, 'on' ); ?> value='on'><?php esc_html_e('Enabled', 'push-syndication' ) ?></option>
+								<option<?php selected( $site_enabled, 'off' ); ?> value='off'><?php esc_html_e('Disabled', 'push-syndication' ) ?></option>
 							</select>
-							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php _e( 'OK', 'push-syndication' ); ?></a>
+							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php esc_html_e( 'OK', 'push-syndication' ); ?></a>
 						</div>
 
 					</div>
@@ -621,17 +621,19 @@ class WP_Push_Syndication_Server {
 			<div id="major-publishing-actions">
 
 				<div id="delete-action">
-					<a class="submitdelete deletion" href="<?php echo get_delete_post_link($site->ID); ?>"><?php echo __( 'Move to Trash', 'push-syndication' ); ?></a>
+					<a class="submitdelete deletion" href="<?php echo esc_url( get_delete_post_link( $site->ID ) ); ?>">
+						<?php esc_html_e( 'Move to Trash', 'push-syndication' ); ?>
+					</a>
 				</div>
 
 				<div id="publishing-action">
 					<img src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" class="ajax-loading" id="ajax-loading" alt="" />
 					<?php
 					if ( !in_array( $site_enabled, array( 'on', 'off' ) ) || 0 == $site->ID ) { ?>
-						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Add Site') ?>" />
-						<?php submit_button( __( 'Add Site', 'push-syndication' ), 'primary', 'enabled', false, array( 'tabindex' => '5', 'accesskey' => 'p' ) ); ?>
+						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Add Site', 'push-syndication') ?>" />
+						<?php submit_button( esc_html__( 'Add Site', 'push-syndication' ), 'primary', 'enabled', false, array( 'tabindex' => '5', 'accesskey' => 'p' ) ); ?>
 					<?php } else { ?>
-						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Update') ?>" />
+						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Update', 'push-syndication') ?>" />
 						<input name="save" type="submit" class="button-primary" id="publish" tabindex="5" accesskey="p" value="<?php esc_attr_e( 'Update', 'push-syndication' ) ?>" />
 					<?php } ?>
 				</div>
@@ -684,7 +686,7 @@ class WP_Push_Syndication_Server {
 		$max_len = 0;
 		foreach( $this->push_syndicate_transports as $key => $value ) {
 			$mode = array_shift( $value['modes'] );
-			echo '<option value="' . esc_html( $key ) . '"' . selected( $key, $transport_type ) . '>' . sprintf( esc_html__( '%s (%s)' ), $value['name'], $mode ) . '</option>';
+			echo '<option value="' . esc_html( $key ) . '"' . selected( $key, $transport_type ) . '>' . sprintf( esc_html__( '%s (%s)', 'push-syndication' ), $value['name'], $mode ) . '</option>';
 		}
 		echo '</select>';
 
@@ -733,20 +735,20 @@ class WP_Push_Syndication_Server {
 	public function push_syndicate_admin_messages( $messages ) {
 
 		// general error messages
-		$messages['syn_site'][250] = __( 'Transport class not found!', 'push-syndication' );
-		$messages['syn_site'][251] = __( 'Connection Successful!', 'push-syndication' );
-		$messages['syn_site'][252] = __( 'Something went wrong when connecting to the site. Site disabled.', 'push-syndication' );
+		$messages['syn_site'][250] = esc_html__( 'Transport class not found!', 'push-syndication' );
+		$messages['syn_site'][251] = esc_html__( 'Connection Successful!', 'push-syndication' );
+		$messages['syn_site'][252] = esc_html__( 'Something went wrong when connecting to the site. Site disabled.', 'push-syndication' );
 
 		// xmlrpc error messages.
-		$messages['syn_site'][301] = __( 'Invalid URL.', 'push-syndication' );
-		$messages['syn_site'][302] = __( 'You do not have sufficient capability to perform this action.', 'push-syndication' );
-		$messages['syn_site'][303] = __( 'Bad login/pass combination.', 'push-syndication' );
-		$messages['syn_site'][304] = __( 'XML-RPC services are disabled on this site.', 'push-syndication' );
-		$messages['syn_site'][305] = __( 'Transport error. Invalid endpoint', 'push-syndication' );
-		$messages['syn_site'][306] = __( 'Something went wrong when connecting to the site.', 'push-syndication' );
+		$messages['syn_site'][301] = esc_html__( 'Invalid URL.', 'push-syndication' );
+		$messages['syn_site'][302] = esc_html__( 'You do not have sufficient capability to perform this action.', 'push-syndication' );
+		$messages['syn_site'][303] = esc_html__( 'Bad login/pass combination.', 'push-syndication' );
+		$messages['syn_site'][304] = esc_html__( 'XML-RPC services are disabled on this site.', 'push-syndication' );
+		$messages['syn_site'][305] = esc_html__( 'Transport error. Invalid endpoint', 'push-syndication' );
+		$messages['syn_site'][306] = esc_html__( 'Something went wrong when connecting to the site.', 'push-syndication' );
 
 		// WordPress.com REST error messages
-		$messages['site'][301] = __( 'Invalid URL', 'push-syndication' );
+		$messages['site'][301] = esc_html__( 'Invalid URL', 'push-syndication' );
 
 		// RSS error messages
 
@@ -765,7 +767,7 @@ class WP_Push_Syndication_Server {
 
 		$selected_post_types = $this->push_syndicate_settings[ 'selected_post_types' ];
 		foreach( $selected_post_types as $selected_post_type ) {
-			add_meta_box( 'syndicatediv', __( ' Syndicate ' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
+			add_meta_box( 'syndicatediv', esc_html__( ' Syndicate '. 'push-syndication' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
 			//add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' );
 		}
 
@@ -1220,7 +1222,7 @@ class WP_Push_Syndication_Server {
 		// Adds the custom time interval to the existing schedules.
 		$schedules['syn_pull_time_interval'] = array(
 			'interval' => intval( $this->push_syndicate_settings['pull_time_interval'] ),
-			'display' => __( 'Pull Time Interval', 'push-syndication' )
+			'display' => esc_html__( 'Pull Time Interval', 'push-syndication' )
 		);
 
 		return $schedules;
@@ -1332,9 +1334,9 @@ class WP_Push_Syndication_Server {
 			$post_types_processed = array();
 
 			if ( count( $posts ) > 0 ) {
-				Syndication_Logger::log_post_info( $site_id, $status = 'start_import', $message = sprintf( __( 'starting import for site id %d with %d posts', 'push-syndication' ), $site_id, count( $posts ) ), $log_time = null, $extra = array() );
+				Syndication_Logger::log_post_info( $site_id, $status = 'start_import', $message = sprintf( esc_html__( 'starting import for site id %d with %d posts', 'push-syndication' ), $site_id, count( $posts ) ), $log_time = null, $extra = array() );
 			} else {
-				Syndication_Logger::log_post_info( $site_id, $status = 'no_posts', $message = sprintf( __( 'no posts for site id %d', 'push-syndication' ), $site_id ), $log_time = null, $extra = array() );
+				Syndication_Logger::log_post_info( $site_id, $status = 'no_posts', $message = sprintf( esc_html__( 'no posts for site id %d', 'push-syndication' ), $site_id ), $log_time = null, $extra = array() );
 			}
 
 			foreach( $posts as $post ) {
@@ -1345,7 +1347,7 @@ class WP_Push_Syndication_Server {
 				}
 
 				if ( empty( $post['post_guid'] ) ) {
-					Syndication_Logger::log_post_error( $site_id, $status = 'no_post_guid', $message = sprintf( __( 'skipping post no guid', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
+					Syndication_Logger::log_post_error( $site_id, $status = 'no_post_guid', $message = sprintf( esc_html__( 'skipping post no guid', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 					continue;
 				}
 				$post_id = $this->find_post_by_guid( $post['post_guid'], $post, $site );
@@ -1353,12 +1355,12 @@ class WP_Push_Syndication_Server {
 				if ( $post_id ) {
 					$pull_edit_shortcircuit = apply_filters( 'syn_pre_pull_edit_post_shortcircuit', false, $post, $site, $transport_type, $client );
 					if ( true === $pull_edit_shortcircuit ) {
-						Syndication_Logger::log_post_info( $site_id, $status = 'skip_pre_pull_edit_post', $message = sprintf( __( 'skipping post per syn_pre_pull_edit_post_shortcircuit', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
+						Syndication_Logger::log_post_info( $site_id, $status = 'skip_pre_pull_edit_post', $message = sprintf( esc_html__( 'skipping post per syn_pre_pull_edit_post_shortcircuit', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 						continue;
 					}
 					// if updation is disabled continue
 					if( $this->push_syndicate_settings['update_pulled_posts'] != 'on' ) {
-						Syndication_Logger::log_post_info( $site_id, $status = 'skip_update_pulled_posts', $message = sprintf( __( 'skipping post update per update_pulled_posts setting', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
+						Syndication_Logger::log_post_info( $site_id, $status = 'skip_update_pulled_posts', $message = sprintf( esc_html__( 'skipping post update per update_pulled_posts setting', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 						continue;
 					}
 					$post['ID'] = $post_id;
@@ -1374,7 +1376,7 @@ class WP_Push_Syndication_Server {
 				} else {
 					$pull_new_shortcircuit = apply_filters( 'syn_pre_pull_new_post_shortcircuit', false, $post, $site, $transport_type, $client );
 					if ( true === $pull_new_shortcircuit ) {
-						Syndication_Logger::log_post_info( $site_id, $status = 'syn_pre_pull_new_post_shortcircuit', $message = sprintf( __( 'skipping post per syn_pre_pull_edit_post_shortcircuit', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
+						Syndication_Logger::log_post_info( $site_id, $status = 'syn_pre_pull_new_post_shortcircuit', $message = sprintf( esc_html__( 'skipping post per syn_pre_pull_edit_post_shortcircuit', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 						continue;
 					}
 					$post = apply_filters( 'syn_pull_new_post', $post, $site, $client );


### PR DESCRIPTION
Properly escape translatable strings. Correct invalid or non-existent text domains on translation functions. Use literal strings where possible.