### PR TITLE
replaces create_function with anonymous functions

### DIFF
--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -398,19 +398,29 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 			switch( $error_code ) {
 				case 32301:
-					add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 305, $location);' ) );
+					add_filter('redirect_post_location', function($location) {
+						return add_query_arg("message", 305, $location);
+					});
 					break;
 				case 401:
-					add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 302, $location);' ) );
+					add_filter('redirect_post_location', function($location) {
+						return add_query_arg("message", 302, $location);
+					});
 					break;
 				case 403:
-					add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 303, $location);' ) );
+					add_filter('redirect_post_location', function($location) {
+						return add_query_arg("message", 303, $location);
+					});
 					break;
 				case 405:
-					add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 304, $location);' ) );
+					add_filter('redirect_post_location', function($location) {
+						return add_query_arg("message", 304, $location);
+					});
 					break;
 				default:
-					add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 306, $location);' ) );
+					add_filter('redirect_post_location', function($location) {
+						return add_query_arg("message", 306, $location);
+					});
 					break;
 			}
 
@@ -504,7 +514,9 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		update_post_meta( $site_ID, 'syn_site_password', push_syndicate_encrypt( sanitize_text_field( $_POST['site_password'] ) ) );
 
 		if( !filter_var( $_POST['site_url'], FILTER_VALIDATE_URL ) ) {
-			add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 301, $location);' ) );
+			add_filter('redirect_post_location', function($location) {
+				return add_query_arg("message", 301, $location);
+			});
 			return false;
 		}
 

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -716,14 +716,20 @@ class WP_Push_Syndication_Server {
 			$client = Syndication_Client_Factory::get_client( $transport_type, $post->ID );
 
 			if ( $client->test_connection()  ) {
-				add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 251, $location);' ) );
+				add_filter('redirect_post_location', function ($location) {
+					return add_query_arg("message", 251, $location);
+				});
 			} else {
-				add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 252, $location);' ) );
+				add_filter('redirect_post_location', function ($location) {
+					return add_query_arg("message", 252, $location);
+				});
 				$site_enabled = 'off';
 			}
 
 		} catch( Exception $e ) {
-			add_filter('redirect_post_location', create_function( '$location', 'return add_query_arg("message", 250, $location);' ) );
+			add_filter('redirect_post_location', function ($location) {
+				return add_query_arg("message", 250, $location);
+			});
 		}
 
 		update_post_meta( $post->ID, 'syn_site_enabled', $site_enabled );


### PR DESCRIPTION
Fixes #142 

replaces create_function with anonymous functions in includes/class-syndication-wp-xmlrpc-client.php

The bug report recommends using `function use ($location)` so that the anonymous function inherits the parent scope variable `$location`, but it looks like `$location` is passed to the function when it is used.

I'm pretty new to the wordpress world. I'll try to get set up to test my changes. 