### PR TITLE
Declare Syndication globally in a more explicit way.

### DIFF
--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -132,7 +132,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 			return;
 
 		$this->enabled_verbosity = true;
-		
+
 		add_filter( 'syn_pre_push_post_sites', function( $sites, $post_id, $slave_states ) {
 			WP_CLI::line( sprintf( "Processing post_id #%d (%s)", $post_id, get_the_title( $post_id ) ) );
 			WP_CLI::line( sprintf( "-- pushing to %s sites and deleting from %s sites", number_format( count( $sites['selected_sites'] ) ), number_format( count( $sites['removed_sites'] ) ) ) );
@@ -151,8 +151,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	}
 
 	private function _get_syndication_server() {
-		global $push_syndication_server;
-		return $push_syndication_server;
+		return $GLOBALS['push_syndication_server'];
 	}
 
 	protected function stop_the_insanity() {

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -25,7 +25,7 @@ require_once( dirname( __FILE__ ) . '/includes/class-wp-push-syndication-server.
 if ( defined( 'WP_CLI' ) && WP_CLI )
 	require_once( dirname( __FILE__ ) . '/includes/class-wp-cli.php' );
 
-$push_syndication_server = new WP_Push_Syndication_Server;
+$GLOBALS['push_syndication_server'] = new WP_Push_Syndication_Server;
 
 // Create the event counter.
 require __DIR__ . '/includes/class-syndication-event-counter.php';


### PR DESCRIPTION
Some hosts load plugins differently, and this may impact the way that Syndication is available for reference in some circumstances (such as when running cron jobs), causing Syndication to not be available.

This change uses `$GLOBALS` instead of the `global` keyword to more reliably make Syndication available to plugins and themes.