### PR TITLE
Fail more gracefully if transport class does not exist

### DIFF
--- a/includes/class-syndication-client-factory.php
+++ b/includes/class-syndication-client-factory.php
@@ -14,8 +14,8 @@ class Syndication_Client_Factory {
 			return new $class( $site_ID );
 		}
 
-		throw new Exception(' transport class not found' );
-
+		error_log( 'Transport class not found: ' . $class );
+		return;
 	}
 
 	public static function display_client_settings( $site, $transport_type ) {

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -1122,7 +1122,7 @@ class WP_Push_Syndication_Server {
 				$transport_type = get_post_meta( $site_ID, 'syn_transport_type', true);
 				$client         = Syndication_Client_Factory::get_client( $transport_type , $site_ID );
 
-				if( $client->is_post_exists( $ext_ID ) ) {
+				if( $client && $client->is_post_exists( $ext_ID ) ) {
 					$push_delete_shortcircuit = apply_filters( 'syn_pre_push_delete_post_shortcircuit', false, $ext_ID, $post_ID, $site_ID, $transport_type, $client );
 					if ( true === $push_delete_shortcircuit )
 						continue;


### PR DESCRIPTION
Reference ticket: #76793-z

If the transporter class does not exist, then the delete does not take place and it throws a 500 instead.