### PR TITLE
WP REST API Integration

### DIFF
--- a/includes/class-bootstrap.php
+++ b/includes/class-bootstrap.php
@@ -58,6 +58,7 @@ class Bootstrap {
 		new Clients\RSS_Pull\Bootstrap();
 		new Clients\XML_Push\Bootstrap();
 		new Clients\REST_Push\Bootstrap();
+		new Clients\REST_Push_New\Bootstrap();
 
 		// Command line stuff.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/includes/clients/rest-push-new/class-bootstrap.php
+++ b/includes/clients/rest-push-new/class-bootstrap.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Syndication Client: REST Push New
+ *
+ * Create 'syndication sites' to push external content from your site
+ * to a remote WordPress site via the WP REST API
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Clients\REST_Push_New
+ * @internal Called via instantiation in includes/class-bootstrap.php
+ */
+
+namespace Automattic\Syndication\Clients\REST_Push_New;
+
+use Automattic\Syndication\Client_Manager;
+
+/**
+ * Class Bootstrap
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Clients\REST_Push_New
+ */
+class Bootstrap {
+	/**
+	 * Bootstrap constructor.
+	 *
+	 * @since 2.1
+	 */
+	public function __construct() {
+		// Register our syndication client
+		add_action( 'syndication/register_clients', [ $this, 'register_clients' ] );
+
+		add_action( 'syndication/pre_load_client/rest_push_new', [ $this, 'pre_load' ] );
+
+		new Client_Options();
+	}
+
+	/**
+	 * Register our new Syndication client
+	 *
+	 * @since 2.1
+	 * @param Client_Manager $client_man
+	 */
+	public function register_clients( Client_Manager $client_man ) {
+		$client_man->register_push_client(
+			'rest_push_new', [
+				'label' => 'REST Push Client (New)',
+				'class' => __NAMESPACE__ . '\Push_Client',
+			]
+		);
+	}
+
+	/**
+	 * Clients could use this hook to make sure the class is included.
+	 *
+	 * @since 2.1
+	 */
+	public function pre_load() { }
+}

--- a/includes/clients/rest-push-new/class-client-options.php
+++ b/includes/clients/rest-push-new/class-client-options.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Site Options
+ *
+ * Site options are options specific to site using a particular client.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Clients\REST_Push_New
+ */
+
+namespace Automattic\Syndication\Clients\REST_Push_New;
+
+/**
+ * Class Client_Options
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Clients\REST_Push_New
+ */
+class Client_Options {
+
+	/**
+	 * Client_Options constructor.
+	 *
+	 * @since 2.1
+	 */
+	public function __construct() {
+		// Site options.
+		add_action( 'syndication/render_site_options/rest_push_new', [ $this, 'render_site_options_push' ] );
+		add_action( 'syndication/save_site_options/rest_push_new', [ $this, 'save_site_options_push' ] );
+
+		// Set up the connection test action.
+		add_action( 'syndication/test_site_options/rest_push_new', [ $this, 'test_connection' ] );
+
+		// Client settings.
+		add_action( 'syndication/render_client_options', [ $this, 'render_client_options' ] );
+		add_action( 'syndication/save_client_options', [ $this, 'save_client_options' ] );
+	}
+
+	/**
+	 * Render the options.
+	 *
+	 * @since 2.1
+	 * @param integer $site_id The ID of the site.
+	 */
+	public function render_site_options_push( $site_id ) {
+		global $settings_manager;
+
+		$site_token = $settings_manager->syndicate_decrypt( get_post_meta( $site_id, 'syn_site_token', true ) );
+		$site_url   = get_post_meta( $site_id, 'syn_site_url', true );
+		?>
+		<p>
+			<label for="site_token"><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>
+		</p>
+		<p>
+			<input type="text" class="widefat" name="site_token" id="site_token" size="100" value="<?php echo esc_attr( $site_token ); ?>" />
+		</p>
+		<p>
+			<label for="site_url"><?php echo esc_html__( 'Enter a valid Blog URL', 'push-syndication' ); ?></label>
+		</p>
+		<p>
+			<input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_url( $site_url ); ?>" />
+		</p>
+		<?php
+		/**
+		 * Fires after the site options form renders.
+		 *
+		 * @since 2.1
+		 * @param int $site_id The id of the site being rendered.
+		 */
+		do_action( 'syn_after_site_form', $site_id );
+	}
+
+	/**
+	 * Save the options.
+	 *
+	 * @since 2.1
+	 * @param integer $site_id The site ID to save the options to.
+	 * @return bool
+	 */
+	public function save_site_options_push( $site_id ) {
+		global $settings_manager;
+
+		// Verify values set before saving.
+		$site_token   = isset( $_POST['site_token'] ) ? $_POST['site_token'] : '';
+		$site_url     = isset( $_POST['site_url'] ) ? $_POST['site_url'] : '';
+
+		// Save the options.
+		update_post_meta( $site_id, 'syn_site_token', $settings_manager->syndicate_encrypt( sanitize_text_field( $site_token ) ) );
+		update_post_meta( $site_id, 'syn_site_url', sanitize_text_field( $site_url ) );
+
+		return true;
+	}
+
+	/**
+	 * Test the connection, used to validate feed.
+	 *
+	 * @param integer $site_id The ID of the site.
+	 * @return bool
+	 */
+	public function test_connection( $site_id ) {
+		global $client_manager;
+
+		$client_manager->test_connection( $site_id );
+	}
+
+	/**
+	 * Render client options on the Settings->Syndication screen.
+	 *
+	 * @todo: This could use the same credentials as the legacy WP.com API. We
+	 * currently don't have OAuth2 setup for the new REST API, once it's implemented
+	 * we may have to create a new form here.
+	 *
+	 * @since 2.1
+	 */
+	public function render_client_options() { }
+
+	/**
+	 * Save client settings from the Settings->Syndication screen.
+	 *
+	 * @since 2.1
+	 */
+	public function save_client_options() { }
+}

--- a/includes/clients/rest-push-new/class-push-client.php
+++ b/includes/clients/rest-push-new/class-push-client.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Syndication Client: REST Push
+ *
+ * Create 'syndication sites' to push site content to an external WordPress
+ * install via the WP REST API. Includes XPath mapping to map incoming
+ * REST data to specific post data.
+ *
+ * @package Automattic\Syndication\Clients\REST
+ */
+
+namespace Automattic\Syndication\Clients\REST_Push_New;
+
+use Automattic\Syndication;
+use Automattic\Syndication\Pusher;
+use Automattic\Syndication\Types;
+
+class Push_Client extends Pusher {
+	private $access_token;
+	private $endpoint_url;
+	private $port;
+	private $useragent;
+	private $timeout;
+
+	/**
+	 * Push_Client constructor.
+	 *
+	 * @since 2.1
+	 */
+	public function __construct() {}
+
+	/**
+	 * Init
+	 *
+	 * @since 2.1
+	 * @param int $site_id The Site ID (Syndication Endpoint) to Push to.
+	 * @param int $port The port number of the receiving REST API.
+	 * @param int $timeout How long to wait before killing the request.
+	 */
+	public function init( $site_id = 0, $port = 80, $timeout = 45 ) {
+		global $settings_manager;
+
+		$this->access_token = $settings_manager->syndicate_decrypt( get_post_meta( $site_id, 'syn_site_token', true ) );
+		$this->endpoint_url = untrailingslashit( get_post_meta( $site_id, 'syn_site_url', true ) );
+		$this->timeout      = $timeout;
+		$this->useragent    = 'push-syndication-plugin';
+		$this->port         = $port;
+
+	}
+
+	/**
+	 * Push a new post to the remote.
+	 */
+	public function new_post( $post_id ) {
+		$post = (array) get_post( $post_id );
+
+		/**
+		 * Filter the post used by the REST push client when pushing a new post to a remote.
+		 *
+		 * This filter can be used to exclude or alter posts during a content push. Return false
+		 * to short circuit the post push.
+		 *
+		 * @param WP_Post $post    The post the be pushed.
+		 * @param int     $post_ID The id of the post originating this request.
+		 */
+		$post = apply_filters( 'syn_rest_push_filter_new_post', $post, $post_id );
+
+		if ( false === $post ) {
+			return true;
+		}
+
+		$body = array(
+			'title'      => $post['post_title'],
+			'content'    => $post['post_content'],
+			'excerpt'    => $post['post_excerpt'],
+			'status'     => $post['post_status'],
+			'password'   => $post['post_password'],
+			'date'       => $post['post_date_gmt'],
+		);
+
+		/**
+		 * Filter the REST push client body before pushing a new post.
+		 *
+		 * @param string $body    The body to send to the REST API endpoint.
+		 * @param int    $post_ID The id of the post being pushed.
+		 */
+		$body = apply_filters( 'syn_rest_push_filter_new_post_body', $body, $post_id );
+
+		$response = wp_remote_post(
+			$this->endpoint_url . '/wp-json/wp/v2/posts',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body' => wp_json_encode( $body ),
+			)
+		);
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( ! is_wp_error( $response ) && in_array( $response['response']['code'], array( 200, 201 ), true ) ) {
+			// Add Categories.
+			$this->sync_taxonomy( 'category', $post_id, $body->id );
+
+			// Add tags.
+			$this->sync_taxonomy( 'post_tag', $post_id, $body->id );
+
+			return $body->id;
+		} else {
+			if ( ! empty( $body->message ) ) {
+				$message = $body->message;
+			} else {
+				$message = __( 'Failed to push new post', 'push-syndication' );
+			}
+
+			return new \WP_Error( 'rest-push-new-fail', $message );
+		}
+	}
+
+	public function sync_taxonomy( $taxonomy, $post_id, $remote_post_id ) {
+		// Make sure we support the taxonomy being called.
+		switch ( $taxonomy ) {
+			case 'category':
+				$slug_key = 'categories';
+				break;
+			case 'post_tag':
+				$slug_key = 'tags';
+				break;
+		}
+
+		if ( empty( $slug_key ) ) {
+			return false;
+		}
+
+		$terms      = array();
+		$post_terms = wp_get_object_terms( $post_id, $taxonomy, array( 'fields' => 'names' ) );
+
+		if ( empty( $post_terms ) ) {
+			return true;
+		}
+
+		/**
+		 * Filter the terms.
+		 *
+		 * @since 2.1
+		 * @param array  $post_terms List of terms in taxonomy assigned to post.
+		 * @param string $taxonomy   The name of the taxonomy.
+		 * @param string $post_id    The id of the post being pushed.
+		 */
+		$post_terms = apply_filters( 'syn_rest_push_filter_post_taxonomies', $post_terms, $taxonomy, $post_id );
+
+		// Get a list of terms that exist.
+		$response = wp_remote_get(
+			$this->endpoint_url . '/wp-json/wp/v2/' . $slug_key . '?slug=' . implode( ',', $post_terms ),
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+					'Content-Type'  => 'application/json',
+				),
+			)
+		);
+
+		if ( ! is_wp_error( $response ) && in_array( $response['response']['code'], array( 200, 201 ), true ) ) {
+			$remote_terms = json_decode( wp_remote_retrieve_body( $response ) );
+
+			/*
+			 * Go through any remote terms that match the post terms and add
+			 * them to the list of terms to assign to the post. Also remove them
+			 * for the list of terms to add that don't exist.
+			 */
+			if ( count( $remote_terms ) ) {
+				foreach ( $remote_terms as $term ) {
+					if ( false !== ( $key = array_search( $term->name, $post_terms, true ) ) ) {
+						$terms[] = $term->id;
+						unset( $post_terms[ $key ] );
+					}
+				}
+			}
+		} else {
+			return false;
+		}
+
+		// Create the remaining categories that don't exist remotely.
+		if ( count( $post_terms ) ) {
+			foreach ( $post_terms as $post_term ) {
+				$body = array(
+					'name' => $post_term,
+				);
+
+				$response = wp_remote_post(
+					$this->endpoint_url . '/wp-json/wp/v2/' . $slug_key,
+					array(
+						'timeout'    => $this->timeout,
+						'user-agent' => $this->useragent,
+						'sslverify'  => false,
+						'headers'    => array(
+							'authorization' => 'Bearer ' . $this->access_token,
+							'Content-Type'  => 'application/json',
+						),
+						'body'       => wp_json_encode( $body ),
+					)
+				);
+
+				if ( ! is_wp_error( $response ) && in_array( $response['response']['code'], array( 200, 201 ), true ) ) {
+					$term    = json_decode( wp_remote_retrieve_body( $response ) );
+					$terms[] = $term->id;
+				} else {
+					return false;
+				}
+			}
+		}
+
+		// Assign categories to post.
+		if ( ! empty( $terms ) ) {
+			$body = array(
+				$slug_key => $terms,
+			);
+
+			$response = wp_remote_post(
+				$this->endpoint_url . '/wp-json/wp/v2/posts/' . $remote_post_id,
+				array(
+					'timeout' => $this->timeout,
+					'user-agent' => $this->useragent,
+					'sslverify' => false,
+					'headers' => array(
+						'authorization' => 'Bearer ' . $this->access_token,
+						'Content-Type'  => 'application/json',
+					),
+					'body' => wp_json_encode( $body ),
+				)
+			);
+
+			if ( ! is_wp_error( $response ) && in_array( $response['response']['code'], array( 200, 201 ), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Test the connection to the remote server.
+	 *
+	 * @since 2.1
+	 * @param int $site_id The ID of the Syndication Endpoint.
+	 * @return bool
+	 */
+	public function test_connection( $site_id ) {
+		$response = wp_remote_get(
+			$this->endpoint_url . '/wp-json/wp/v2/posts',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			)
+		);
+
+		if ( ! is_wp_error( $response ) && in_array( $response['response']['code'], array( 200, 201 ), true ) ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}

--- a/includes/clients/rest-push-new/class-push-client.php
+++ b/includes/clients/rest-push-new/class-push-client.php
@@ -11,15 +11,47 @@
 
 namespace Automattic\Syndication\Clients\REST_Push_New;
 
-use Automattic\Syndication;
 use Automattic\Syndication\Pusher;
-use Automattic\Syndication\Types;
 
 class Push_Client extends Pusher {
+	/**
+	 * Access token.
+	 *
+	 * @since 2.1
+	 * @var string
+	 */
 	private $access_token;
+
+	/**
+	 * Endpoint URL.
+	 *
+	 * @since 2.1
+	 * @var string
+	 */
 	private $endpoint_url;
+
+	/**
+	 * Port.
+	 *
+	 * @since 2.1
+	 * @var int
+	 */
 	private $port;
+
+	/**
+	 * User Agent.
+	 *
+	 * @since 2.1
+	 * @var string
+	 */
 	private $useragent;
+
+	/**
+	 * Timeout.
+	 *
+	 * @since 2.1
+	 * @var integer
+	 */
 	private $timeout;
 
 	/**
@@ -49,7 +81,11 @@ class Push_Client extends Pusher {
 	}
 
 	/**
-	 * Push a new post to the remote.
+	 * Push a new post to the remote endpoint.
+	 *
+	 * @since 2.1
+	 * @param int $post_id The ID of the post to be pushed.
+	 * @return int|WP_Error The ID of the remote post or error.
 	 */
 	public function new_post( $post_id ) {
 		$post = (array) get_post( $post_id );
@@ -60,8 +96,9 @@ class Push_Client extends Pusher {
 		 * This filter can be used to exclude or alter posts during a content push. Return false
 		 * to short circuit the post push.
 		 *
+		 * @since 2.1
 		 * @param WP_Post $post    The post the be pushed.
-		 * @param int     $post_ID The id of the post originating this request.
+		 * @param int     $post_id The id of the post originating this request.
 		 */
 		$post = apply_filters( 'syn_rest_push_filter_new_post', $post, $post_id );
 
@@ -81,8 +118,9 @@ class Push_Client extends Pusher {
 		/**
 		 * Filter the REST push client body before pushing a new post.
 		 *
+		 * @since 2.1
 		 * @param string $body    The body to send to the REST API endpoint.
-		 * @param int    $post_ID The id of the post being pushed.
+		 * @param int    $post_id The id of the post being pushed.
 		 */
 		$body = apply_filters( 'syn_rest_push_filter_new_post_body', $body, $post_id );
 
@@ -121,6 +159,16 @@ class Push_Client extends Pusher {
 		}
 	}
 
+	/**
+	 * Syncs the taxonomies between the local post and remote post. Adds
+	 * taxonomies where need be.
+	 *
+	 * @since 2.1
+	 * @param string $taxonomy The taxonomy name to sync.
+	 * @param int    $post_id The ID of the local post.
+	 * @param int    $remote_post_id The ID of the remote post.
+	 * @return bool
+	 */
 	public function sync_taxonomy( $taxonomy, $post_id, $remote_post_id ) {
 		// Make sure we support the taxonomy being called.
 		switch ( $taxonomy ) {

--- a/tests/clients/test-rest-push-client.php
+++ b/tests/clients/test-rest-push-client.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for the REST Push Client.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication
+ */
+
+namespace Automattic\Syndication\Clients\REST_Push_New;
+
+/**
+ * Class Test_Push_Client.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication
+ */
+class Test_Push_Client extends \WP_UnitTestCase {
+	/**
+	 * Setup a sample REST Push site.
+	 *
+	 * @since 2.1
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setup_REST_inteceptor();
+
+		// Create a site group.
+		$sitegroup = $this->factory->term->create_and_get( array(
+			'taxonomy' => 'syn_sitegroup',
+			'name' => 'Test Syndication Endpoint Group',
+		) );
+
+		// Create a site.
+		$this->site = $this->factory->post->create_and_get( array(
+			'post_title' => 'RSS Pull Syndication Endpoint',
+			'post_type' => 'syn_site',
+		) );
+
+		/*
+		 * Setup a fake REST service, we actually intercept the REST call below
+		 * and send the request to a multisite install in our tests.
+		 */
+		add_post_meta( $this->site->ID, 'syn_transport_type', 'WP_RSS' );
+		add_post_meta( $this->site->ID, 'syn_site_token', '123' );
+		add_post_meta( $this->site->ID, 'syn_site_url', 'http://localhost/' );
+		add_post_meta( $this->site->ID, 'syn_default_post_type', 'post' );
+		add_post_meta( $this->site->ID, 'syn_default_post_status', 'publish' );
+		add_post_meta( $this->site->ID, 'syn_default_comment_status', 'open' );
+		add_post_meta( $this->site->ID, 'syn_default_ping_status', 'open' );
+		add_post_meta( $this->site->ID, 'syn_default_cat_status', 'yes' );
+		add_post_meta( $this->site->ID, 'syn_site_enabled', 'on' );
+
+		// Add the site to the sitegroup.
+		wp_set_object_terms( $this->site->ID, $sitegroup->term_id, 'syn_sitegroup' );
+
+		// Instance of the actual client.
+		$this->client = new Push_Client();
+		$this->client->init( $this->site->ID );
+
+		// Create a new multisite blog to send the request to.
+		$this->blog_id = $this->factory->blog->create();
+	}
+
+	/**
+	 * Clean up after yourself.
+	 *
+	 * @since 2.1
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		switch_to_blog( $this->blog_id );
+
+		$q = new \WP_Query( array(
+			'post_type' => array( 'syn_site', 'syn_sitegroup', 'post' ),
+			'posts_per_page' => -1,
+		) );
+
+		$post_ids = wp_list_pluck( $q->posts, 'ID' );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( $post_id );
+		}
+
+		restore_current_blog();
+	}
+
+	/**
+	 * Test that a new posts gets sent sent and created on the other side.
+	 *
+	 * @since 2.1
+	 * @covers Push_Client::new_post()
+	 */
+	public function test_new_post() {
+		// Create a new post.
+		$post_id = wp_insert_post( array( 'post_title' => 'Test Post', 'post_content' => 'Test post content', 'post_status' => 'publish' ) );
+
+		// Send the new post to the other side.
+		$this->client->new_post( $post_id );
+
+		// Switch to the other blog and fetch it's posts.
+		switch_to_blog( $this->blog_id );
+
+		$posts = new \WP_Query( array(
+			'post_type'      => 'post',
+			'posts_per_page' => 1,
+			'orderby'        => 'ID',
+			'order'          => 'DESC',
+		) );
+
+		restore_current_blog();
+
+		// Test that the post was created as expected.
+		$this->assertEquals( 'Test Post', $posts->post->post_title );
+		$this->assertEquals( 'Test post content', $posts->post->post_content );
+	}
+
+	/**
+	 * This method intercepts our XML RPC calls and sends them to a multisite
+	 * blog that was created above. It handles new posts, updating posts and
+	 * deleting posts. Once the request is fulfilled, it retuns a valid HTTP
+	 * response back to the caller.
+	 *
+	 * @since 2.1
+	 */
+	public function setup_REST_inteceptor() {
+		// Mock remote HTTP calls made by XMLRPC
+		add_action( 'pre_http_request', function( $short_circuit, $args, $url ) {
+			if ( 'http://localhost/' === $url ) {
+				switch_to_blog( $this->blog_id );
+
+				global $wp_rest_server;
+				$this->server = $wp_rest_server = new Spy_REST_Server;
+				do_action( 'rest_api_init' );
+
+
+
+				restore_current_blog();
+
+				return array(
+					'headers'  => array(),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => $xml,
+				);
+			}
+
+			return $short_circuit;
+		}, 10, 3 );
+	}
+}

--- a/tests/clients/test-rss-pull-client.php
+++ b/tests/clients/test-rss-pull-client.php
@@ -118,8 +118,8 @@ class Test_Pull_Client extends \WP_UnitTestCase {
 		// Test log was added.
 		$logs = Syndication_Logger::get_messages();
 
-		$this->assertEquals( 'success', $logs[ $this->site->ID ][ $posts->posts[1]->ID ]['msg_type'] );
-		$this->assertEquals( 'new', $logs[ $this->site->ID ][ $posts->posts[1]->ID ]['status'] );
+		$this->assertEquals( 'success', $logs[ $this->site->ID ][0]['msg_type'] );
+		$this->assertEquals( 'new', $logs[ $this->site->ID ][0]['status'] );
 	}
 
 	public function test_processing_invalid_feed_returns_false() {

--- a/tests/clients/test-xml-push-client.php
+++ b/tests/clients/test-xml-push-client.php
@@ -23,7 +23,7 @@ class Test_Push_Client extends \WP_XMLRPC_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->setup_XMLRPC_inteceptor();
+		$this->setup_XMLRPC_interceptor();
 
 		// Create a site group.
 		$sitegroup = $this->factory->term->create_and_get( array(
@@ -204,7 +204,7 @@ class Test_Push_Client extends \WP_XMLRPC_UnitTestCase {
 	 *
 	 * @since 2.1
 	 */
-	public function setup_XMLRPC_inteceptor() {
+	public function setup_XMLRPC_interceptor() {
 		// Mock remote HTTP calls made by XMLRPC
 		add_action( 'pre_http_request', function( $short_circuit, $args, $url ) {
 			if ( 'http://localhost/xmlrpc/xmlrpc.php' === $url ) {


### PR DESCRIPTION
* Adds new REST class for WP REST API support
* Adds tests for different methods

This leaves the old REST implementation intact. The new endpoint configuration is called "REST Push Client (New)"

@philipjohn The only piece that is missing here is the actual authentication layer. On my local, I used  https://wp-oauth.com/ but the actual WordPress.com implementation will be different. In the configuration, it lets you paste the Auth token for now if you want to test.