### PR TITLE
Fix fatal in class-syndication-logger.php

### DIFF
--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -305,7 +305,7 @@ class Syndication_Logger {
 					return new WP_Error( 'logger_no_post', __( 'The post_id provided does not exist.', 'push-syndication' ) );
 				}
 
-				$log = get_post_meta( $post->ID, 'syn_log', true);
+				$log = get_post_meta( $post->ID, 'syn_log' );
 
 				if ( empty( $log ) ) {
 					$log[0] = $log_entry;


### PR DESCRIPTION
on line 308: we are asking for a string to be returned.
on line 311: If it's empty, we are converting it to an array
on line 313: count() should throw a warning because it's being used on a string
same on line 315
on line 316: array_slice should throw a warning for the same reason
on line 319: [] throws a fatal if $log is not an array
but if 319 throws a fatal, 313, 315 and 316 should throw a warning too since they are in the same control structure