### PR TITLE
PHPCS Fixes 

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,7 +48,9 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element value="syndication"/>
+				<element value="push_syn"/>
+				<element value="pull_syn"/>
+				<element value="syn"/>
 			</property>
 		</properties>
 	</rule>
@@ -56,7 +58,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="syndication"/>
+				<element value="push-syndication"/>
 			</property>
 		</properties>
 	</rule>

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -5,11 +5,14 @@
  */
 class Syndication_Logger_Admin_Notice {
 
-	private static $notice_option = 'syn_notices';
+	private static $notice_option         = 'syn_notices';
 	private static $notice_bundles_option = 'syn_notice_bundles';
 
 	private static $dismiss_parameter = 'syn_dismiss';
 
+	/**
+	 * Syndication_Logger_Admin_Notice constructor.
+	 */
 	public function __construct() {
 		add_action( 'admin_init', array( __CLASS__, 'handle_dismiss_syndication_notice' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'display_valid_notices' ) );
@@ -17,24 +20,25 @@ class Syndication_Logger_Admin_Notice {
 
 	/**
 	 * Create a admin notice
-	 * @param text    $message_text       The message you would like to show
-	 * @param string  $message_type       A message type, shown alongside with your message and used to categorize and bundle messages of the same type
-	 * @param string  $class              css class applied to the notice eg. 'updated', 'error', 'update-nag'
-	 * @param boolean $summarize_multiple setting this to true allows summarizing messages of the same message_type into one message. The message text is then passed through the syn_message_text_multiple filter and all messages of this type can be dismissed at once
+	 *
+	 * @param string  $message_text       The message you would like to show.
+	 * @param string  $message_type       A message type, shown alongside with your message and used to categorize and bundle messages of the same type.
+	 * @param string  $class              css class applied to the notice eg. 'updated', 'error', 'update-nag'.
+	 * @param boolean $summarize_multiple setting this to true allows summarizing messages of the same message_type into one message. The message text is then passed through the syn_message_text_multiple filter and all messages of this type can be dismissed at once.
 	 */
 	public static function add_notice( $message_text, $message_type = 'Syndication', $class = 'updated', $summarize_multiple = false ) {
 		$notices = get_option( self::$notice_option );
 
-		$changed = false;
+		$changed     = false;
 		$message_key = md5( $message_type . $message_text );
-		if ( ! is_array( $notices ) || ! isset( $notices[$message_type] ) || ! isset( $notices[$message_type][$message_key] ) ) {
-			$notices[$message_type][$message_key] = array(
-				'message_text' => sanitize_text_field( $message_text ),
-				'summarize_multiple' => (boolean) $summarize_multiple,
-				'message_type' => sanitize_text_field( $message_type ),
-				'class' => sanitize_text_field( $class ),
+		if ( ! is_array( $notices ) || ! isset( $notices[ $message_type ] ) || ! isset( $notices[ $message_type ][ $message_key ] ) ) {
+			$notices[ $message_type ][ $message_key ] = array(
+				'message_text'       => sanitize_text_field( $message_text ),
+				'summarize_multiple' => (bool) $summarize_multiple,
+				'message_type'       => sanitize_text_field( $message_type ),
+				'class'              => sanitize_text_field( $class ),
 			);
-			$changed = true;
+			$changed                                  = true;
 		}
 
 		if ( true === $changed ) {
@@ -50,40 +54,40 @@ class Syndication_Logger_Admin_Notice {
 	public static function display_valid_notices() {
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
-		$messages = get_option( self::$notice_option );
-		$notice_bundles = get_option( self::$notice_bundles_option );
-		$messages_to_display = array();
+		$messages               = get_option( self::$notice_option );
+		$notice_bundles         = get_option( self::$notice_bundles_option );
+		$messages_to_display    = array();
 		$notice_bundles_changed = false;
 
-		if ( !is_array( $messages ) || empty( $messages ) ) {
+		if ( ! is_array( $messages ) || empty( $messages ) ) {
 			return;
 		}
 
-		foreach( $messages as $message_type => $message_values ) {
-			foreach( $message_values as $message_key => $message_data ) {
+		foreach ( $messages as $message_type => $message_values ) {
+			foreach ( $message_values as $message_key => $message_data ) {
 				if ( isset( $message_data['summarize_multiple'] ) && true === $message_data['summarize_multiple'] ) {
 					$message_text = apply_filters( 'syn_message_text_multiple', $message_data['message_text'], $message_data );
 				} else {
 					$message_text = apply_filters( 'syn_message_text', $message_data['message_text'], $message_data );
 				}
 
-				$new_message_key = md5( $message_type . $message_text );
+				$new_message_key  = md5( $message_type . $message_text );
 				$new_message_data = array(
-					'message_text' => sanitize_text_field( $message_text ),
-					'summarize_multiple' => (boolean) $message_data['summarize_multiple'],
-					'message_type' => sanitize_text_field( $message_data['message_type'] ),
-					'class' => sanitize_text_field( $message_data['class'] )
+					'message_text'       => sanitize_text_field( $message_text ),
+					'summarize_multiple' => (bool) $message_data['summarize_multiple'],
+					'message_type'       => sanitize_text_field( $message_data['message_type'] ),
+					'class'              => sanitize_text_field( $message_data['class'] ),
 				);
 
 				if ( $new_message_key != $message_key ) {
-					if ( ! isset( $notice_bundles[$new_message_key] ) || ! in_array( $message_key, $notice_bundles[$new_message_key] ) ) {
-						$notice_bundles[$new_message_key][] = $message_key;
-						$notice_bundles_changed = true;
+					if ( ! isset( $notice_bundles[ $new_message_key ] ) || ! in_array( $message_key, $notice_bundles[ $new_message_key ] ) ) {
+						$notice_bundles[ $new_message_key ][] = $message_key;
+						$notice_bundles_changed               = true;
 					}
 				}
 
 				if ( current_user_can( $capability ) ) {
-					$messages_to_display[$message_type][$new_message_key] = $new_message_data;
+					$messages_to_display[ $message_type ][ $new_message_key ] = $new_message_data;
 				}
 			}
 		}
@@ -92,11 +96,23 @@ class Syndication_Logger_Admin_Notice {
 			update_option( self::$notice_bundles_option, $notice_bundles );
 		}
 
-		foreach( $messages_to_display as $message_type => $message_values ) {
-			foreach( $message_values as $message_key => $message_data ) {
+		foreach ( $messages_to_display as $message_type => $message_values ) {
+			foreach ( $message_values as $message_key => $message_data ) {
 				$dismiss_nonce = wp_create_nonce( esc_attr( $message_key ) );
 				printf( '<div class="%s"><p>', esc_attr( $message_data['class'] ) );
-				printf( __('%1$s : %2$s <a href="%3$s">Hide Notice</a>'), esc_html( $message_type ), wp_kses_post( $message_data['message_text'] ), add_query_arg( array( self::$dismiss_parameter => esc_attr( $message_key ), 'syn_dismiss_nonce' => esc_attr( $dismiss_nonce ) ) ) );
+				printf(
+					__( '%1$s : %2$s <a href="%3$s">Hide Notice</a>' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					esc_html( $message_type ),
+					wp_kses_post( $message_data['message_text'] ),
+					esc_url(
+						add_query_arg(
+							array(
+								self::$dismiss_parameter => esc_attr( $message_key ),
+								'syn_dismiss_nonce'      => esc_attr( $dismiss_nonce ),
+							)
+						)
+					)
+				);
 				printf( '</p></div>' );
 			}
 		}
@@ -108,49 +124,63 @@ class Syndication_Logger_Admin_Notice {
 	public static function handle_dismiss_syndication_notice() {
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
-		// add nonce
-		if ( isset( $_GET[self::$dismiss_parameter] ) && current_user_can( $capability ) ) {
-
-			$dismiss_key = esc_attr( $_GET[self::$dismiss_parameter] );
-			$dismiss_nonce = esc_attr( $_GET['syn_dismiss_nonce'] );
+		// add nonce.
+		if ( isset( $_GET[ self::$dismiss_parameter ] ) && current_user_can( $capability ) ) {
+			$dismiss_key   = esc_attr( $_GET[ self::$dismiss_parameter ] );  // phpcs:ignore
+			$dismiss_nonce = esc_attr( isset( $_GET['syn_dismiss_nonce'] ) ? $_GET['syn_dismiss_nonce'] : '' ); // phpcs:ignore
 			if ( ! wp_verify_nonce( $dismiss_nonce, $dismiss_key ) ) {
-				wp_die( __( "Invalid security check" ) );
+				wp_die( esc_html__( 'Invalid security check' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 			}
-			$messages = get_option( self::$notice_option );
+			$messages       = get_option( self::$notice_option );
 			$notice_bundles = get_option( self::$notice_bundles_option );
 
 			$dismiss_items = array();
-			if ( isset( $notice_bundles[$dismiss_key] ) ) {
-				$dismiss_items = $notice_bundles[$dismiss_key];
+			if ( isset( $notice_bundles[ $dismiss_key ] ) ) {
+				$dismiss_items = $notice_bundles[ $dismiss_key ];
 			} else {
 				$dismiss_items = array( $dismiss_key );
 			}
 
-			foreach( $messages as $message_type => $message_values ) {
+			foreach ( $messages as $message_type => $message_values ) {
 				$message_keys = array_keys( $message_values );
-				$dismiss_it = array_intersect( $message_keys, $dismiss_items );
-				foreach( $dismiss_it as $dismiss_it_key ) {
-					unset( $messages[$message_type][$dismiss_it_key] );
+				$dismiss_it   = array_intersect( $message_keys, $dismiss_items );
+				foreach ( $dismiss_it as $dismiss_it_key ) {
+					unset( $messages[ $message_type ][ $dismiss_it_key ] );
 				}
 			}
 
-			if ( isset( $notice_bundles[$dismiss_key] ) ) {
-				unset( $notice_bundles[$dismiss_key] );
+			if ( isset( $notice_bundles[ $dismiss_key ] ) ) {
+				unset( $notice_bundles[ $dismiss_key ] );
 			}
 
 			update_option( self::$notice_option, $messages );
 			update_option( self::$notice_bundles_option, $notice_bundles );
-
 		}
 	}
 }
 
+/**
+ * @param $message
+ * @param $message_data
+ *
+ * @return string|void
+ */
+function syn_handle_multiple_error_notices( $message, $message_data ) { //phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+	return esc_html__( 'There have been multiple errors. Please validate your syndication logs', 'push-syndication' );
+}
 add_filter( 'syn_message_text_multiple', 'syn_handle_multiple_error_notices', 10, 2 );
-function syn_handle_multiple_error_notices( $message, $message_data ) {
-	return __( 'There have been multiple errors. Please validate your syndication logs' );
-}
 
-add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10, 2 );
+/**
+ * @param $site_id
+ * @param $count
+ */
 function syn_add_site_disabled_notice( $site_id, $count ) {
-	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( __( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
+	Syndication_Logger_Admin_Notice::add_notice(
+		sprintf( __( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ),
+		'Syndication site disabled',
+		'error',
+		false
+	);
 }
+add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10, 2 );
+

--- a/includes/class-syndication-client-factory.php
+++ b/includes/class-syndication-client-factory.php
@@ -1,45 +1,68 @@
 <?php
 
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-xmlrpc-client.php' );
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-xml-client.php' );
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-rest-client.php' );
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-rss-client.php' );
+require_once dirname( __FILE__ ) . '/class-syndication-wp-xmlrpc-client.php';
+require_once dirname( __FILE__ ) . '/class-syndication-wp-xml-client.php';
+require_once dirname( __FILE__ ) . '/class-syndication-wp-rest-client.php';
+require_once dirname( __FILE__ ) . '/class-syndication-wp-rss-client.php';
 
+/**
+ * Class Syndication_Client_Factory
+ */
 class Syndication_Client_Factory {
 
-	public static function get_client( $transport_type, $site_ID ) {
-
+	/**
+	 * @param $transport_type
+	 * @param $site_id
+	 *
+	 * @return mixed
+	 * @throws Exception
+	 */
+	public static function get_client( $transport_type, $site_id ) {
 		$class = self::get_transport_type_class( $transport_type );
-		if( class_exists( $class ) ) {
-			return new $class( $site_ID );
+		if ( class_exists( $class ) ) {
+			return new $class( $site_id );
 		}
 
-		throw new Exception(' transport class not found' );
-
+		throw new Exception( ' transport class not found' );
 	}
 
+	/**
+	 * @param $site
+	 * @param $transport_type
+	 *
+	 * @return false|mixed
+	 * @throws Exception
+	 */
 	public static function display_client_settings( $site, $transport_type ) {
-
 		$class = self::get_transport_type_class( $transport_type );
-		if( class_exists( $class ) ) {
+		if ( class_exists( $class ) ) {
 			return call_user_func( array( $class, 'display_settings' ), $site );
 		}
 
-		throw new Exception( 'transport class not found: '. $class );
-
+		throw new Exception( 'transport class not found: ' . $class );
 	}
 
-	public static function save_client_settings( $site_ID, $transport_type ) {
-
+	/**
+	 * @param $site_id
+	 * @param $transport_type
+	 *
+	 * @return false|mixed
+	 * @throws Exception
+	 */
+	public static function save_client_settings( $site_id, $transport_type ) {
 		$class = self::get_transport_type_class( $transport_type );
-		if( class_exists( $class ) ) {
-			return call_user_func( array( $class, 'save_settings' ), $site_ID );
+		if ( class_exists( $class ) ) {
+			return call_user_func( array( $class, 'save_settings' ), $site_id );
 		}
 
 		throw new Exception( 'transport class not found' );
-
 	}
 
+	/**
+	 * @param $transport_type
+	 *
+	 * @return string
+	 */
 	public static function get_transport_type_class( $transport_type ) {
 		return 'Syndication_' . $transport_type . '_Client';
 	}

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -1,10 +1,11 @@
 <?php
+
+
 /**
  * Event Counter
  *
  * This allows for generic events to be captured and counted. Use the push_syndication_event and push_syndication_reset_event actions to capture and reset counters. Use push_syndication_after_event to handle events once they've occurred, and to see the number of times the event has occurred.
  */
-
 class Syndication_Event_Counter {
 
 	/**
@@ -19,18 +20,18 @@ class Syndication_Event_Counter {
 	/**
 	 * Increments an event counter.
 	 *
-	 * @param string $event_slug An identifier for the event.
+	 * @param string     $event_slug An identifier for the event.
 	 * @param string|int $event_object_id An identifier for the object the event is associated with. Should be unique across all objects associated with the given $event_slug.
 	 */
 	public function count_event( $event_slug, $event_object_id = null ) {
 		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
-		$event_slug = (string) $event_slug;
+		$event_slug      = (string) $event_slug;
 		$event_object_id = (string) $event_object_id;
 
 		// Increment the event counter.
-		$option_name = $this->_get_safe_option_name( $event_slug, $event_object_id );
-		$count = get_option( $option_name, 0 );
-		$count = $count + 1;
+		$option_name = $this->get_safe_option_name( $event_slug, $event_object_id );
+		$count       = get_option( $option_name, 0 );
+		$count       = ++$count;
 		update_option( $option_name, $count );
 
 		/**
@@ -61,10 +62,10 @@ class Syndication_Event_Counter {
 	 */
 	public function reset_event( $event_slug, $event_object_id ) {
 		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
-		$event_slug = (string) $event_slug;
+		$event_slug      = (string) $event_slug;
 		$event_object_id = (string) $event_object_id;
 
-		delete_option( $this->_get_safe_option_name( $event_slug, $event_object_id ) );
+		delete_option( $this->get_safe_option_name( $event_slug, $event_object_id ) );
 	}
 
 	/**
@@ -76,7 +77,7 @@ class Syndication_Event_Counter {
 	 * @param $event_object_id
 	 * @return string
 	 */
-	protected function _get_safe_option_name( $event_slug, $event_object_id ) {
+	protected function get_safe_option_name( $event_slug, $event_object_id ) {
 		return 'push_syndication_event_counter_' . md5( $event_slug . $event_object_id );
 	}
 }

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -1,9 +1,14 @@
 <?php
 
-if( ! class_exists( 'WP_List_Table' ) ) {
-	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
+//@TODO: phpcs - break this file into multiple files, one for each class
+
+/**
+ * Class Syndication_Logger_List_Table
+ */
 class Syndication_Logger_List_Table extends WP_List_Table {
 
 	public $prepared_data = array();
@@ -16,22 +21,29 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 
 	protected $_max_date = null;
 
-	public function __construct(){
+	/**
+	 * Syndication_Logger_List_Table constructor.
+	 */
+	public function __construct() {
 		global $status, $page;
 
-		parent::__construct( array(
-			'singular'  => __( 'log', 'push-syndication' ),
-			'plural'    => __( 'logs', 'push-syndication' ),
-			'ajax'      => false
-		) );
+		parent::__construct(
+			array(
+				'singular' => __( 'log', 'push-syndication' ),
+				'plural'   => __( 'logs', 'push-syndication' ),
+				'ajax'     => false,
+			)
+		);
 
 		add_action( 'admin_head', array( $this, 'admin_header' ) );
 	}
 
 	public function admin_header() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$current_page = ( isset( $_GET['page'] ) ) ? (int) $_GET['page'] : false;
-		if( 'syndication_dashboard' != $current_page )
+		if ( 'syndication_dashboard' != $current_page ) {
 			return;
+		}
 
 		?>
 		<style type="text/css">
@@ -45,12 +57,13 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
+
 	public function no_items() {
-		_e( 'No log entries found.' );
+		esc_html_e( 'No log entries found.', 'push-syndication' );
 	}
 
 	public function column_default( $item, $column_name ) {
-		switch( $column_name ) {
+		switch ( $column_name ) {
 			case 'object_id':
 			case 'log_id':
 			case 'time':
@@ -60,43 +73,43 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 				return $item[ $column_name ];
 
 			default:
-				return print_r( $item, true );
+				return print_r( $item, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		}
 	}
 
 	public function get_sortable_columns() {
 		$sortable_columns = array(
-			'object_id' => array( 'object_id',	false ),
-			'log_id'	=> array( 'log_id', 	false ),
-			'time'		=> array( 'time', 		false ),
-			'msg_type' 	=> array( 'msg_type',	false ),
-			'message'  	=> array( 'message', 	false ),
-			'status'   	=> array( 'status',		false )
-			);
+			'object_id' => array( 'object_id', false ),
+			'log_id'    => array( 'log_id', false ),
+			'time'      => array( 'time', false ),
+			'msg_type'  => array( 'msg_type', false ),
+			'message'   => array( 'message', false ),
+			'status'    => array( 'status', false ),
+		);
 		return $sortable_columns;
 	}
 
-	public function get_columns(){
+	public function get_columns() {
 		$columns = array(
-			'object_id'	=> __( 'Object ID', 'push-syndication' ),
-			'log_id'	=> __( 'Log ID', 	'push-syndication' ),
-			'time'		=> __( 'Time', 		'push-syndication' ),
-			'msg_type'	=> __( 'Type', 		'push-syndication' ),
-			'status'	=> __( 'Status', 	'push-syndication' ),
-			'message'	=> __( 'Message', 	'push-syndication' ),
-			);
+			'object_id' => __( 'Object ID', 'push-syndication' ),
+			'log_id'    => __( 'Log ID', 'push-syndication' ),
+			'time'      => __( 'Time', 'push-syndication' ),
+			'msg_type'  => __( 'Type', 'push-syndication' ),
+			'status'    => __( 'Status', 'push-syndication' ),
+			'message'   => __( 'Message', 'push-syndication' ),
+		);
 		return $columns;
 	}
 
 	public function usort_reorder( $a, $b ) {
-		$orderby = ( ! empty( $_GET['orderby'] ) ) ? esc_attr( $_GET['orderby'] ) : 'time';
-		$order = ( ! empty($_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc';
-		$result = strcmp( $a[$orderby], $b[$orderby] );
-		return ( $order === 'asc' ) ? $result : -$result;
+		$orderby = ( ! empty( $_GET['orderby'] ) ) ? esc_attr( $_GET['orderby'] ) : 'time'; // phpcs:ignore
+		$order   = ( ! empty( $_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc'; // phpcs:ignore
+		$result  = strcmp( $a[ $orderby ], $b[ $orderby ] );
+		return ( 'asc' === $order ) ? $result : -$result;
 	}
 
-	public function column_log_id($item){
-		return sprintf('%1$s', substr( $item['log_id'], 0, 3 ) . '&hellip;' . substr( $item['log_id'], -3 ) );
+	public function column_log_id( $item ) {
+		return sprintf( '%1$s', substr( $item['log_id'], 0, 3 ) . '&hellip;' . substr( $item['log_id'], -3 ) );
 	}
 
 	public function get_bulk_actions() {
@@ -108,80 +121,91 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	 *
 	 */
 	public function prepare_items() {
-		$columns  = $this->get_columns();
-		$hidden   = array();
-		$sortable = $this->get_sortable_columns();
+		$columns               = $this->get_columns();
+		$hidden                = array();
+		$sortable              = $this->get_sortable_columns();
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 
-		$log_id = ( isset( $_REQUEST['log_id'] ) ) ? esc_attr( $_REQUEST['log_id'] ) : null;
-		$msg_type = null;
-		$object_id = null;
-		$object_type = 'post';
-		$log_status = null;
-		$date_start = null;
-		$date_end = null;
-		$message = null;
+		$log_id       = ( isset( $_REQUEST['log_id'] ) ) ? esc_attr( $_REQUEST['log_id'] ) : null; // phpcs:ignore
+		$msg_type     = null;
+		$object_id    = null;
+		$object_type  = 'post';
+		$log_status   = null;
+		$date_start   = null;
+		$date_end     = null;
+		$message      = null;
 		$storage_type = 'object';
 
 		$log_data = Syndication_Logger::instance()->get_messages(
-				$log_id,
-				$msg_type,
-				$object_id,
-				$object_type,
-				$log_status,
-				$date_start,
-				$date_end,
-				$message,
-				$storage_type
+			$log_id,
+			$msg_type,
+			$object_id,
+			$object_type,
+			$log_status,
+			$date_start,
+			$date_end,
+			$message,
+			$storage_type
 		);
 
-		foreach( $log_data as $site_id => $log_items ) {
+		foreach ( $log_data as $site_id => $log_items ) {
 			$this->prepared_data = array_merge( $this->prepared_data, $log_items );
 		}
 		usort( $this->prepared_data, array( $this, 'usort_reorder' ) );
 
-		$per_page = $this->get_items_per_page( 'per_page' );
+		$per_page     = $this->get_items_per_page( 'per_page' );
 		$current_page = $this->get_pagenum();
-		$total_items = count( $this->prepared_data );
+		$total_items  = count( $this->prepared_data );
 
-		$this->found_data = array_slice( $this->prepared_data,( ( $current_page-1 )* $per_page ), $per_page );
+		$this->found_data = array_slice( $this->prepared_data, ( ( $current_page - 1 ) * $per_page ), $per_page );
 
 
 		// Populate min/max dates.
 		if ( $this->found_data ) {
 			$items_sorted_by_time = $this->found_data;
 
-			usort( $items_sorted_by_time, function ( $a, $b  ) {
-				return strtotime( $a['time'] ) - strtotime( $b['time'] );
-			} );
+			usort(
+				$items_sorted_by_time,
+				function ( $a, $b ) {
+					return strtotime( $a['time'] ) - strtotime( $b['time'] );
+				}
+			);
 
 			$this->_max_date = strtotime( end( $items_sorted_by_time )['time'] );
 			$this->_min_date = strtotime( reset( $items_sorted_by_time )['time'] );
 		}
 
 
-		// Filter by month
-		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null;
+		// Filter by month.
+		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null; // phpcs:ignore
 		if ( $requested_month ) {
-			$this->found_data = array_filter( $this->found_data, function ( $item ) use ( $requested_month ) {
-				return date( 'Y-m', strtotime( $item['time'] ) ) === $requested_month;
-			} );
+			$this->found_data = array_filter(
+				$this->found_data,
+				function ( $item ) use ( $requested_month ) {
+					return gmdate( 'Y-m', strtotime( $item['time'] ) ) === $requested_month;
+				}
+			);
 		}
 
 
-		// Filter by type
-		$requested_type = isset( $_REQUEST['type'] ) ? esc_attr( $_REQUEST['type'] ) : null;
+		// Filter by type.
+		$requested_type = isset( $_REQUEST['type'] ) ? esc_attr( $_REQUEST['type'] ) : null; // phpcs:ignore
 		if ( $requested_type ) {
-			$this->found_data = array_filter( $this->found_data, function ( $item  ) use ( $requested_type ) {
-				return $requested_type === $item['msg_type'];
-			} );
+			$this->found_data = array_filter(
+				$this->found_data,
+				function ( $item ) use ( $requested_type ) {
+					return $requested_type === $item['msg_type'];
+				}
+			);
 		}
 
 
-		$this->set_pagination_args( array(
-			'total_items' => $total_items,
-			'per_page'    => $per_page
-		) );
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+			)
+		);
 		$this->items = $this->found_data;
 	}
 
@@ -189,13 +213,18 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		?>
 		<div class="alignleft actions">
 			<?php
-			if ( 'top' == $which && !is_singular() ) {
-
+			if ( 'top' == $which && ! is_singular() ) {
 				$this->create_log_id_dropdown();
-				$this->_create_months_dropdown();
-				$this->_create_types_dropdown();
+				$this->create_months_dropdown();
+				$this->create_types_dropdown();
 
-				submit_button( __( 'Filter' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+				submit_button(
+					esc_attr__( 'Filter', 'push-syndication' ),
+					'button',
+					'filter_action',
+					false,
+					array( 'id' => 'post-query-submit' )
+				);
 			}
 
 			?>
@@ -204,20 +233,22 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	}
 
 	private function create_log_id_dropdown() {
-		$requested_log_id = isset( $_REQUEST['log_id'] ) ? esc_attr( $_REQUEST['log_id'] ) : 0;
+		$requested_log_id = isset( $_REQUEST['log_id'] ) ? esc_attr( $_REQUEST['log_id'] ) : 0; // phpcs:ignore
 		?>
-		<label class="screen-reader-text" for="filter-by-log-id"><?php _e( 'Filter by Log ID' ); ?></label>
+		<label class="screen-reader-text" for="filter-by-log-id"><?php esc_html_e( 'Filter by Log ID', 'push-syndication' ); ?></label>
 		<select name="log_id" id="filter-by-log-id">
-			<option<?php selected( $requested_log_id, 0 ); ?> value="0"><?php _e( 'All logs' ); ?></option>
+			<option<?php selected( $requested_log_id, 0 ); ?> value="0"><?php esc_html_e( 'All logs', 'push-syndication' ); ?></option>
 			<?php
 			$log_ids = array();
 			foreach ( $this->prepared_data as $row ) {
-				if ( 0 == $row['log_id'] )
+				if ( 0 == $row['log_id'] ) {
 					continue;
+				}
 
 				$log_id = esc_attr( $row['log_id'] );
-				if ( ! isset( $log_ids[$log_id] ) ) {
-					$log_ids[$log_id] = sprintf( "<option %s value='%s'>%s</option>\n",
+				if ( ! isset( $log_ids[ $log_id ] ) ) {
+					$log_ids[ $log_id ] = sprintf(
+						"<option %s value='%s'>%s</option>\n",
 						selected( $requested_log_id, $log_id, false ),
 						esc_attr( $log_id ),
 						esc_attr( $this->column_log_id( $row ) )
@@ -225,6 +256,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 				}
 			}
 
+			// phpcs:ignore
 			echo implode( "\n", $log_ids ); // sanitization happens right above
 			?>
 		</select>
@@ -232,8 +264,8 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
-	protected function _create_months_dropdown() {
-		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null;
+	protected function create_months_dropdown() {
+		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null; // phpcs:ignore
 		?>
 		<label class="screen-reader-text" for="filter-by-month">Filter by month</label>
 		<select name="month" id="filter-by-month">
@@ -242,11 +274,11 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 			<?php
 			if ( $this->_min_date && $this->_max_date ) {
 				$month_pointer = new DateTime( '@' . $this->_min_date );
-				$max_month = new DateTime( '@' . $this->_max_date );
+				$max_month     = new DateTime( '@' . $this->_max_date );
 
-				while ( $month_pointer <= $max_month ) { ?>
-					<option
-						value='<?php echo esc_attr( $month_pointer->format( 'Y-m' ) ); ?>' <?php selected( $requested_month, $month_pointer->format( 'Y-m' ) ); ?>><?php echo esc_html( $month_pointer->format( 'F Y' ) ); ?></option>
+				while ( $month_pointer <= $max_month ) {
+					?>
+					<option	value='<?php echo esc_attr( $month_pointer->format( 'Y-m' ) ); ?>' <?php selected( $requested_month, $month_pointer->format( 'Y-m' ) ); ?>><?php echo esc_html( $month_pointer->format( 'F Y' ) ); ?></option>
 					<?php
 					$month_pointer->modify( '+1 month' );
 				}
@@ -256,13 +288,19 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
-	protected function _create_types_dropdown() {
-		$requested_type = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['type'] ) : null;
+	protected function create_types_dropdown() {
+		$requested_type = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['type'] ) : null; // phpcs:ignore
 		?>
 		<label class="screen-reader-text" for="filter-by-type">Filter by type</label>
 		<select name="type" id="filter-by-type">
 			<option value="">All types</option>
-			<?php foreach( array( 'success' => 'Success', 'info' => 'Information', 'error' => 'Error' ) as $key => $label ): ?>
+			<?php
+			foreach ( array(
+				'success' => 'Success',
+				'info'    => 'Information',
+				'error'   => 'Error',
+			) as $key => $label ) :
+				?>
 				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $requested_type, $key ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
@@ -270,31 +308,38 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	}
 }
 
-
+/**
+ * Class Syndication_Logger_Viewer
+ */
 class Syndication_Logger_Viewer {
 
 	public $syndication_logger_table;
 
+	/**
+	 * Syndication_Logger_Viewer constructor.
+	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'add_menu_items' ) );
 	}
 
-	public function add_menu_items(){
+	public function add_menu_items() {
 		$hook = add_submenu_page( 'edit.php?post_type=syn_site', 'Logs', 'Logs', 'activate_plugins', 'syndication_dashboard', array( $this, 'render_list_page' ) );
 		add_action( "load-$hook", array( $this, 'initialize_list_table' ) );
 	}
 
 	public function initialize_list_table() {
+		// phpcs:ignore
 		if ( ! empty( $_POST['log_id'] ) && ( empty( $_GET['log_id'] ) || esc_attr( $_GET['log_id'] ) != esc_attr( $_POST['log_id'] ) ) ) {
-			wp_safe_redirect( add_query_arg( array( 'log_id' => esc_attr( $_REQUEST['log_id'] ) ), wp_unslash($_SERVER['REQUEST_URI'] ) ) );
+			// phpcs:ignore
+			wp_safe_redirect( add_query_arg( array( 'log_id' => esc_attr( $_REQUEST['log_id'] ) ), wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 			exit;
 		}
 		$this->syndication_logger_table = new Syndication_Logger_List_Table();
 	}
 
-	public function render_list_page(){
+	public function render_list_page() {
 		?>
-		<div class="wrap"><h2><?php _e( "Syndication Logs", "syndication" ); ?></h2>
+		<div class="wrap"><h2><?php _e( 'Syndication Logs', 'push-syndication' ); ?></h2>
 			<?php
 			$this->syndication_logger_table->prepare_items();
 			?>

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -8,42 +8,51 @@
 class Syndication_Logger {
 
 	/**
-	 * singleton handle
+	 * Singleton handle
+	 *
 	 * @var object
 	 */
-	private static $__instance = null;
+	private static $__instance = null; // phpcs:ignore
 
 	/**
-	 * maximum amount of rows to keep for single object log entries
+	 * Maximum amount of rows to keep for single object log entries
+	 *
 	 * @var integer
 	 */
 	private $log_entry_limit = 150;
 
 	/**
-	 * level of information to log. Can be info for all and default for errors/success
+	 * Level of information to log. Can be info for all and default for errors/success
+	 *
 	 * @var string
 	 */
 	private $debug_level = null;
 
 	/**
-	 * if true log messages will also be sent to php error log
+	 * If true log messages will also be sent to php error log
+	 *
 	 * @var boolean
 	 */
 	private $use_php_error_logging = null;
 
 	/**
-	 * filter variables for retrieving log messages
+	 * Filter variables for retrieving log messages
+	 *
 	 * @var array
 	 */
 	private $log_filter = array();
 
 	/**
-	 * a unique identifier for each page load / logging session
+	 * A unique identifier for each page load / logging session
+	 *
 	 * @var string
 	 */
 	private $log_id = null;
 
-	public function __construct() {
+	/**
+	 * Syndication_Logger constructor.
+	 */
+	private function __construct() {
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'log_new' ), 10, 5 );
 		add_action( 'syn_post_pull_edit_post', array( __CLASS__, 'log_update' ), 10, 5 );
 		add_action( 'syn_post_push_delete_post', array( __CLASS__, 'log_delete' ), 10, 6 );
@@ -55,9 +64,9 @@ class Syndication_Logger {
 
 		if ( false === $this->debug_level ) {
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
-				$this->debug_level = 'info';	// log everything
+				$this->debug_level = 'info';    // log everything.
 			} else {
-				$this->debug_level = 'default';	// log only errors + success
+				$this->debug_level = 'default'; // log only errors + success.
 			}
 		}
 
@@ -66,9 +75,9 @@ class Syndication_Logger {
 
 		if ( false === $this->use_php_error_logging ) {
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
-				$this->use_php_error_logging = true;	// log also with error_log()
+				$this->use_php_error_logging = true;    // log also with error_log().
 			} else {
-				$this->use_php_error_logging = false;	// log only in db
+				$this->use_php_error_logging = false;   // log only in db.
 			}
 		}
 	}
@@ -79,20 +88,22 @@ class Syndication_Logger {
 	public static function init() {
 		self::instance()->log_id = md5( uniqid() . microtime() );
 
-		require_once( dirname( __FILE__ ) . '/class-syndication-admin-notices.php' );
-		new Syndication_Logger_Admin_Notice;
+		require_once dirname( __FILE__ ) . '/class-syndication-admin-notices.php';
+		new Syndication_Logger_Admin_Notice();
 
 		if ( is_admin() ) {
-			require_once( dirname( __FILE__ ) . '/class-syndication-logger-viewer.php' );
-			$viewer = new Syndication_Logger_Viewer;
+			require_once dirname( __FILE__ ) . '/class-syndication-logger-viewer.php';
+			$viewer = new Syndication_Logger_Viewer();
 		}
 	}
 
-	/*
+	/**
 	 * Use this singleton to address non-static methods
+	 *
+	 * @return Syndication_Logger
 	 */
 	public static function instance() {
-		if ( self::$__instance == null ) {
+		if ( null === self::$__instance ) {
 			self::$__instance = new self();
 		}
 		return self::$__instance;
@@ -105,11 +116,11 @@ class Syndication_Logger {
 	 * do_action( 'syn_post_pull_new_post', $result, $post, $site, $transport_type, $client );
 	 * do_action( 'syn_post_push_new_post', $result, $post_ID, $site, $transport_type, $client, $info );
 	 *
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	public static function log_new( $result, $post, $site, $transport_type, $client ) {
 		self::instance()->log_post_event( 'new', $result, $post, $site, $transport_type, $client );
@@ -121,11 +132,11 @@ class Syndication_Logger {
 	 * do_action( 'syn_post_pull_edit_post', $result, $post, $site, $transport_type, $client );
 	 * do_action( 'syn_post_push_edit_post', $result, $post_ID, $site, $transport_type, $client, $info );
 	 *
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	public static function log_update( $result, $post, $site, $transport_type, $client ) {
 		self::instance()->log_post_event( 'update', $result, $post, $site, $transport_type, $client );
@@ -136,12 +147,12 @@ class Syndication_Logger {
 	 * usually implemented via action hook
 	 * do_action( 'syn_post_push_delete_post', $result, $ext_ID, $post_ID, $site_ID, $transport_type, $client );
 	 *
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
- 	 * @param  mixed  $external_id    External post post_id
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $external_id    External post post_id.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	public static function log_delete( $result, $external_id, $post, $site, $transport_type, $client ) {
 		self::instance()->log_post_event( 'delete', $result, $post, $site, $transport_type, $client );
@@ -149,12 +160,13 @@ class Syndication_Logger {
 
 	/**
 	 * Prepares data for the post level log events
-	 * @param  string $event          Type of event new/update/delete
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
- 	 * @param  mixed  $post           Post object or post_id
- 	 * @param  object $site           Post object for the site doing the syndication
- 	 * @param  string $transport_type Post meta syn_transport_type for site
- 	 * @param  object $client         Syndication_Client class
+	 *
+	 * @param  string $event          Type of event new/update/delete.
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	private function log_post_event( $event, $result, $post, $site, $transport_type, $client ) {
 		if ( is_int( $post ) ) {
@@ -168,10 +180,10 @@ class Syndication_Logger {
 		}
 
 		$extra = array(
-			'post' 			 => $post,
-			'result' 		 => $result,
+			'post'           => $post,
+			'result'         => $result,
 			'transpost_type' => $transport_type,
-			'client' 		 => $client
+			'client'         => $client,
 		);
 
 		if ( false == $result || is_wp_error( $result ) ) {
@@ -180,20 +192,23 @@ class Syndication_Logger {
 			} else {
 				$message = 'fail';
 			}
-			Syndication_Logger::log_post_error( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+			self::log_post_error( $site->ID, esc_attr__( $event, 'push-syndication' ), $message, $log_time, $extra );
 		} else {
 			$message = sprintf( '%s,%d', sanitize_text_field( $post['post_guid'] ), intval( $result ) );
-			Syndication_Logger::log_post_success( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+			self::log_post_success( $site->ID, esc_attr__( $event, 'push-syndication' ), $message, $log_time, $extra );
 		}
 	}
 
 	/**
 	 * Log a faulty post level event
-	 * @param  int 	  $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 *
+	 * @param  int    $post_id  post_id to attach the log entry to.
+	 * @param  string $status   status entry.
+	 * @param  string $message  log message.
+	 * @param  string $log_time time of event.
+	 * @param  array  $extra    additional data.
 	 */
 	public static function log_post_error( $post_id, $status = 'error', $message = '', $log_time = '', $extra = array() ) {
 		self::instance()->log_post( 'error', $post_id, $status, $message, $log_time, $extra );
@@ -201,11 +216,12 @@ class Syndication_Logger {
 
 	/**
 	 * Log a successful post level event
-	 * @param  int 	  $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 *
+	 * @param  int    $post_id  post_id to attach the log entry to.
+	 * @param  string $status   status entry.
+	 * @param  string $message  log message.
+	 * @param  string $log_time time of event.
+	 * @param  array  $extra    additional data.
 	 */
 	public function log_post_success( $post_id, $status = 'ok', $message = '', $log_time = '', $extra = array() ) {
 		self::instance()->log_post( 'success', $post_id, $status, $message, $log_time, $extra );
@@ -213,11 +229,12 @@ class Syndication_Logger {
 
 	/**
 	 * Log a post level informal event
-	 * @param  int 	  $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 *
+	 * @param  int    $post_id  post_id to attach the log entry to.
+	 * @param  string $status   status entry.
+	 * @param  string $message  log message.
+	 * @param  string $log_time time of event.
+	 * @param  array  $extra    additional data.
 	 */
 	public static function log_post_info( $post_id, $status = '', $message = '', $log_time = '', $extra = array() ) {
 		self::instance()->log_post( 'info', $post_id, $status, $message, $log_time, $extra );
@@ -225,38 +242,40 @@ class Syndication_Logger {
 
 	/**
 	 * Pass post level events to logger function
-	 * @param  string $msg_type event type success/error/info
-	 * @param  int 	  $post_id  post_id to attach the log entry to
- 	 * @param  string $status   status entry
- 	 * @param  string $message  log message
- 	 * @param  string $log_time time of event
- 	 * @param  array  $extra    additional data
+	 *
+	 * @param  string $msg_type event type success/error/info.
+	 * @param  int    $post_id  post_id to attach the log entry to.
+	 * @param  string $status   status entry.
+	 * @param  string $message  log message.
+	 * @param  string $log_time time of event.
+	 * @param  array  $extra    additional data.
 	 */
 	private function log_post( $msg_type, $post_id, $status, $message, $log_time, $extra ) {
-		$this->log( $storage_type = 'object', $msg_type, $object_type = 'post', $object_id = $post_id, $status, $message, $log_time, $extra );
+		$this->log( 'object', $msg_type, 'post', $post_id, $status, $message, $log_time, $extra );
 	}
 
 	/**
 	 * Log an entry to the database
-	 * @param  string $storage_type Where the log entry will be stored. object / option
- 	 * @param  string $msg_type 	event type success/error/info
-	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported
- 	 * @param  int 	  $object_id  	object_id (post_id) to attach the log entry to
-  	 * @param  string $status   	status entry
-  	 * @param  string $message  	log message
-  	 * @param  string $log_time 	time of event
-  	 * @param  array  $extra    	additional data
+	 *
+	 * @param  string $storage_type Where the log entry will be stored. object / option.
+	 * @param  string $msg_type     event type success/error/info.
+	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported.
+	 * @param  int    $object_id    object_id (post_id) to attach the log entry to.
+	 * @param  string $status       status entry.
+	 * @param  string $message      log message.
+	 * @param  string $log_time     time of event.
+	 * @param  array  $extra        additional data.
 	 * @return mixed                true or WP_Error
 	 */
 	private function log( $storage_type, $msg_type, $object_type = 'post', $object_id = '', $status, $message, $log_time, $extra ) {
-		// Don't log infos depending on debug level
+		// Don't log infos depending on debug level.
 		if ( 'info' == $msg_type && 'info' != $this->debug_level ) {
 			return;
 		}
 
 		$log_entry = array(
-			'log_id' 	=> $this->log_id,
-			'msg_type'  => $msg_type,
+			'log_id'   => $this->log_id,
+			'msg_type' => $msg_type,
 		);
 
 		if ( ! empty( $object_type ) ) {
@@ -276,9 +295,9 @@ class Syndication_Logger {
 		}
 
 		if ( ! empty( $log_time ) ) {
-			$log_entry['time'] = date('Y-m-d H:i:s', strtotime( $log_time ) );
+			$log_entry['time'] = gmdate( 'Y-m-d H:i:s', strtotime( $log_time ) );
 		} else {
-			$log_entry['time'] = current_time('mysql');
+			$log_entry['time'] = current_time( 'mysql' );
 		}
 
 		if ( ! empty( $extra ) && is_array( $extra ) ) {
@@ -288,32 +307,41 @@ class Syndication_Logger {
 
 
 		if ( true === $this->use_php_error_logging ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $this->format_log_message( $msg_type, $log_entry ) );
 		}
 
 		if ( 'object' == $storage_type ) {
-			// Storing the log alongside the object
+			// Storing the log alongside the object.
 
 			if ( 'post' == $object_type ) {
-
 				if ( ! is_integer( $object_id ) ) {
-					return new WP_Error( 'logger_no_post_id', __( 'You need to provide a valid post_id or use log_option instead', 'push-syndication' ) );
+					return new WP_Error(
+						'logger_no_post_id',
+						__(
+							'You need to provide a valid post_id or use log_option instead',
+							'push-syndication'
+						)
+					);
 				}
 
 				$post = get_post( $object_id );
 				if ( ! $post ) {
-					return new WP_Error( 'logger_no_post', __( 'The post_id provided does not exist.', 'push-syndication' ) );
+					return new WP_Error(
+						'logger_no_post',
+						__( 'The post_id provided does not exist.', 'push-syndication' )
+					);
 				}
 
-				$log = get_post_meta( $post->ID, 'syn_log', true);
+				$log = get_post_meta( $post->ID, 'syn_log', true );
 
 				if ( empty( $log ) ) {
 					$log[0] = $log_entry;
 				} else {
 					if ( count( $log ) >= $this->log_entry_limit ) {
-						// Slice the array to keep the log size in the limits
-						$offset = count ( $log ) - $this->log_entry_limit;
-						$log = array_slice( $log, $offset + 1 );
+						// Slice the array to keep the log size in the limits.
+						$offset = count( $log ) - $this->log_entry_limit;
+						$log    = array_slice( $log, $offset + 1 );
 					}
 
 					$log[] = $log_entry;
@@ -322,33 +350,32 @@ class Syndication_Logger {
 
 				if ( 'success' == $msg_type ) {
 					update_post_meta( $post->ID, 'syn_log_errors', 0 );
-				} else if ( 'error' == $msg_type ) {
-					// track failures since last success
+				} elseif ( 'error' == $msg_type ) {
+					// track failures since last success.
 					$errors = get_post_meta( $post->ID, 'syn_log_errors', true );
 					$errors = (int) $errors + 1;
 					update_post_meta( $post->ID, 'syn_log_errors', $errors );
-					// track overall failures
+					// track overall failures.
 					$errors = get_post_meta( $post->ID, 'syn_log_errors_overall', true );
 					$errors = (int) $errors + 1;
 					update_post_meta( $post->ID, 'syn_log_errors_overall', $errors );
 				}
 
 				// @TODO log error counter
-			} else if ( 'term' == $object_type ) {
+			} elseif ( 'term' == $object_type ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
 				// @TODO implement if needed
 			}
-
-		} else if ( 'option' == $storage_type ) {
-			// Storing the log in an option value
+		} elseif ( 'option' == $storage_type ) {
+			// Storing the log in an option value.
 
 			$log = get_option( 'syn_log', true );
 			if ( empty( $log ) ) {
 				$log[0] = $log_entry;
 			} else {
 				if ( count( $log ) >= $this->log_entry_limit ) {
-					// Slice the array to keep the log size in the limits
-					$offset = count ( $log ) - $this->log_entry_limit;
-					$log = array_slice( $log, $offset + 1 );
+					// Slice the array to keep the log size in the limits.
+					$offset = count( $log ) - $this->log_entry_limit;
+					$log    = array_slice( $log, $offset + 1 );
 				}
 
 				$log[] = $log_entry;
@@ -357,12 +384,12 @@ class Syndication_Logger {
 
 			if ( 'success' == $msg_type ) {
 				update_option( 'syn_log_errors', 0 );
-			} else if ( 'error' == $msg_type ) {
-				// track failures since last success
+			} elseif ( 'error' == $msg_type ) {
+				// track failures since last success.
 				$errors = get_option( 'syn_log_errors' );
 				$errors = (int) $errors + 1;
 				update_option( 'syn_log_errors', $errors );
-				// track overall failures
+				// track overall failures.
 				$errors = get_option( 'syn_log_errors_overall' );
 				$errors = (int) $errors + 1;
 				update_option( 'syn_log_errors_overall', $errors );
@@ -373,36 +400,50 @@ class Syndication_Logger {
 
 	/**
 	 * Format log message for error_log()
-	 * @param  string $msg_type  Type of message
-	 * @param  array  $log_entry Prepared log_entry array
+	 *
+	 * @param  string $msg_type  Type of message.
+	 * @param  array  $log_entry Prepared log_entry array.
 	 * @return string            Formatted log message
 	 */
 	private function format_log_message( $msg_type, $log_entry ) {
-		$msg = apply_filters( 'syn_error_log_message_format', sprintf( 'SYN_%s:%s,%d,%s%s', strtoupper( $msg_type ), $log_entry['object_type'], $log_entry['object_id'], $log_entry['status'], $log_entry['message'] ? ',' . $log_entry['message'] : '' ), $msg_type, $log_entry );
+		$msg = apply_filters(
+			'syn_error_log_message_format', //phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			sprintf(
+				'SYN_%s:%s,%d,%s%s',
+				strtoupper( $msg_type ),
+				$log_entry['object_type'],
+				$log_entry['object_id'],
+				$log_entry['status'],
+				$log_entry['message'] ? ',' . $log_entry['message'] : ''
+			),
+			$msg_type,
+			$log_entry
+		);
 		return $msg;
 	}
 
 	/**
 	 * Retrieve and filter log messages from database
- 	 * @param  string $log_id		unique log session id
- 	 * @param  string $msg_type 	event type success/error/info
- 	 * @param  int 	  $object_id  	object_id (post_id) to attach the log entry to
-	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported
-  	 * @param  string $status   	status entry
-	 * @param  string $date_start   Date string for starting date filter
-	 * @param  string $date_end     Date string for starting date filter
-	 * @param  string $message      regular expression for message text matching
-	 * @param  string $storage_type Where the log entry will be stored. object / option
-  	 * @return array                Array of matching log entries
+	 *
+	 * @param  string $log_id       unique log session id.
+	 * @param  string $msg_type     event type success/error/info.
+	 * @param  int    $object_id    object_id (post_id) to attach the log entry to.
+	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported.
+	 * @param  string $status       status entry.
+	 * @param  string $date_start   Date string for starting date filter.
+	 * @param  string $date_end     Date string for starting date filter.
+	 * @param  string $message      regular expression for message text matching.
+	 * @param  string $storage_type Where the log entry will be stored. object / option.
+	 * @return array                Array of matching log entries
 	 */
-	public static function get_messages( $log_id = null, $msg_type = null, $object_id = null, $object_type = 'post', $status = null, $date_start = null, $date_end = null, $message = null, $storage_type = 'object' ) {
-
+	public static function get_messages( $log_id = null, $msg_type = null, $object_id = null, $object_type = 'post',
+		$status = null, $date_start = null, $date_end = null, $message = null, $storage_type = 'object' ) {
 		$log_entries = array();
 
 		if ( 'object' == $storage_type ) {
 			if ( 'post' == $object_type ) {
 				if ( ! empty( $object_id ) ) {
-					$log_entries[$object_id] = get_post_meta( $object_id, 'syn_log' );
+					$log_entries[ $object_id ] = get_post_meta( $object_id, 'syn_log' );
 				} else {
 					global $wpdb;
 					/**
@@ -410,33 +451,40 @@ class Syndication_Logger {
 					 * This call may return objects larger than 1 MB and is usually only called infrequently
 					 * from the admin dashboard. Implementing a segmented object caching for this result seems
 					 * unnecessary.
+					 *
 					 * @TODO implement walker
 					 */
-					$all_log_entries = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'syn_log' GROUP BY post_id ORDER BY meta_id DESC LIMIT 0, 100" ); // cache pass (see note above)
-					foreach( $all_log_entries as $log_entry ) {
-						$log_entries[$log_entry->post_id] = unserialize( $log_entry->meta_value );
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+					$all_log_entries = $wpdb->get_results(
+						"SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'syn_log' GROUP BY post_id ORDER BY meta_id DESC LIMIT 0, 100"
+					); // cache pass (see note above).
+
+					foreach ( $all_log_entries as $log_entry ) {
+						//@TODO: phpcs - replace unserialize with json_decode
+						$log_entries[ $log_entry->post_id ] = unserialize( $log_entry->meta_value );
 					}
 				}
 			}
 		}
 
 		$filter = array();
-		foreach( array( 'log_id', 'msg_type', 'object_type', 'status', 'date_start', 'date_end', 'message' ) as $filter_key ) {
+		foreach ( array( 'log_id', 'msg_type', 'object_type', 'status', 'date_start', 'date_end', 'message' ) as $filter_key ) {
 			if ( ! empty( ${$filter_key} ) ) {
-				$filter[$filter_key] = ${$filter_key};
+				$filter[ $filter_key ] = ${$filter_key};
 			}
 		}
 		self::instance()->log_filter = $filter;
 
-		foreach( $log_entries as $object_id => $entries ) {
-			$entries = array_filter( $entries, array( self::instance(), 'filter_log_entries' ) );
-			$log_entries[$object_id] = $entries;
+		foreach ( $log_entries as $object_id => $entries ) {
+			$entries                   = array_filter( $entries, array( self::instance(), 'filter_log_entries' ) );
+			$log_entries[ $object_id ] = $entries;
 		}
 		return $log_entries;
 	}
 
 	/**
 	 * Retrieve log_filter variable
+	 *
 	 * @return array Log filter conditions
 	 */
 	public function get_log_filter() {
@@ -445,20 +493,21 @@ class Syndication_Logger {
 
 	/**
 	 * Filter retrieved log entries by log_filter conditions
+	 *
 	 * @uses array_filter()
-	 * @param  array $data Array Element
+	 * @param  array $data Array Element.
 	 * @return boolean     True to keep the entry, false to skip it
 	 */
 	public function filter_log_entries( $data ) {
 		$filter = $this->get_log_filter();
 
-		foreach( $filter as $key => $value ) {
-			switch( $key ) {
+		foreach ( $filter as $key => $value ) {
+			switch ( $key ) {
 				case 'log_id':
 				case 'msg_type':
 				case 'object_type':
 				case 'status':
-					if ( ! isset( $data[$key] ) || $data[$key] <> $value ) {
+					if ( ! isset( $data[ $key ] ) || $data[ $key ] <> $value ) {
 						return false;
 					}
 					break;

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -19,8 +19,8 @@ class Syndication_Site_Failure_Monitor {
 	/**
 	 * Handle the pull failure event. If the number of failures exceeds the maximum attempts set in the options, then disable the site.
 	 *
-	 * @param $site_id
-	 * @param $count
+	 * @param int $site_id The site id.
+	 * @param int $count   The number of attempts.
 	 */
 	public function handle_pull_failure_event( $site_id, $count ) {
 		$site_id = (int) $site_id;
@@ -36,10 +36,20 @@ class Syndication_Site_Failure_Monitor {
 			update_post_meta( $site_id, 'syn_site_enabled', false );
 
 			// Reset the event counter.
+
 			do_action( 'push_syndication_reset_event', 'pull_failure', $site_id );
 
 			// Log what happened.
-			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( __( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ) );
+			Syndication_Logger::log_post_error(
+				$site_id,
+				'error',
+				sprintf(
+					__( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ),
+					(int) $site_id,
+					(int) $count
+				)
+			);
+
 
 			do_action( 'push_syndication_site_disabled', $site_id, $count );
 		}

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -1,63 +1,86 @@
 <?php
 
-include_once(dirname(__FILE__) . '/interface-syndication-client.php');
-include_once( dirname( __FILE__ ) . '/push-syndicate-encryption.php' );
+require_once dirname( __FILE__ ) . '/interface-syndication-client.php';
+require_once dirname( __FILE__ ) . '/push-syndicate-encryption.php';
 
+/**
+ * Class Syndication_WP_REST_Client
+ */
 class Syndication_WP_REST_Client implements Syndication_Client {
 
 	private $access_token;
-	private $blog_ID;
+	private $blog_id;
 
 	private $port;
 	private $useragent;
 	private $timeout;
 
-	function __construct( $site_ID, $port = 80, $timeout = 45 ) {
-
-		$this->access_token = push_syndicate_decrypt( get_post_meta( $site_ID, 'syn_site_token', true) );
-		$this->blog_ID	  = get_post_meta( $site_ID, 'syn_site_id', true);
-		$this->timeout	  = $timeout;
-		$this->useragent	= 'push-syndication-plugin';
-		$this->port		 = $port;
-
+	/**
+	 * Syndication_WP_REST_Client constructor.
+	 *
+	 * @param int	  $site_id
+	 * @param int     $port
+	 * @param int     $timeout
+	 */
+	public function __construct( $site_id, $port = 80, $timeout = 45 ) {
+		$this->access_token = push_syndicate_decrypt( get_post_meta( $site_id, 'syn_site_token', true ) );
+		$this->blog_id      = get_post_meta( $site_id, 'syn_site_id', true );
+		$this->timeout      = $timeout;
+		$this->useragent    = 'push-syndication-plugin';
+		$this->port         = $port;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_client_data() {
-		return array( 'id' => 'WP_REST', 'modes' => array( 'push' ), 'name' => 'WordPress.com REST' );
+		return array(
+			'id'    => 'WP_REST',
+			'modes' => array( 'push' ),
+			'name'  => 'WordPress.com REST',
+		);
 	}
-	
-	public function new_post( $post_ID ) {
 
-		$post = (array)get_post( $post_ID );
+	/**
+	 * @param int $post_id
+	 *
+	 * @return array|bool|WP_Error
+	 */
+	public function new_post( $post_id ) {
+		$post = (array) get_post( $post_id );
 
-		// This filter can be used to exclude or alter posts during a content push
-		$post = apply_filters( 'syn_rest_push_filter_new_post', $post, $post_ID );
-		if ( false === $post )
+		// This filter can be used to exclude or alter posts during a content push.
+		$post = apply_filters( 'syn_rest_push_filter_new_post', $post, $post_id );
+		if ( false === $post ) {
 			return true;
+		}
 
-		$body = array (
-			'title'		 => $post['post_title'],
-			'content'	   => $post['post_content'],
-			'excerpt'	   => $post['post_excerpt'],
-			'status'		=> $post['post_status'],
-			'password'	  => $post['post_password'],
-			'date'		  => $post['post_date_gmt'],
-			'categories'	=> $this->_prepare_terms( wp_get_object_terms( $post_ID, 'category', array('fields' => 'names') ) ),
-			'tags'		  => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'post_tag', array('fields' => 'names') ) )
+		$body = array(
+			'title'      => $post['post_title'],
+			'content'    => $post['post_content'],
+			'excerpt'    => $post['post_excerpt'],
+			'status'     => $post['post_status'],
+			'password'   => $post['post_password'],
+			'date'       => $post['post_date_gmt'],
+			'categories' => $this->prepare_terms( wp_get_object_terms( $post_id, 'category', array( 'fields' => 'names' ) ) ),
+			'tags'       => $this->prepare_terms( wp_get_object_terms( $post_id, 'post_tag', array( 'fields' => 'names' ) ) ),
 		);
 
-		$body = apply_filters( 'syn_rest_push_filter_new_post_body', $body, $post_ID );
+		$body = apply_filters( 'syn_rest_push_filter_new_post_body', $body, $post_id );
 
-		$response = wp_remote_post( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/new/', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-				'Content-Type'  => 'application/x-www-form-urlencoded'
-			),
-			'body' => $body,
-		) );
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_id . '/posts/new/',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+					'Content-Type'  => 'application/x-www-form-urlencoded',
+				),
+				'body'       => $body,
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -65,46 +88,54 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return $response->ID;
 		} else {
 			return new WP_Error( 'rest-push-new-fail', $response->message );
 		}
-
 	}
 
-	public function edit_post( $post_ID, $ext_ID ) {
+	/**
+	 * @param int $post_id
+	 * @param int $ext_id
+	 *
+	 * @return array|bool|int|WP_Error
+	 */
+	public function edit_post( $post_id, $ext_id ) {
+		$post = (array) get_post( $post_id );
 
-		$post = (array)get_post( $post_ID );
-
-		// This filter can be used to exclude or alter posts during a content push
-		$post = apply_filters( 'syn_rest_push_filter_edit_post', $post, $post_ID );
-		if ( false === $post )
+		// This filter can be used to exclude or alter posts during a content push.
+		$post = apply_filters( 'syn_rest_push_filter_edit_post', $post, $post_id );
+		if ( false === $post ) {
 			return true;
+		}
 
-		$body = array (
-			'title'		 => $post['post_title'],
-			'content'	   => $post['post_content'],
-			'excerpt'	   => $post['post_excerpt'],
-			'status'		=> $post['post_status'],
-			'password'	  => $post['post_password'],
-			'date'		  => $post['post_date_gmt'],
-			'categories'	=> $this->_prepare_terms( wp_get_object_terms( $post_ID, 'category', array('fields' => 'names') ) ),
-			'tags'		  => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'post_tag', array('fields' => 'names') ) )
+		$body = array(
+			'title'      => $post['post_title'],
+			'content'    => $post['post_content'],
+			'excerpt'    => $post['post_excerpt'],
+			'status'     => $post['post_status'],
+			'password'   => $post['post_password'],
+			'date'       => $post['post_date_gmt'],
+			'categories' => $this->prepare_terms( wp_get_object_terms( $post_id, 'category', array( 'fields' => 'names' ) ) ),
+			'tags'       => $this->prepare_terms( wp_get_object_terms( $post_id, 'post_tag', array( 'fields' => 'names' ) ) ),
 		);
 
-		$body = apply_filters( 'syn_rest_push_filter_edit_post_body', $body, $post_ID );
+		$body = apply_filters( 'syn_rest_push_filter_edit_post_body', $body, $post_id );
 
-		$response = wp_remote_post( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $ext_ID . '/', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-				'Content-Type'  => 'application/x-www-form-urlencoded'
-			),
-			'body' => $body,
-		) );
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_id . '/posts/' . $ext_id . '/',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+					'Content-Type'  => 'application/x-www-form-urlencoded',
+				),
+				'body'       => $body,
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -112,37 +143,47 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
-			return $post_ID;
+		if ( empty( $response->error ) ) {
+			return $post_id;
 		} else {
 			return new WP_Error( 'rest-push-edit-fail', $response->message );
 		}
-
 	}
 
-	// get an array of values and convert it to CSV
-	function _prepare_terms( $terms ) {
-
+	/**
+	 * Get an array of values and convert it to CSV
+	 *
+	 * @param $terms
+	 *
+	 * @return string
+	 */
+	private function prepare_terms( $terms ) {
 		$terms_csv = '';
 
-		foreach( $terms as $term ) {
+		foreach ( $terms as $term ) {
 			$terms_csv .= $term . ',';
 		}
 
 		return $terms_csv;
-
 	}
 
-	public function delete_post( $ext_ID ) {
-
-		$response = wp_remote_post( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $ext_ID . '/delete', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-			),
-		) );
+	/**
+	 * @param int $ext_id
+	 *
+	 * @return array|bool|WP_Error
+	 */
+	public function delete_post( $ext_id ) {
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_id . '/posts/' . $ext_id . '/delete',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -150,50 +191,61 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return true;
 		} else {
 			return new WP_Error( 'rest-push-delete-fail', $response->message );
 		}
-
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function test_connection() {
 		// @TODo find a better method
-		$response = wp_remote_get( 'https://public-api.wordpress.com/rest/v1/me/?pretty=1', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-			),
-		) );
+		$response = wp_remote_get(
+			'https://public-api.wordpress.com/rest/v1/me/?pretty=1',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			)
+		);
 
-		// TODO: return WP_Error
+		// TODO: return WP_Error.
 		if ( is_wp_error( $response ) ) {
 			return false;
 		}
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return true;
 		} else {
 			return false;
 		}
-
 	}
 
-	public function is_post_exists( $post_ID ) {
-
-		$response = wp_remote_get( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $post_ID . '/?pretty=1', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-			),
-		) );
+	/**
+	 * @param int $post_id
+	 *
+	 * @return bool
+	 */
+	public function is_post_exists( $post_id ) {
+		$response = wp_remote_get( //phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_id . '/posts/' . $post_id . '/?pretty=1',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return false;
@@ -201,19 +253,20 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty($response->error) ) {
+		if ( empty( $response->error ) ) {
 			return true;
 		} else {
 			return false;
 		}
-
 	}
 
+	/**
+	 * @param object $site
+	 */
 	public static function display_settings( $site ) {
-
-		$site_token = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_token', true) );
-		$site_id	= get_post_meta( $site->ID, 'syn_site_id', true);
-		$site_url   = get_post_meta( $site->ID, 'syn_site_url', true);
+		$site_token = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_token', true ) );
+		$site_id    = get_post_meta( $site->ID, 'syn_site_id', true );
+		$site_url   = get_post_meta( $site->ID, 'syn_site_url', true );
 
 		// @TODO refresh UI
 
@@ -221,7 +274,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		<p>
 			<?php echo esc_html__( 'To generate the following information automatically please visit the ', 'push-syndication' ); ?>
-			<a href="<?php echo get_admin_url(); ?>/options-general.php?page=push-syndicate-settings" target="_blank"><?php echo esc_html__( 'settings page', 'push-syndication' ); ?></a>
+			<a href="<?php echo esc_url( get_admin_url() ); ?>/options-general.php?page=push-syndicate-settings" target="_blank"><?php echo esc_html__( 'settings page', 'push-syndication' ); ?></a>
 		</p>
 		<p>
 			<label for=site_token><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>
@@ -247,23 +300,41 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		do_action( 'syn_after_site_form', $site );
 	}
 
-	public static function save_settings( $site_ID ) {
+	/**
+	 * @param int $site_id
+	 *
+	 * @return bool
+	 */
+	public static function save_settings( $site_id ) {
+		// @TODO: nonce validation
 
-		update_post_meta( $site_ID, 'syn_site_token', push_syndicate_encrypt( sanitize_text_field( $_POST['site_token'] ) ) );
-		update_post_meta( $site_ID, 'syn_site_id', sanitize_text_field( $_POST['site_id'] ) );
-		update_post_meta( $site_ID, 'syn_site_url', sanitize_text_field( $_POST['site_url'] ) );
-
+		if ( isset( $_POST['site_token'] ) ) {
+			update_post_meta( $site_id, 'syn_site_token', push_syndicate_encrypt( sanitize_text_field( $_POST['site_token'] ) ) );
+		}
+		if ( isset( $_POST['site_id'] ) ) {
+			update_post_meta( $site_id, 'syn_site_id', sanitize_text_field( $_POST['site_id'] ) );
+		}
+		if ( isset( $_POST['site_url'] ) ) {
+			update_post_meta( $site_id, 'syn_site_url', sanitize_text_field( $_POST['site_url'] ) );
+		}
 		return true;
-
 	}
 
-	public function get_post( $ext_ID )
-	{
+	/**
+	 * @param int $ext_id
+	 *
+	 * @return bool|void
+	 */
+	public function get_post( $ext_id ) {
 		// TODO: Implement get_post() method.
 	}
 
-	public function get_posts( $args = array() )
-	{
+	/**
+	 * @param array $args
+	 *
+	 * @return bool|void
+	 */
+	public function get_posts( $args = array() ) {
 		// TODO: Implement get_posts() method.
 	}
 }

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -1,8 +1,11 @@
 <?php
 
-include_once( ABSPATH . 'wp-includes/class-simplepie.php' );
-include_once( dirname(__FILE__) . '/interface-syndication-client.php' );
+require_once ABSPATH . 'wp-includes/class-simplepie.php';
+require_once dirname( __FILE__ ) . '/interface-syndication-client.php';
 
+/**
+ * Class Syndication_WP_RSS_Client
+ */
 class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client {
 
 	private $default_post_type;
@@ -11,17 +14,19 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 	private $default_ping_status;
 	private $default_cat_status;
 
-	private $site_ID;
+	private $site_id;
 
-	function __construct( $site_ID ) {
-
-		switch( SIMPLEPIE_VERSION ) {
+	/**
+	 * Syndication_WP_RSS_Client constructor.
+	 *
+	 * @param int $site_id
+	 */
+	public function __construct( $site_id ) {
+		switch ( SIMPLEPIE_VERSION ) {
 			case '1.2.1':
-				parent::SimplePie();
+				parent::SimplePie(); // phpcs:ignore
 				break;
 			case '1.3':
-				parent::__construct();
-				break;
 			default:
 				parent::__construct();
 				break;
@@ -29,17 +34,17 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 		parent::__construct();
 
-		$this->site_ID = $site_ID;
+		$this->site_id = $site_id;
 
-		$this->set_feed_url( get_post_meta( $site_ID, 'syn_feed_url', true ) );
-		
+		$this->set_feed_url( get_post_meta( $site_id, 'syn_feed_url', true ) );
+
 		$this->set_cache_class( 'WP_Feed_Cache' );
 
-		$this->default_post_type        = get_post_meta( $site_ID, 'syn_default_post_type', true );
-		$this->default_post_status      = get_post_meta( $site_ID, 'syn_default_post_status', true );
-		$this->default_comment_status   = get_post_meta( $site_ID, 'syn_default_comment_status', true );
-		$this->default_ping_status      = get_post_meta( $site_ID, 'syn_default_ping_status', true );
-		$this->default_cat_status       = get_post_meta( $site_ID, 'syn_default_cat_status', true );
+		$this->default_post_type      = get_post_meta( $site_id, 'syn_default_post_type', true );
+		$this->default_post_status    = get_post_meta( $site_id, 'syn_default_post_status', true );
+		$this->default_comment_status = get_post_meta( $site_id, 'syn_default_comment_status', true );
+		$this->default_ping_status    = get_post_meta( $site_id, 'syn_default_ping_status', true );
+		$this->default_cat_status     = get_post_meta( $site_id, 'syn_default_cat_status', true );
 
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'save_meta' ), 10, 5 );
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'save_tax' ), 10, 5 );
@@ -48,21 +53,25 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 	}
 
 	public static function get_client_data() {
-		return array( 'id' => 'WP_RSS', 'modes' => array( 'pull' ), 'name' => 'RSS' );
+		return array(
+			'id'    => 'WP_RSS',
+			'modes' => array( 'pull' ),
+			'name'  => 'RSS',
+		);
 	}
 
-	public function new_post($post_ID) {
-		// Not supported
+	public function new_post( $post_id ) {
+		// Not supported.
 		return false;
 	}
 
-	public function edit_post($post_ID, $ext_ID) {
-		// Not supported
+	public function edit_post( $post_id, $ext_id ) {
+		// Not supported.
 		return false;
 	}
 
-	public function delete_post($ext_ID) {
-		// Not supported
+	public function delete_post( $ext_id ) {
+		// Not supported.
 		return false;
 	}
 
@@ -71,19 +80,18 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		return true;
 	}
 
-	public function is_post_exists($ext_ID) {
-		// Not supported
+	public function is_post_exists( $ext_id ) {
+		// Not supported.
 		return false;
 	}
 
-	public static function display_settings($site) {
-
-		$feed_url                   = get_post_meta( $site->ID, 'syn_feed_url', true );
-		$default_post_type          = get_post_meta( $site->ID, 'syn_default_post_type', true );
-		$default_post_status        = get_post_meta( $site->ID, 'syn_default_post_status', true );
-		$default_comment_status     = get_post_meta( $site->ID, 'syn_default_comment_status', true );
-		$default_ping_status        = get_post_meta( $site->ID, 'syn_default_ping_status', true );
-		$default_cat_status         = get_post_meta( $site->ID, 'syn_default_cat_status', true );
+	public static function display_settings( $site ) {
+		$feed_url               = get_post_meta( $site->ID, 'syn_feed_url', true );
+		$default_post_type      = get_post_meta( $site->ID, 'syn_default_post_type', true );
+		$default_post_status    = get_post_meta( $site->ID, 'syn_default_post_status', true );
+		$default_comment_status = get_post_meta( $site->ID, 'syn_default_comment_status', true );
+		$default_ping_status    = get_post_meta( $site->ID, 'syn_default_ping_status', true );
+		$default_cat_status     = get_post_meta( $site->ID, 'syn_default_cat_status', true );
 
 		?>
 
@@ -103,8 +111,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 			$post_types = get_post_types();
 
-			foreach( $post_types as $post_type ) {
-				echo '<option value="' . esc_attr( $post_type ) . '"' . selected( $post_type, $default_post_type ) . '>' . esc_html( $post_type )  . '</option>';
+			foreach ( $post_types as $post_type ) {
+				echo '<option value="' . esc_attr( $post_type ) . '"' . selected( $post_type, $default_post_type ) . '>' . esc_html( $post_type ) . '</option>';
 			}
 
 			?>
@@ -119,10 +127,10 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 			<?php
 
-			$post_statuses  = get_post_statuses();
+			$post_statuses = get_post_statuses();
 
-			foreach( $post_statuses as $key => $value ) {
-				echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $default_post_status ) . '>' . esc_html( $key )  . '</option>';
+			foreach ( $post_statuses as $key => $value ) {
+				echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $default_post_status ) . '>' . esc_html( $key ) . '</option>';
 			}
 
 			?>
@@ -134,8 +142,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_comment_status" id="default_comment_status" />
-				<option value="open" <?php selected( 'open', $default_comment_status )  ?> >open</option>
-				<option value="closed" <?php selected( 'closed', $default_comment_status )  ?> >closed</option>
+				<option value="open" <?php selected( 'open', $default_comment_status ); ?> >open</option>
+				<option value="closed" <?php selected( 'closed', $default_comment_status ); ?> >closed</option>
 			</select>
 		</p>
 		<p>
@@ -143,8 +151,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_ping_status" id="default_ping_status" />
-			<option value="open" <?php selected( 'open', $default_ping_status )  ?> >open</option>
-			<option value="closed" <?php selected( 'closed', $default_ping_status )  ?> >closed</option>
+			<option value="open" <?php selected( 'open', $default_ping_status ); ?> >open</option>
+			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?> >closed</option>
 			</select>
 		</p>
 		<p>
@@ -152,8 +160,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_cat_status" id="default_cat_status" />
-			<option value="yes" <?php selected( 'yes', $default_cat_status )  ?> ><?php echo esc_html__( 'import categories', 'push-syndication' ); ?></option>
-			<option value="no" <?php selected( 'no', $default_cat_status )  ?> ><?php echo esc_html__( 'ignore categories', 'push-syndication' ); ?></option>
+			<option value="yes" <?php selected( 'yes', $default_cat_status ); ?> ><?php echo esc_html__( 'import categories', 'push-syndication' ); ?></option>
+			<option value="no" <?php selected( 'no', $default_cat_status ); ?> ><?php echo esc_html__( 'ignore categories', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 
@@ -162,84 +170,99 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		do_action( 'syn_after_site_form', $site );
 	}
 
-	public static function save_settings( $site_ID ) {
-
-		update_post_meta( $site_ID, 'syn_feed_url', esc_url_raw( $_POST['feed_url'] ) );
-		update_post_meta( $site_ID, 'syn_default_post_type', sanitize_text_field( $_POST['default_post_type'] ) );
-		update_post_meta( $site_ID, 'syn_default_post_status', sanitize_text_field( $_POST['default_post_status'] ) );
-		update_post_meta( $site_ID, 'syn_default_comment_status', sanitize_text_field($_POST['default_comment_status'] ) );
-		update_post_meta( $site_ID, 'syn_default_ping_status', sanitize_text_field( $_POST['default_ping_status'] ) );
-		update_post_meta( $site_ID, 'syn_default_cat_status', sanitize_text_field( $_POST['default_cat_status'] ) );
+	public static function save_settings( $site_id ) {
+		// @TODO: add nonces
+		update_post_meta( $site_id, 'syn_feed_url', esc_url_raw( isset( $_POST['feed_url'] ) ? $_POST['feed_url'] : '' ) );
+		update_post_meta( $site_id, 'syn_default_post_type', sanitize_text_field( isset( $_POST['default_post_type'] ) ? $_POST['default_post_type'] : '' ) );
+		update_post_meta( $site_id, 'syn_default_post_status', sanitize_text_field( isset( $_POST['default_post_status'] ) ? $_POST['default_post_status'] : '' ) );
+		update_post_meta( $site_id, 'syn_default_comment_status', sanitize_text_field( isset( $_POST['default_comment_status'] ) ? $_POST['default_comment_status'] : '' ) );
+		update_post_meta( $site_id, 'syn_default_ping_status', sanitize_text_field( isset( $_POST['default_ping_status'] ) ? $_POST['default_ping_status'] : '' ) );
+		update_post_meta( $site_id, 'syn_default_cat_status', sanitize_text_field( isset( $_POST['default_cat_status'] ) ? $_POST['default_ping_status'] : '' ) );
 		return true;
-
 	}
 
-	public function get_post( $ext_ID ) {
+	public function get_post( $ext_id ) {
 		// TODO: Implement get_post() method.
 	}
 
 	public function get_posts( $args = array() ) {
-
-		$site_post = get_post( $this->site_ID );
+		$site_post = get_post( $this->site_id );
 
 		$rss_init = $this->init();
 
 		if ( false === $rss_init ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = isset( $site_post->postmeta['is_update'] ) ? $site_post->postmeta['is_update'] : null, $extra = array( 'error' => $this->error() ) );
+			Syndication_Logger::log_post_error(
+				$this->site_id,
+				$status   = 'error',
+				$message  = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ),
+				$log_time = isset( $site_post->postmeta['is_update'] ) ? $site_post->postmeta['is_update'] : null,
+				$extra    = array( 'error' => $this->error() )
+			);
 
 			// Track the event.
-			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_failure', $this->site_id );
 		} else {
-			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $this->get_raw_data() ) ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_info(
+				$this->site_id,
+				$status   = 'fetch_feed',
+				$message  = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $this->get_raw_data() ) ),
+				$log_time = null,
+				$extra    = array()
+			);
 
 			// Track the event.
-			do_action( 'push_syndication_event', 'pull_success', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_success', $this->site_id );
 		}
 
 		$this->handle_content_type();
 
-		// hold all the posts
-		$posts = array();
-		$taxonomy = array( 'cats' => array(), 'tags' => array() );
+		// hold all the posts.
+		$posts    = array();
+		$taxonomy = array(
+			'cats' => array(),
+			'tags' => array(),
+		);
 
-		foreach( $this->get_items() as $item ) {
+		foreach ( $this->get_items() as $item ) {
 			if ( 'yes' == $this->default_cat_status ) {
 				$taxonomy = $this->set_taxonomy( $item );
 			}
 
 			$post = array(
-				'post_title'        => $item->get_title(),
-				'post_content'      => $item->get_content(),
-				'post_excerpt'      => $item->get_description(),
-				'post_type'         => $this->default_post_type,
-				'post_status'       => $this->default_post_status,
-				'post_date'         => date( 'Y-m-d H:i:s', strtotime( $item->get_date() ) ),
-				'comment_status'    => $this->default_comment_status,
-				'ping_status'       => $this->default_ping_status,
-				'post_guid'         => $item->get_id(),
-				'post_category'     => $taxonomy['cats'],
-				'tags_input'        => $taxonomy['tags']
+				'post_title'     => $item->get_title(),
+				'post_content'   => $item->get_content(),
+				'post_excerpt'   => $item->get_description(),
+				'post_type'      => $this->default_post_type,
+				'post_status'    => $this->default_post_status,
+				'post_date'      => gmdate( 'Y-m-d H:i:s', strtotime( $item->get_date() ) ),
+				'comment_status' => $this->default_comment_status,
+				'ping_status'    => $this->default_ping_status,
+				'post_guid'      => $item->get_id(),
+				'post_category'  => $taxonomy['cats'],
+				'tags_input'     => $taxonomy['tags'],
 			);
-			// This filter can be used to exclude or alter posts during a pull import
+			// This filter can be used to exclude or alter posts during a pull import.
 			$post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item );
-			if ( false === $post )
+
+			if ( false === $post ) {
 				continue;
+			}
+
 			$posts[] = $post;
 		}
 
 		return $posts;
-
 	}
 
 	public function set_taxonomy( $item ) {
 		$cats = $item->get_categories();
-		$ids = array(
-			'cats'    => array(),
-			'tags'            => array()
+		$ids  = array(
+			'cats' => array(),
+			'tags' => array(),
 		);
 
 		foreach ( $cats as $cat ) {
-			// checks if term exists
+			// checks if term exists.
 			if ( $result = get_term_by( 'name', $cat->term, 'category' ) ) {
 				if ( isset( $result->term_id ) ) {
 					$ids['cats'][] = $result->term_id;
@@ -249,7 +272,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 					$ids['tags'][] = $result->term_id;
 				}
 			} else {
-				// creates if not
+				// creates if not.
 				$result = wp_insert_term( $cat->term, 'category' );
 				if ( isset( $result->term_id ) ) {
 					$ids['cats'][] = $result->term_id;
@@ -257,7 +280,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			}
 		}
 
-		// returns array ready for post creation
+		// returns array ready for post creation.
 		return $ids;
 	}
 
@@ -266,28 +289,28 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			return false;
 		}
 		$categories = $post['post_category'];
-		wp_set_post_terms($result, $categories, 'category', true);
+		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		//handle enclosures separately first
-		$enc_field = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
+		// handle enclosures separately first.
+		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
-		if ( isset( $enclosures ) && isset ( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates) if any
-			delete_post_meta( $result, $enc_field);
-			foreach( $enclosures as $enclosure ) {
-				if (defined('ENCLOSURES_AS_STRINGS') && constant('ENCLOSURES_AS_STRINGS')) {
-					$enclosure = implode("\n", $enclosure);
+		if ( isset( $enclosures ) && isset( $enc_field ) ) {
+			// first remove all enclosures for the post (for updates) if any.
+			delete_post_meta( $result, $enc_field );
+			foreach ( $enclosures as $enclosure ) {
+				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
+					$enclosure = implode( "\n", $enclosure );
 				}
-				add_post_meta($result, $enc_field, $enclosure, false);
+				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
-			unset($metas['enclosures']);
+			// now remove them from the rest of the metadata before saving the rest.
+			unset( $metas['enclosures'] );
 		}
 
-		foreach ($metas as $meta_key => $meta_value) {
-			add_post_meta($result, $meta_key, $meta_value, true);
+		foreach ( $metas as $meta_key => $meta_value ) {
+			add_post_meta( $result, $meta_key, $meta_value, true );
 		}
 	}
 
@@ -296,28 +319,28 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			return false;
 		}
 		$categories = $post['post_category'];
-		wp_set_post_terms($result, $categories, 'category', true);
+		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		// handle enclosures separately first
-		$enc_field = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
+		// handle enclosures separately first.
+		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates)
-			delete_post_meta( $result, $enc_field);
-			foreach( $enclosures as $enclosure ) {
-				if (defined('ENCLOSURES_AS_STRINGS') && constant('ENCLOSURES_AS_STRINGS')) {
-					$enclosure = implode("\n", $enclosure);
+			// first remove all enclosures for the post (for updates).
+			delete_post_meta( $result, $enc_field );
+			foreach ( $enclosures as $enclosure ) {
+				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
+					$enclosure = implode( "\n", $enclosure );
 				}
-				add_post_meta($result, $enc_field, $enclosure, false);
+				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
-			unset($metas['enclosures']);
+			// now remove them from the rest of the metadata before saving the rest.
+			unset( $metas['enclosures'] );
 		}
 
-		foreach ($metas as $meta_key => $meta_value) {
-			update_post_meta($result, $meta_key, $meta_value);
+		foreach ( $metas as $meta_key => $meta_value ) {
+			update_post_meta( $result, $meta_key, $meta_value );
 		}
 	}
 
@@ -327,11 +350,11 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		}
 		$taxonomies = $post['tax'];
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			// post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
-			wp_set_object_terms($result, (string)$tax_value, $tax_name, true);
+			wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 		}
 	}
 
@@ -339,20 +362,20 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {
 			return false;
 		}
-		$taxonomies = $post['tax'];
+		$taxonomies       = $post['tax'];
 		$replace_tax_list = array();
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			//post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
-			if ( !in_array($tax_name, $replace_tax_list ) ) {
-				//if we haven't processed this taxonomy before, replace any terms on the post with the first new one
-				wp_set_object_terms($result, (string)$tax_value, $tax_name );
+			if ( ! in_array( $tax_name, $replace_tax_list ) ) {
+				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one.
+				wp_set_object_terms( $result, (string) $tax_value, $tax_name );
 				$replace_tax_list[] = $tax_name;
 			} else {
-				//if we've already added one term for this taxonomy, append any others
-				wp_set_object_terms($result, (string)$tax_value, $tax_name, true);
+				// if we've already added one term for this taxonomy, append any others.
+				wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 			}
 		}
 	}

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -17,12 +17,12 @@
 /**
  * Load the {@see Walker_CategoryDropdownMultiple}
  */
-include_once( dirname( __FILE__ ) . '/class-walker-category-dropdown-multiple.php' );
+require_once dirname( __FILE__ ) . '/class-walker-category-dropdown-multiple.php';
 
 /**
  * Load the {@see Syndication_Client} interface.
  */
-include_once( dirname( __FILE__ ) . '/interface-syndication-client.php' );
+require_once dirname( __FILE__ ) . '/interface-syndication-client.php';
 
 /**
  * Class Syndication_WP_XML_Client
@@ -32,7 +32,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * @var int
 	 */
-	private $site_ID;
+	private $site_id;
 
 	/**
 	 * @var string
@@ -87,20 +87,20 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Class constructor.
 	 *
-	 * @param int $site_ID The ID of the site to pull feeds from.
+	 * @param int $site_id The ID of the site to pull feeds from.
 	 */
-	function __construct( $site_ID ) {
-		$this->site_ID = $site_ID;
-		$this->set_feed_url( get_post_meta( $site_ID, 'syn_feed_url', true ) );
+	function __construct( $site_id ) {
+		$this->site_id = $site_id;
+		$this->set_feed_url( get_post_meta( $site_id, 'syn_feed_url', true ) );
 
-		$this->default_post_type      = get_post_meta( $site_ID, 'syn_default_post_type', true );
-		$this->default_post_status    = get_post_meta( $site_ID, 'syn_default_post_status', true );
-		$this->default_comment_status = get_post_meta( $site_ID, 'syn_default_comment_status', true );
-		$this->default_ping_status    = get_post_meta( $site_ID, 'syn_default_ping_status', true );
-		$this->nodes_to_post          = get_post_meta( $site_ID, 'syn_node_config', false );
-		$this->id_field               = get_post_meta( $site_ID, 'syn_id_field', true );
-		$this->enc_field              = get_post_meta( $site_ID, 'syn_enc_field', true );
-		$this->enc_is_photo           = get_post_meta( $site_ID, 'syn_enc_is_photo', true );
+		$this->default_post_type      = get_post_meta( $site_id, 'syn_default_post_type', true );
+		$this->default_post_status    = get_post_meta( $site_id, 'syn_default_post_status', true );
+		$this->default_comment_status = get_post_meta( $site_id, 'syn_default_comment_status', true );
+		$this->default_ping_status    = get_post_meta( $site_id, 'syn_default_ping_status', true );
+		$this->nodes_to_post          = get_post_meta( $site_id, 'syn_node_config', false );
+		$this->id_field               = get_post_meta( $site_id, 'syn_id_field', true );
+		$this->enc_field              = get_post_meta( $site_id, 'syn_enc_field', true );
+		$this->enc_is_photo           = get_post_meta( $site_id, 'syn_enc_is_photo', true );
 
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'save_meta' ), 10, 5 );
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'save_tax' ), 10, 5 );
@@ -115,13 +115,12 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @param string $url The URL of the feed to pull.
 	 */
 	private function set_feed_url( $url ) {
-
 		$url = apply_filters( 'syn_feed_url', $url );
 
-		if ( parse_url( $url ) ) {
+		if ( wp_parse_url( $url ) ) {
 			$this->feed_url = $url;
 		} else {
-			$this->error_message = sprintf( __( 'Feed URL not set for this feed: %s', 'push-syndication' ), $this->site_ID );
+			$this->error_message = sprintf( __( 'Feed URL not set for this feed: %s', 'push-syndication' ), $this->site_id );
 		}
 	}
 
@@ -131,62 +130,70 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return array
 	 */
 	public static function get_client_data() {
-		return array( 'id' => 'WP_XML', 'modes' => array( 'pull' ), 'name' => 'XML' );
+		return array(
+			'id'    => 'WP_XML',
+			'modes' => array( 'pull' ),
+			'name'  => 'XML',
+		);
 	}
 
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $post_ID
+	 * @param int $post_id
+	 *
 	 * @return bool
 	 */
-	public function new_post( $post_ID ) {
-		return false; // Not supported
+	public function new_post( $post_id ) {
+		return false; // Not supported.
 	}
 
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $post_ID
-	 * @param int $ext_ID
+	 * @param int $post_id
+	 * @param int $ext_id
+	 *
 	 * @return bool
 	 */
-	public function edit_post( $post_ID, $ext_ID ) {
-		return false; // Not supported
+	public function edit_post( $post_id, $ext_id ) {
+		return false; // Not supported.
 	}
 
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $ext_ID
+	 * @param int $ext_id
+	 *
 	 * @return bool
 	 */
-	public function delete_post( $ext_ID ) {
-		return false; // Not supported
+	public function delete_post( $ext_id ) {
+		return false; // Not supported.
 	}
 
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $ext_ID
+	 * @param int $ext_id
+	 *
 	 * @return bool
 	 */
-	public function get_post( $ext_ID ) {
-		return false; // Not supported
+	public function get_post( $ext_id ) {
+		return false; // Not supported.
 	}
 
 	/**
 	 * Retrieves a list of posts from a remote site.
 	 *
 	 * @param   array $args Arguments when retrieving posts.
-	 * @return  boolean true on success false on failure.
+	 * @return  array true on success false on failure.
 	 */
 	public function get_posts( $args = array() ) {
 		// create $post with values from $this::node_to_post
-		// create $post_meta with values from $this::node_to_meta
+		// create $post_meta with values from $this::node_to_meta.
 
-		//TODO: required fields for post
-		//TODO: handle categories
+		// TODO: required fields for post
+		// TODO: handle categories.
 
 		$abs_nodes       = array();
 		$item_nodes      = array();
@@ -215,16 +222,16 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$enclosures_as_strings = isset( $nodes['enclosures_as_strings'] ) ? true : false;
 		unset( $nodes['enclosures_as_strings'] );
 
-		//TODO: add checkbox on feed config to allow enclosures to be saved as strings as SI does
-		//TODO: add tags here and in feed set up UI
+		// TODO: add checkbox on feed config to allow enclosures to be saved as strings as SI does
+		// TODO: add tags here and in feed set up UI.
 		foreach ( $nodes['nodes'] as $key => $storage_locations ) {
 			foreach ( $storage_locations as $storage_location ) {
 				$storage_location['xpath'] = $key;
 				if ( $storage_location['is_item'] ) {
 					$item_nodes[] = $storage_location;
-				} else if ( $storage_location['is_photo'] ) {
+				} elseif ( $storage_location['is_photo'] ) {
 					$enc_nodes[] = $storage_location;
-				} else if ( $storage_location['is_tax'] && $storage_location['is_item'] ) {
+				} elseif ( $storage_location['is_tax'] && $storage_location['is_item'] ) {
 					$tax_nodes[] = $storage_location;
 				} else {
 					$abs_nodes[] = $storage_location;
@@ -235,37 +242,55 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$feed = $this->fetch_feed();
 
 		// Catch attempts to pull content from a file which doesn't exist.
-		// TODO: kill feed client if too many failures
-		$site_post = get_post( $this->site_ID );
+		// TODO: kill feed client if too many failures.
+		$site_post = get_post( $this->site_id );
 		if ( is_wp_error( $feed ) ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Could not reach feed at: %s | Error: %s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_error(
+				$this->site_id,
+				'error',
+				sprintf( __( 'Could not reach feed at: %1$s | Error: %2$s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ),
+				null,
+				array()
+			);
 
 			// Track the event.
-			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_failure', $this->site_id );
 
 			return array();
 		} else {
-			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $feed ) ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_info(
+				$this->site_id,
+				'fetch_feed',
+				sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $feed ) ),
+				null,
+				array()
+			);
 
 			// Track the event.
-			do_action( 'push_syndication_event', 'pull_success', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_success', $this->site_id );
 		}
 
 		/** @var SimpleXMLElement $xml */
 		$xml = simplexml_load_string( $feed, null, 0, $namespace, false );
 
 		if ( false === $xml ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
+			Syndication_Logger::log_post_error(
+				$this->site_id,
+				'error',
+				sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ),
+				$site_post->postmeta['is_update'],
+				array()
+			);
 
 			// Track the event.
-			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
+			do_action( 'push_syndication_event', 'pull_failure', $this->site_id );
 
 			return array();
 		}
 
 		$abs_post_fields['enclosures_as_strings'] = $enclosures_as_strings;
 
-		// TODO: handle constant strings in XML
+		// TODO: handle constant strings in XML.
 		foreach ( $abs_nodes as $abs_node ) {
 			$value_array = array();
 			try {
@@ -277,15 +302,14 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 				if ( $abs_node['is_meta'] ) {
 					$abs_meta_data[ $abs_node['field'] ] = (string) $value_array[0];
-				} else if ( $abs_node['is_tax'] ) {
+				} elseif ( $abs_node['is_tax'] ) {
 					$abs_tax_data[ $abs_node['field'] ] = (string) $value_array[0];
 				} else {
 					$abs_post_fields[ $abs_node['field'] ] = (string) $value_array[0];
 				}
-			}
-			catch ( Exception $e ) {
-				//TODO: catch value not found here and alert for error
-				//TODO: catch multiple values returned here and alert for error
+			} catch ( Exception $e ) {
+				// TODO: catch value not found here and alert for error
+				// TODO: catch multiple values returned here and alert for error.
 				return array();
 			}
 		}
@@ -294,10 +318,22 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$items         = $xml->xpath( $post_root );
 
 		if ( empty( $items ) ) {
-			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = printf( __( 'No post nodes found using XPath "%s" in feed', 'push-syndication' ), $post_root ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
+			Syndication_Logger::log_post_error(
+				$this->site_id,
+				'error',
+				sprintf( __( 'No post nodes found using XPath "%s" in feed', 'push-syndication' ), $post_root ),
+				$site_post->postmeta['is_update'],
+				array()
+			);
 			return array();
 		} else {
-			Syndication_Logger::log_post_info( $this->site_ID, $status = 'simplexml_load_string', $message = sprintf( __( 'parsed feed, received %d items', 'push-syndication' ), count( $items ) ), $log_time = null, $extra = array() );
+			Syndication_Logger::log_post_info(
+				$this->site_id,
+				'simplexml_load_string',
+				sprintf( __( 'parsed feed, received %d items', 'push-syndication' ), count( $items ) ),
+				null,
+				array()
+			);
 		}
 
 		foreach ( $items as $item ) {
@@ -310,7 +346,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			$item_fields['post_type'] = $this->default_post_type;
 
-			//save photos as enclosures in meta
+			// save photos as enclosures in meta.
 			if ( ( isset( $enc_parent ) && strlen( $enc_parent ) ) && ! empty( $enc_nodes ) ) {
 				$meta_data['enclosures'] = $this->get_encs( $item->xpath( $enc_parent ), $enc_nodes );
 			}
@@ -323,27 +359,26 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 						$value_array = $item->xpath( stripslashes( $save_location['xpath'] ) );
 					}
 					if ( isset( $save_location['is_meta'] ) && $save_location['is_meta'] ) {
-						//SimpleXMLElement::xpath returns either an array or false if an element isn't returned
-						//checking $value_array first avoids the warning we get if the field isn't found
+						// SimpleXMLElement::xpath returns either an array or false if an element isn't returned
+						// checking $value_array first avoids the warning we get if the field isn't found.
 						if ( $value_array && ( count( $value_array ) > 1 ) ) {
-							$value_array = array_map( 'strval', $value_array );
+							$value_array                          = array_map( 'strval', $value_array );
 							$meta_data[ $save_location['field'] ] = $value_array;
-						} else if ( $value_array ) {
-							//return a string if $value_array contains only a single element
+						} elseif ( $value_array ) {
+							// return a string if $value_array contains only a single element.
 							$meta_data[ $save_location['field'] ] = (string) $value_array[0];
 						}
-					} else if ( isset( $save_location['is_tax'] ) && $save_location['is_tax'] ) {
-						//for some taxonomies, multiple values may be supplied in the field
+					} elseif ( isset( $save_location['is_tax'] ) && $save_location['is_tax'] ) {
+						// for some taxonomies, multiple values may be supplied in the field.
 						foreach ( $value_array as $value ) {
 							$tax_data[ $save_location['field'] ] = (string) $value;
 						}
 					} else {
 						$item_fields[ $save_location['field'] ] = (string) $value_array[0];
 					}
-				}
-				catch ( Exception $e ) {
+				} catch ( Exception $e ) {
 					// TODO: catch value not found here and alert for error
-					// TODO: catch multiple values returned here and alert for error
+					// TODO: catch multiple values returned here and alert for error.
 					return array();
 				}
 			}
@@ -375,10 +410,15 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			$post_position++;
 		}
 
-		Syndication_Logger::log_post_info( $this->site_ID, $status = 'posts_received', $message = sprintf( __( '%d posts were prepared', 'push-syndication' ), count( $posts ) ), $log_time = null, $extra = array() );
+		Syndication_Logger::log_post_info(
+			$this->site_id,
+			'posts_received',
+			sprintf( __( '%d posts were prepared', 'push-syndication' ), count( $posts ) ),
+			null,
+			array()
+		);
 
 		return $posts;
-
 	}
 
 	/**
@@ -415,13 +455,12 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 						$enc_value = $enc->xpath( stripslashes( $post_value['xpath'] ) );
 					}
 					$enc_array[ $post_value['field'] ] = esc_attr( (string) $enc_value[0] );
-				}
-				catch ( Exception $e ) {
-					//TODO: catch value not found here and alert for error or not
+				} catch ( Exception $e ) {
+					// TODO: catch value not found here and alert for error or not.
 					return true;
 				}
 			}
-			// if position is not provided in the feed, use the order in which they appear in the feed
+			// if position is not provided in the feed, use the order in which they appear in the feed.
 			if ( empty( $enc_array['position'] ) ) {
 				$enc_array['position'] = $count;
 			}
@@ -443,11 +482,12 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $ext_ID External post ID to check.
+	 * @param int $ext_id External post ID to check.
+	 *
 	 * @return bool
 	 */
-	public function is_post_exists( $ext_ID ) {
-		return false; // Not supported
+	public function is_post_exists( $ext_id ) {
+		return false; // Not supported.
 	}
 
 	/**
@@ -456,24 +496,24 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @param   object $site The site object to display settings.
 	 */
 	public static function display_settings( $site ) {
-		//TODO: JS if is_meta show text box, if is_photo show photo select with numbers as values, else show select of post fields
-		//TODO: JS Validation
-		//TODO: deal with ability to select, i.e. media:group/media:thumbnail[@width="75"]/@url (can't be unserialized as is with quotes around 75)
-		$feed_url					= get_post_meta( $site->ID, 'syn_feed_url', true );
-		$default_post_type			= get_post_meta( $site->ID, 'syn_default_post_type', true );
-		$default_post_status		= get_post_meta( $site->ID, 'syn_default_post_status', true );
-		$default_comment_status		= get_post_meta( $site->ID, 'syn_default_comment_status', true );
-		$default_ping_status		= get_post_meta( $site->ID, 'syn_default_ping_status', true );
-		$node_config				= get_post_meta( $site->ID, 'syn_node_config', true );
-		$id_field					= get_post_meta( $site->ID, 'syn_id_field', true );
-		$enc_field					= get_post_meta( $site->ID, 'syn_enc_field', true );
-		$enc_is_photo				= get_post_meta( $site->ID, 'syn_enc_is_photo', true);
+		// TODO: JS if is_meta show text box, if is_photo show photo select with numbers as values, else show select of post fields
+		// TODO: JS Validation
+		// TODO: deal with ability to select, i.e. media:group/media:thumbnail[@width="75"]/@url (can't be unserialized as is with quotes around 75).
+		$feed_url               = get_post_meta( $site->ID, 'syn_feed_url', true );
+		$default_post_type      = get_post_meta( $site->ID, 'syn_default_post_type', true );
+		$default_post_status    = get_post_meta( $site->ID, 'syn_default_post_status', true );
+		$default_comment_status = get_post_meta( $site->ID, 'syn_default_comment_status', true );
+		$default_ping_status    = get_post_meta( $site->ID, 'syn_default_ping_status', true );
+		$node_config            = get_post_meta( $site->ID, 'syn_node_config', true );
+		$id_field               = get_post_meta( $site->ID, 'syn_id_field', true );
+		$enc_field              = get_post_meta( $site->ID, 'syn_enc_field', true );
+		$enc_is_photo           = get_post_meta( $site->ID, 'syn_enc_is_photo', true );
 
-		if ( isset( $node_config['namespace'] )) {
+		if ( isset( $node_config['namespace'] ) ) {
 			$namespace = $node_config['namespace'];
 		}
 
-		//unset is outside of isset() test to remove the item from the array if the key is there with no value
+		// unset is outside of isset() test to remove the item from the array if the key is there with no value.
 		$namespace = isset( $node_config['namespace'] ) ? $node_config['namespace'] : null;
 		unset( $node_config['namespace'] );
 
@@ -492,7 +532,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<label for="feed_url"><?php esc_html_e( 'Enter feed URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="feed_url" id="feed_url" size="100" value="<?php esc_attr_e( $feed_url ); ?>" />
+			<input type="text" name="feed_url" id="feed_url" size="100" value="<?php echo esc_url_raw( $feed_url ); ?>" />
 		</p>
 		<p>
 			<label for="default_post_type"><?php esc_html_e( 'Select post type', 'push-syndication' ); ?></label>
@@ -504,7 +544,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			foreach ( $post_types as $post_type ) {
 				?>
-				<option value="<?php esc_attr_e( $post_type ); ?>" <?php selected( $post_type, $default_post_type ); ?>><?php esc_html_e( $post_type ); ?></option>
+				<option value="<?php echo esc_attr( $post_type ); ?>" <?php selected( $post_type, $default_post_type ); ?>><?php echo esc_html( $post_type ); ?></option>
 			<?php } ?>
 			</select>
 		</p>
@@ -518,7 +558,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			foreach ( $post_statuses as $key => $value ) {
 				?>
-				<option value="<?php esc_attr_e( $key ); ?>" <?php selected( $key, $default_post_status ); ?>><?php esc_html_e( $key ); ?></option>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $default_post_status ); ?>><?php echo esc_html( $key ); ?></option>
 			<?php } ?>
 			</select>
 		</p>
@@ -527,8 +567,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		</p>
 		<p>
 			<select name="default_comment_status" id="default_comment_status">
-			<option value="open" <?php selected( 'open', $default_comment_status ); ?>><?php _e( 'open', 'push-syndication' ); ?></option>
-			<option value="closed" <?php selected( 'closed', $default_comment_status ); ?>><?php _e( 'closed', 'push-syndication' ); ?></option>
+			<option value="open" <?php selected( 'open', $default_comment_status ); ?>><?php esc_html_e( 'open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_comment_status ); ?>><?php esc_html_e( 'closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 		<p>
@@ -536,8 +576,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		</p>
 		<p>
 			<select name="default_ping_status" id="default_ping_status">
-			<option value="open" <?php selected( 'open', $default_ping_status ); ?>><?php _e( 'open', 'push-syndication' ); ?></option>
-			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?>><?php _e( 'closed', 'push-syndication' ); ?></option>
+			<option value="open" <?php selected( 'open', $default_ping_status ); ?>><?php esc_html_e( 'open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?>><?php esc_html_e( 'closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 
@@ -545,35 +585,35 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<label for="namespace"><?php esc_html_e( 'Enter XML namespace', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" size="75" name="namespace" id="namespace" value="<?php esc_attr_e( $namespace ); ?>" />
+			<input type="text" size="75" name="namespace" id="namespace" value="<?php echo esc_attr( $namespace ); ?>" />
 		</p>
 
 		<p>
 			<label for="post_root"><?php esc_html_e( 'Enter XPath to post root', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="post_root" id="post_root" value="<?php esc_attr_e( $post_root ); ?>" />
+			<input type="text" name="post_root" id="post_root" value="<?php echo esc_attr( $post_root ); ?>" />
 		</p>
 
 		<p>
 			<label for="id_field"><?php esc_html_e( 'Enter post meta key for unique post identifier', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="id_field" id="id_field" value="<?php esc_attr_e( $id_field ); ?>" />
+			<input type="text" name="id_field" id="id_field" value="<?php echo esc_attr( $id_field ); ?>" />
 		</p>
 
 		<p>
 			<label for="enc_parent"><?php esc_html_e( 'Enter parent element for enclosures', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="enc_parent" id="enc_parent" value="<?php esc_attr_e( $enc_parent ); ?>" />
+			<input type="text" name="enc_parent" id="enc_parent" value="<?php echo esc_attr( $enc_parent ); ?>" />
 		</p>
 
 		<p>
 			<label for="enc_field"><?php esc_html_e( 'Enter meta name for enclosures', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="enc_field" id="enc_field" value="<?php esc_attr_e( $enc_field ); ?>" />
+			<input type="text" name="enc_field" id="enc_field" value="<?php echo esc_attr( $enc_field ); ?>" />
 		</p>
 
 		<p>
@@ -590,20 +630,34 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		<p>
 			<?php
 				add_filter( 'wp_dropdown_cats', array( __CLASS__, 'make_multiple_categories_dropdown' ) );
-				wp_dropdown_categories( array(
-						'hide_empty' => false,
-						'hierarchical' => true,
+				wp_dropdown_categories(
+					array(
+						'hide_empty'     => false,
+						'hierarchical'   => true,
 						'selected_array' => $categories,
-						'walker' => new Walker_CategoryDropdownMultiple,
-						'name' => 'categories[]'
-				) );
+						'walker'         => new Walker_CategoryDropdownMultiple(),
+						'name'           => 'categories[]',
+					)
+				);
 				remove_filter( 'wp_dropdown_cats', array( __CLASS__, 'make_multiple_categories_dropdown' ) );
 			?>
 		</p>
 
 		<h2><?php _e( 'XPath-to-Data Mapping', 'push-syndication' ); ?></h2>
 
-		<p><?php printf( __( '<strong>PLEASE NOTE:</strong> %s are required. If you want a link to another site, %s is required. To include a static string, enclose the string as "%s(your_string_here)" &mdash; no quotes.', 'push-syndication' ), 'post_title, post_guid, guid', 'is_permalink', 'string' ); ?></p>
+		<p>
+		<?php
+		printf(
+			wp_kses(
+				__( '<strong>PLEASE NOTE:</strong> %1$s are required. If you want a link to another site, %2$s is required. To include a static string, enclose the string as "%3$s(your_string_here)" &mdash; no quotes.', 'push-syndication' ),
+				array( 'strong' => array() )
+			),
+			'post_title, post_guid, guid',
+			'is_permalink',
+			'string'
+		);
+		?>
+				</p>
 
 		<ul class='syn-xml-client-xpath-head syn-xml-client-list-head'>
 			<li class="text">
@@ -630,7 +684,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$rowcount = 0;
 		if ( ! empty( $custom_nodes ) ) :
 			foreach ( $custom_nodes as $key => $storage_locations ) :
-				foreach ( $storage_locations as $storage_location ) : ?>
+				foreach ( $storage_locations as $storage_location ) :
+					?>
 					<ul class='syn-xml-client-xpath-form syn-xml-client-xpath-list syn-xml-client-list' data-row-count="<?php echo (int) $rowcount; ?>">
 					<li class="text">
 						<input type="text" name="node[<?php echo (int) $rowcount; ?>][xpath]" id="node-<?php echo (int) $rowcount; ?>-xpath" value="<?php echo htmlspecialchars( stripslashes( $key ) ); ?>" />
@@ -695,16 +750,16 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 					e.preventDefault();
 
 					var $lastForm = $( '.syn-xml-client-xpath-form:last' ),
-					    $newForm = $lastForm.clone(),
-					    originalRowCount = parseInt( $lastForm.attr( 'data-row-count' ) ),
-					    newRowCount = originalRowCount + 1;
+						$newForm = $lastForm.clone(),
+						originalRowCount = parseInt( $lastForm.attr( 'data-row-count' ) ),
+						newRowCount = originalRowCount + 1;
 
 					$newForm.attr( 'data-row-count', newRowCount );
 
 					$newForm.find( 'input' ).each( function () {
 						var $this = $( this ),
-						    name = $this.attr( 'name' ),
-						    type = $this.attr( 'type' );
+							name = $this.attr( 'name' ),
+							type = $this.attr( 'type' );
 
 						if ( 'radio' === type || 'checkbox' === type ) {
 							$this.attr( 'checked', false );
@@ -732,7 +787,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 	/**
 	 * Rewrite wp_dropdown_categories output to enable a multiple select
-	 * @param  string $result rendered category dropdown list
+	 *
+	 * @param  string $result rendered category dropdown list.
 	 * @return string altered category dropdown list
 	 */
 	public static function make_multiple_categories_dropdown( $result ) {
@@ -743,39 +799,42 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Save the client settings for the remote site.
 	 *
-	 * @param   int $site_ID The site ID to save settings.
+	 * @param   int $site_id The site ID to save settings.
+	 *
 	 * @return  bool True on success; false on failure.
 	 */
-	public static function save_settings( $site_ID ) {
+	public static function save_settings( $site_id ) {
 		// TODO: adjust to save all settings required by XML feed
 		// TODO: validate saved values (e.g. valid post_type? valid status?)
-		// TODO: actually check if saving was successful or not and return a proper bool
+		// TODO: actually check if saving was successful or not and return a proper bool.
 
-		update_post_meta( $site_ID, 'syn_feed_url', esc_url_raw( $_POST['feed_url'] ) );
-		update_post_meta( $site_ID, 'syn_default_post_type', sanitize_text_field( $_POST['default_post_type'] ) );
-		update_post_meta( $site_ID, 'syn_default_post_status', sanitize_text_field( $_POST['default_post_status'] ) );
-		update_post_meta( $site_ID, 'syn_default_comment_status', sanitize_text_field( $_POST['default_comment_status'] ) );
-		update_post_meta( $site_ID, 'syn_default_ping_status', sanitize_text_field( $_POST['default_ping_status'] ) );
-		update_post_meta( $site_ID, 'syn_id_field', sanitize_text_field( $_POST['id_field'] ) );
-		update_post_meta( $site_ID, 'syn_enc_field', sanitize_text_field( $_POST['enc_field'] ) );
-		update_post_meta( $site_ID, 'syn_enc_is_photo', isset( $_POST['enc_is_photo'] ) ? sanitize_text_field( $_POST['enc_is_photo'] ) : null );
+		update_post_meta( $site_id, 'syn_feed_url', isset( $_POST['feed_url'] ) ? esc_url_raw( $_POST['feed_url'] ) : '' );
+		update_post_meta( $site_id, 'syn_default_post_type', isset( $_POST['default_post_type'] ) ? sanitize_text_field( $_POST['default_post_type'] ) : '' );
+		update_post_meta( $site_id, 'syn_default_post_status', isset( $_POST['default_post_status'] ) ? sanitize_text_field( $_POST['default_post_status'] ) : '' );
+		update_post_meta( $site_id, 'syn_default_comment_status', isset( $_POST['default_comment_status'] ) ? sanitize_text_field( $_POST['default_comment_status'] ) : '' );
+		update_post_meta( $site_id, 'syn_default_ping_status', isset( $_POST['default_ping_status'] ) ? sanitize_text_field( $_POST['default_ping_status'] ) : '' );
+		update_post_meta( $site_id, 'syn_id_field', isset( $_POST['id_field'] ) ? sanitize_text_field( $_POST['id_field'] ) : '' );
+		update_post_meta( $site_id, 'syn_enc_field', isset( $_POST['enc_field'] ) ? sanitize_text_field( $_POST['enc_field'] ) : '' );
+		update_post_meta( $site_id, 'syn_enc_is_photo', isset( $_POST['enc_is_photo'] ) ? sanitize_text_field( $_POST['enc_is_photo'] ) : null );
 
 
-		$node_changes = $_POST['node'];
+		$node_changes = $_POST['node']; // phpcs:ignore
 		$node_config  = array();
 		$custom_nodes = array();
 		if ( isset( $node_changes ) ) {
 			foreach ( $node_changes as $row ) {
 				$row_data = array();
 
-				//if no new has been added to the empty row at the end, ignore it
+				// if no new has been added to the empty row at the end, ignore it.
 				if ( ! empty( $row['xpath'] ) ) {
-
 					foreach ( array( 'is_item', 'is_meta', 'is_tax', 'is_photo' ) as $field ) {
-						$row_data[ $field ] = isset( $row[ $field ] ) && in_array( $row[ $field ], array(
+						$row_data[ $field ] = isset( $row[ $field ] ) && in_array(
+							$row[ $field ],
+							array(
 								'true',
-								'on'
-							) ) ? 1 : 0;
+								'on',
+							)
+						) ? 1 : 0;
 					}
 					$xpath = html_entity_decode( $row['xpath'] );
 
@@ -792,12 +851,13 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			}
 		}
 
-		$node_config['namespace']  = sanitize_text_field( $_POST['namespace'] );
-		$node_config['post_root']  = sanitize_text_field( $_POST['post_root'] );
-		$node_config['enc_parent'] = sanitize_text_field( $_POST['enc_parent'] );
+		$node_config['namespace']  = isset( $_POST['namespace'] ) ? sanitize_text_field( $_POST['namespace'] ) : '';
+		$node_config['post_root']  = isset( $_POST['post_root'] ) ? sanitize_text_field( $_POST['post_root'] ) : '';
+		$node_config['enc_parent'] = isset( $_POST['enc_parent'] ) ? sanitize_text_field( $_POST['enc_parent'] ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$node_config['categories'] = is_array( $_POST['categories'] ) ? array_map( 'intval', $_POST['categories'] ) : array();
 		$node_config['nodes']      = $custom_nodes;
-		update_post_meta( $site_ID, 'syn_node_config', $node_config );
+		update_post_meta( $site_id, 'syn_node_config', $node_config );
 		return true;
 	}
 
@@ -832,11 +892,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		//handle enclosures separately first
+		// handle enclosures separately first.
 		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
-		if ( isset( $enclosures ) && isset ( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates) if any
+		if ( isset( $enclosures ) && isset( $enc_field ) ) {
+			// first remove all enclosures for the post (for updates) if any.
 			delete_post_meta( $result, $enc_field );
 			foreach ( $enclosures as $enclosure ) {
 				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
@@ -845,7 +905,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
+			// now remove them from the rest of the metadata before saving the rest.
 			unset( $metas['enclosures'] );
 		}
 
@@ -872,11 +932,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		// handle enclosures separately first
+		// handle enclosures separately first.
 		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates)
+			// first remove all enclosures for the post (for updates).
 			delete_post_meta( $result, $enc_field );
 			foreach ( $enclosures as $enclosure ) {
 				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
@@ -885,7 +945,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
+			// now remove them from the rest of the metadata before saving the rest.
 			unset( $metas['enclosures'] );
 		}
 
@@ -908,7 +968,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		}
 		$taxonomies = $post['tax'];
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			// post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
@@ -922,7 +982,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @param $site
 	 * @param $transport_type
 	 * @param $client
-	 * @return mixed False if an error of if the data to save isn't passed.
+	 * @return bool False if an error of if the data to save isn't passed.
 	 */
 	public static function update_tax( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {
@@ -931,19 +991,20 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$taxonomies       = $post['tax'];
 		$replace_tax_list = array();
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			//post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
 			if ( ! in_array( $tax_name, $replace_tax_list ) ) {
-				//if we haven't processed this taxonomy before, replace any terms on the post with the first new one
+				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one.
 				wp_set_object_terms( $result, (string) $tax_value, $tax_name );
 				$replace_tax_list[] = $tax_name;
 			} else {
-				//if we've already added one term for this taxonomy, append any others
+				// if we've already added one term for this taxonomy, append any others.
 				wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 			}
 		}
+		return true;
 	}
 
 	/**
@@ -952,6 +1013,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return string|WP_Error The content of the remote feed, or error if there's a problem.
 	 */
 	public function fetch_feed() {
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$request = wp_remote_get( $this->feed_url );
 		if ( is_wp_error( $request ) ) {
 			return $request;

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -1,58 +1,66 @@
 <?php
 
-include_once( ABSPATH . 'wp-includes/class-IXR.php' );
-include_once( ABSPATH . 'wp-includes/class-wp-http-ixr-client.php' );
-include_once( dirname(__FILE__) . '/interface-syndication-client.php' );
-include_once( dirname( __FILE__ ) . '/push-syndicate-encryption.php' );
+require_once ABSPATH . 'wp-includes/class-IXR.php';
+require_once ABSPATH . 'wp-includes/class-wp-http-ixr-client.php';
+require_once dirname( __FILE__ ) . '/interface-syndication-client.php';
+require_once dirname( __FILE__ ) . '/push-syndicate-encryption.php';
 
+/**
+ * Class Syndication_WP_XMLRPC_Client
+ */
 class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndication_Client {
 
 	private $username;
 	private $password;
 
-	private $site_ID;
+	private $site_id;
 
-	function __construct( $site_ID ) {
+	/**
+	 * Syndication_WP_XMLRPC_Client constructor.
+	 *
+	 * @param int $site_id The site ID.
+	 */
+	public function __construct( $site_id ) {
 
 		// @TODO check port, timeout etc
-		$server = untrailingslashit( get_post_meta( $site_ID, 'syn_site_url', true ) );
-		if ( false === strpos( $server, 'xmlrpc.php' ) )
+		$server = untrailingslashit( get_post_meta( $site_id, 'syn_site_url', true ) );
+		if ( false === strpos( $server, 'xmlrpc.php' ) ) {
 			$server = esc_url_raw( trailingslashit( $server ) . 'xmlrpc.php' );
-		else
+		} else {
 			$server = esc_url_raw( $server );
+		}
 
-		$this->username = get_post_meta( $site_ID, 'syn_site_username', true);
-		$this->password = push_syndicate_decrypt( get_post_meta( $site_ID, 'syn_site_password', true) );
-		$this->site_ID  = $site_ID;
+		$this->username = get_post_meta( $site_id, 'syn_site_username', true );
+		$this->password = push_syndicate_decrypt( get_post_meta( $site_id, 'syn_site_password', true ) );
+		$this->site_id  = $site_id;
 
 		parent::__construct( $server );
 
-		if ( true === apply_filters( 'syn_xmlrpc_push_send_thumbnail', true, $site_ID, $this ) ) {
+		if ( true === apply_filters( 'syn_xmlrpc_push_send_thumbnail', true, $site_id, $this ) ) {
 			add_action( 'syn_xmlrpc_push_new_post_success', array( $this, 'post_push_send_thumbnail' ), 10, 6 );
 			add_action( 'syn_xmlrpc_push_edit_post_success', array( $this, 'post_push_send_thumbnail' ), 10, 6 );
-			// TODO: on delete post, delete thumbnail
+			// TODO: on delete post, delete thumbnail.
 		}
 	}
 
 	private function get_thumbnail_meta_keys( $post_id ) {
-		// Support for non-core images, like from the Multiple Post Thumbnail plugin
+		// Support for non-core images, like from the Multiple Post Thumbnail plugin.
 		return apply_filters( 'syn_xmlrpc_push_thumbnail_metas', array( '_thumbnail_id' ), $post_id );
 	}
 
 	function post_push_send_thumbnail( $remote_post_id, $post_id ) {
-
-		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_id ); 
+		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_id );
 
 		foreach ( $thumbnail_meta_keys as $thumbnail_meta ) {
-			$thumbnail_id = get_post_meta( $post_id, $thumbnail_meta, true );
-			$syn_local_meta_key = '_syn_push_thumb_' . $thumbnail_meta;
+			$thumbnail_id                  = get_post_meta( $post_id, $thumbnail_meta, true );
+			$syn_local_meta_key            = '_syn_push_thumb_' . $thumbnail_meta;
 			$syndicated_thumbnails_by_site = get_post_meta( $post_id, $syn_local_meta_key, true );
 
 			if ( ! is_array( $syndicated_thumbnails_by_site ) ) {
 				$syndicated_thumbnails_by_site = array();
 			}
 
-			$syndicated_thumbnail_id = isset( $syndicated_thumbnails_by_site[ $this->site_ID ] ) ? $syndicated_thumbnails_by_site[ $this->site_ID ] : false;
+			$syndicated_thumbnail_id = isset( $syndicated_thumbnails_by_site[ $this->site_id ] ) ? $syndicated_thumbnails_by_site[ $this->site_id ] : false;
 
 			if ( ! $thumbnail_id ) {
 				if ( $syndicated_thumbnail_id ) {
@@ -65,9 +73,8 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 						$thumbnail_meta
 					);
 
-					unset( $syndicated_thumbnails_by_site[ $this->site_ID ] ); 
+					unset( $syndicated_thumbnails_by_site[ $this->site_id ] );
 					update_post_meta( $post_id, $syn_local_meta_key, $syndicated_thumbnails_by_site );
-
 				}
 				continue;
 			}
@@ -77,11 +84,11 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			}
 
 			list( $thumbnail_url ) = wp_get_attachment_image_src( $thumbnail_id, 'full' );
-			//pass thumbnail data and meta into the addThumnail to sync caption, description and alt-text
-			//has to be this way since mw_newMediaObject doesn't allow to pass description and caption along
+			// pass thumbnail data and meta into the addThumnail to sync caption, description and alt-text
+			// has to be this way since mw_newMediaObject doesn't allow to pass description and caption along.
 			$thumbnail_post_data = get_post( $thumbnail_id );
-			$thumbnail_alt_text = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
-			
+			$thumbnail_alt_text  = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
+
 			$result = $this->query(
 				'syndication.addThumbnail',
 				'1',
@@ -95,42 +102,45 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			);
 
 			if ( $result ) {
-				$syndicated_thumbnails_by_site[ $this->site_ID ] = $thumbnail_id;
+				$syndicated_thumbnails_by_site[ $this->site_id ] = $thumbnail_id;
 				update_post_meta( $post_id, $syn_local_meta_key, $syndicated_thumbnails_by_site );
 			}
 		}
 	}
 
 	public static function get_client_data() {
-		return array( 'id' => 'WP_XMLRPC', 'modes' => array( 'push' ), 'name' => 'WordPress XMLRPC' );
+		return array(
+			'id'    => 'WP_XMLRPC',
+			'modes' => array( 'push' ),
+			'name'  => 'WordPress XMLRPC',
+		);
 	}
-	
-	public function new_post( $post_ID ) {
 
-		$post = (array)get_post( $post_ID );
+	public function new_post( $post_id ) {
+		$post = (array) get_post( $post_id );
 
-		// This filter can be used to exclude or alter posts during a content push
-		$post = apply_filters( 'syn_xmlrpc_push_filter_new_post', $post, $post_ID );
+		// This filter can be used to exclude or alter posts during a content push.
+		$post = apply_filters( 'syn_xmlrpc_push_filter_new_post', $post, $post_id );
 		if ( false === $post ) {
 			return true;
 		}
-		
-		//Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs
+
+		// Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs.
 		$post['post_content'] = $this->syndicate_gallery_images( $post['post_content'] );
 
-		// rearranging arguments
-		$args = array();
-		$args['post_title']	 = $post['post_title'];
-		$args['post_content']   = $post['post_content'];
-		$args['post_excerpt']   = $post['post_excerpt'];
-		$args['post_status']	= $post['post_status'];
-		$args['post_type']	  = $post['post_type'];
-		$args['wp_password']	= $post['post_password'];
-		$args['post_date_gmt']  = $this->convert_date_gmt( $post['post_date_gmt'], $post['post_date'] );
+		// rearranging arguments.
+		$args                  = array();
+		$args['post_title']    = $post['post_title'];
+		$args['post_content']  = $post['post_content'];
+		$args['post_excerpt']  = $post['post_excerpt'];
+		$args['post_status']   = $post['post_status'];
+		$args['post_type']     = $post['post_type'];
+		$args['wp_password']   = $post['post_password'];
+		$args['post_date_gmt'] = $this->convert_date_gmt( $post['post_date_gmt'], $post['post_date'] );
 
-		$args['terms_names'] = $this->_get_post_terms( $post_ID );
+		$args['terms_names'] = $this->get_post_terms( $post_id );
 
-		$args['custom_fields'] = $this->_get_custom_fields( $post_ID );
+		$args['custom_fields'] = $this->get_custom_fields( $post_id );
 
 		$args = apply_filters( 'syn_xmlrpc_push_new_post_args', $args, $post );
 
@@ -148,20 +158,18 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 		$remote_post_id = (int) $this->getResponse();
 
-		do_action( 'syn_xmlrpc_push_new_post_success', $remote_post_id, $post_ID );
+		do_action( 'syn_xmlrpc_push_new_post_success', $remote_post_id, $post_id );
 
 		return $remote_post_id;
-
 	}
 
-	public function edit_post( $post_ID, $remote_post_id ) {
-
+	public function edit_post( $post_id, $remote_post_id ) {
 		$args = array();
 
-		$post = (array)get_post( $post_ID );
+		$post = (array) get_post( $post_id );
 
-		// This filter can be used to exclude or alter posts during a content push
-		$post = apply_filters( 'syn_xmlrpc_push_filter_edit_post', $post, $post_ID );
+		// This filter can be used to exclude or alter posts during a content push.
+		$post = apply_filters( 'syn_xmlrpc_push_filter_edit_post', $post, $post_id );
 		if ( false === $post ) {
 			return true;
 		}
@@ -169,57 +177,57 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		$remote_post = $this->get_remote_post( $remote_post_id );
 
 		if ( ! $remote_post ) {
-			return new WP_Error( 'syn-remote-post-not-found', __( 'Remote post doesn\'t exist.', 'syndication' ) );
+			return new WP_Error( 'syn-remote-post-not-found', __( 'Remote post doesn\'t exist.', 'push-syndication' ) );
 		}
 
-		// Delete existing metadata to avoid duplicates
+		// Delete existing metadata to avoid duplicates.
 		$args['custom_fields'] = array();
 		foreach ( $remote_post['custom_fields'] as $custom_field ) {
-			$args['custom_fields'][] = array( 
-				'id' => $custom_field['id'],
+			$args['custom_fields'][] = array(
+				'id'              => $custom_field['id'],
 				'meta_key_lookup' => $custom_field['key'],
 			);
 		}
 
-		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_ID );
+		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_id );
 
 		foreach ( $thumbnail_meta_keys as $thumbnail_meta_key ) {
-			$thumbnail_id = get_post_meta( $post_ID, $thumbnail_meta_key, true );
-			$syn_local_meta_key = '_syn_push_thumb_' . $thumbnail_meta_key;
-			$syndicated_thumbnails_by_site = get_post_meta( $post_ID, $syn_local_meta_key, true );
+			$thumbnail_id                  = get_post_meta( $post_id, $thumbnail_meta_key, true );
+			$syn_local_meta_key            = '_syn_push_thumb_' . $thumbnail_meta_key;
+			$syndicated_thumbnails_by_site = get_post_meta( $post_id, $syn_local_meta_key, true );
 
 			if ( ! is_array( $syndicated_thumbnails_by_site ) ) {
 				$syndicated_thumbnails_by_site = array();
 			}
 
-			$syndicated_thumbnail_id = isset( $syndicated_thumbnails_by_site[ $this->site_ID ] ) ? $syndicated_thumbnails_by_site[ $this->site_ID ] : false;
+			$syndicated_thumbnail_id = isset( $syndicated_thumbnails_by_site[ $this->site_id ] ) ? $syndicated_thumbnails_by_site[ $this->site_id ] : false;
 
 			if ( $syndicated_thumbnail_id == $thumbnail_id ) {
-				//need to preserve old meta custom_type_thumbnail_id if it wasn't changed during update
-				//hence we remove ID from the custom_fileds list in order to avoid its deletion
+				// need to preserve old meta custom_type_thumbnail_id if it wasn't changed during update
+				// hence we remove ID from the custom_fileds list in order to avoid its deletion.
 				foreach ( $args['custom_fields'] as $index => $value ) {
 					if ( $value['meta_key_lookup'] == $thumbnail_meta_key ) {
-						unset( $args['custom_fields'][$index] );
+						unset( $args['custom_fields'][ $index ] );
 					}
 				}
 			}
 		}
 
-		//Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs
+		// Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs.
 		$post['post_content'] = $this->syndicate_gallery_images( $post['post_content'] );
 
-		// rearranging arguments
-		$args['post_title']	 = $post['post_title'];
-		$args['post_content']   = $post['post_content'];
-		$args['post_excerpt']   = $post['post_excerpt'];
-		$args['post_status']	= $post['post_status'];
-		$args['post_type']	  = $post['post_type'];
-		$args['wp_password']	= $post['post_password'];
-		$args['post_date_gmt']  = $this->convert_date_gmt( $post['post_date_gmt'], $post['post_date'] );
+		// rearranging arguments.
+		$args['post_title']    = $post['post_title'];
+		$args['post_content']  = $post['post_content'];
+		$args['post_excerpt']  = $post['post_excerpt'];
+		$args['post_status']   = $post['post_status'];
+		$args['post_type']     = $post['post_type'];
+		$args['wp_password']   = $post['post_password'];
+		$args['post_date_gmt'] = $this->convert_date_gmt( $post['post_date_gmt'], $post['post_date'] );
 
-		$args['terms_names'] = $this->_get_post_terms( $post_ID );
+		$args['terms_names'] = $this->get_post_terms( $post_id );
 
-		$args['custom_fields'] = array_merge( $args['custom_fields'], $this->_get_custom_fields( $post_ID ) );
+		$args['custom_fields'] = array_merge( $args['custom_fields'], $this->get_custom_fields( $post_id ) );
 
 		$args = apply_filters( 'syn_xmlrpc_push_edit_post_args', $args, $post );
 
@@ -236,49 +244,50 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			return new WP_Error( $this->getErrorCode(), $this->getErrorMessage() );
 		}
 
-		do_action( 'syn_xmlrpc_push_edit_post_success', $remote_post_id, $post_ID );
+		do_action( 'syn_xmlrpc_push_edit_post_success', $remote_post_id, $post_id );
 
 		return $remote_post_id;
 	}
 
 	/**
-	* Utility method to Syndicate [gallery] shortcode images
-	* It needs to upload images and inject new IDs into the post_content
- 	* @access private
- 	* @uses $shortcode_tags global variable
- 	* @param string $post_content - post to be syndicated
- 	* @return string $post_content - post content with replaced gallery shortcodes
-	*/
+	 * Utility method to Syndicate [gallery] shortcode images
+	 * It needs to upload images and inject new IDs into the post_content
+	 *
+	 * @access private
+	 * @uses $shortcode_tags global variable
+	 * @param string $post_content - post to be syndicated.
+	 * @return string|WP_Error $post_content - post content with replaced gallery shortcodes
+	 */
 	private function syndicate_gallery_images( $post_content ) {
 		$attachment_ids = array();
 		global $shortcode_tags;
-		//overwrite global shortcodes for gallery only and then revert back to original
-		$temp = $shortcode_tags;
-		$shortcode_tags = array( 'gallery' => 'gallery_shortcode' );
-		$pattern = get_shortcode_regex();
-		$shortcode_tags = $temp;
+		// overwrite global shortcodes for gallery only and then revert back to original.
+		$temp           = $shortcode_tags;
+		$shortcode_tags = array( 'gallery' => 'gallery_shortcode' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$pattern        = get_shortcode_regex();
+		$shortcode_tags = $temp; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$image_ids = array();
+		$image_ids     = array();
 		$new_image_ids = array();
-		 
+
 		if ( preg_match_all( '/' . $pattern . '/s', $post_content, $matches ) ) {
-		  $count=count( $matches[3] );		  
-		  for ( $i = 0; $i < $count; $i++ ) {
-		    $atts = shortcode_parse_atts( $matches[3][$i] );
-		    if ( isset( $atts['ids'] ) ) {
-		      $attachment_ids = explode( ',', $atts['ids'] );
-		      $image_ids[$i] = $attachment_ids;
-		    }
-		  }
+			$count = count( $matches[3] );
+			for ( $i = 0; $i < $count; $i++ ) {
+				$atts = shortcode_parse_atts( $matches[3][ $i ] );
+				if ( isset( $atts['ids'] ) ) {
+					$attachment_ids  = explode( ',', $atts['ids'] );
+					$image_ids[ $i ] = $attachment_ids;
+				}
+			}
 		}
 
-		if( ! empty( $image_ids ) ) {
+		if ( ! empty( $image_ids ) ) {
 			foreach ( $image_ids as $key => $gallery_ids ) {
 				foreach ( $gallery_ids as $index => $id ) {
-					//do upload, get new ID back
+					// do upload, get new ID back.
 					list( $thumbnail_url ) = wp_get_attachment_image_src( $id, 'full' );
-					$thumbnail_post_data = get_post($id);
-					$thumbnail_alt_text = trim( get_post_meta( $id, '_wp_attachment_image_alt', true ) );
+					$thumbnail_post_data   = get_post( $id );
+					$thumbnail_alt_text    = trim( get_post_meta( $id, '_wp_attachment_image_alt', true ) );
 
 					$result = $this->query(
 						'syndication.postGalleryImage',
@@ -293,34 +302,33 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 					if ( ! $result ) {
 						return new WP_Error( $this->getErrorCode(), $this->getErrorMessage() );
 					}
-					$new_image_ids[$key][$index] = (int) $this->getResponse();
+					$new_image_ids[ $key ][ $index ] = (int) $this->getResponse();
 				}
 			}
 		}
 
-		//new IDs needs to be injected into the post content
-		//replace old gallery code with a new one
+		// new IDs needs to be injected into the post content
+		// replace old gallery code with a new one.
 		$lenght = count( $matches[0] );
 		for ( $i = 0; $i < $lenght; $i++ ) {
-			$shortcode = $matches[0][$i];
-			//WP regex matches attribute with leading space, required here
-			$attribute = ' ids="' . implode( ',', $image_ids[$i] ) . '"';
-			$new_attribute = ' ids="' . implode( ',', $new_image_ids[$i] ) . '"';
+			$shortcode = $matches[0][ $i ];
+			// WP regex matches attribute with leading space, required here.
+			$attribute     = ' ids="' . implode( ',', $image_ids[ $i ] ) . '"';
+			$new_attribute = ' ids="' . implode( ',', $new_image_ids[ $i ] ) . '"';
 			$new_shortcode = str_replace( $attribute, $new_attribute, $shortcode );
-			$post_content = str_replace( $shortcode, $new_shortcode, $post_content );
+			$post_content  = str_replace( $shortcode, $new_shortcode, $post_content );
 		}
 
 		return $post_content;
 	}
 
 	public function delete_post( $remote_post_id ) {
-
 		$result = $this->query(
-				'wp.deletePost',
-				'1',
-				$this->username,
-				$this->password,
-				$remote_post_id
+			'wp.deletePost',
+			'1',
+			$this->username,
+			$this->password,
+			$remote_post_id
 		);
 
 		if ( ! $result ) {
@@ -330,53 +338,55 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		return true;
 	}
 
-	private function _get_custom_fields( $post_id ) {
+	private function get_custom_fields( $post_id ) {
 		$post = get_post( $post_id );
 
 		$custom_fields = array();
 		$all_post_meta = get_post_custom( $post_id );
 
-		$blacklisted_meta = $this->_get_meta_blacklist( $post_id );
+		$blacklisted_meta = $this->get_meta_blacklist( $post_id );
 		foreach ( (array) $all_post_meta as $post_meta_key => $post_meta_values ) {
-
-			if ( in_array( $post_meta_key, $blacklisted_meta ) || preg_match( '/^_?syn/i', $post_meta_key ) )
+			if ( in_array( $post_meta_key, $blacklisted_meta ) || preg_match( '/^_?syn/i', $post_meta_key ) ) {
 				continue;
+			}
 
 			foreach ( $post_meta_values as $post_meta_value ) {
-				$post_meta_value = maybe_unserialize( $post_meta_value ); // get_post_custom returns serialized data
+				$post_meta_value = maybe_unserialize( $post_meta_value ); // get_post_custom returns serialized data.
 
 				$custom_fields[] = array(
-					'key' => $post_meta_key,
+					'key'   => $post_meta_key,
 					'value' => $post_meta_value,
 				);
 			}
 		}
 
 		$custom_fields[] = array(
-			'key' => 'syn_source_url',
+			'key'   => 'syn_source_url',
 			'value' => $post->guid,
 		);
 		return $custom_fields;
 	}
 
-	private function _get_meta_blacklist( $post_id ) {
-		$blacklist = array( '_edit_last', '_edit_lock' /** TODO: add more **/ );
+	private function get_meta_blacklist( $post_id ) {
+		$blacklist           = array( '_edit_last', '_edit_lock' /** TODO: add more */ );
 		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_id );
 
 		$blacklist = array_merge( $blacklist, $thumbnail_meta_keys );
 		return apply_filters( 'syn_ignored_meta_fields', $blacklist, $post_id );
 	}
 
-	private function _get_post_terms( $post_id ) {
+	private function get_post_terms( $post_id ) {
 		$terms_names = array();
 
 		$post = get_post( $post_id );
 
-		if ( is_object_in_taxonomy( $post->post_type, 'category' ) )
+		if ( is_object_in_taxonomy( $post->post_type, 'category' ) ) {
 			$terms_names['category'] = wp_get_object_terms( $post_id, 'category', array( 'fields' => 'names' ) );
+		}
 
-		if ( is_object_in_taxonomy( $post->post_type, 'post_tag' )  )
+		if ( is_object_in_taxonomy( $post->post_type, 'post_tag' ) ) {
 			$terms_names['post_tag'] = wp_get_object_terms( $post_id, 'post_tag', array( 'fields' => 'names' ) );
+		}
 
 		// TODO: custom taxonomy
 
@@ -384,7 +394,6 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 	}
 
 	public function test_connection() {
-
 		$result = $this->query(
 			'wp.getPostTypes', // @TODO find a better suitable function
 			'1',
@@ -392,48 +401,59 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			$this->password
 		);
 
-		if( !$result ) {
+		if ( ! $result ) {
+			$error_code = absint( $this->getErrorCode() );
 
-			$error_code = absint($this->getErrorCode());
-
-			switch( $error_code ) {
+			switch ( $error_code ) {
 				case 32301:
-					add_filter('redirect_post_location', function($location) {
-						return add_query_arg("message", 305, $location);
-					});
+					add_filter(
+						'redirect_post_location',
+						function( $location ) {
+							return add_query_arg( 'message', 305, $location );
+						}
+					);
 					break;
 				case 401:
-					add_filter('redirect_post_location', function($location) {
-						return add_query_arg("message", 302, $location);
-					});
+					add_filter(
+						'redirect_post_location',
+						function( $location ) {
+							return add_query_arg( 'message', 302, $location );
+						}
+					);
 					break;
 				case 403:
-					add_filter('redirect_post_location', function($location) {
-						return add_query_arg("message", 303, $location);
-					});
+					add_filter(
+						'redirect_post_location',
+						function( $location ) {
+							return add_query_arg( 'message', 303, $location );
+						}
+					);
 					break;
 				case 405:
-					add_filter('redirect_post_location', function($location) {
-						return add_query_arg("message", 304, $location);
-					});
+					add_filter(
+						'redirect_post_location',
+						function( $location ) {
+							return add_query_arg( 'message', 304, $location );
+						}
+					);
 					break;
 				default:
-					add_filter('redirect_post_location', function($location) {
-						return add_query_arg("message", 306, $location);
-					});
+					add_filter(
+						'redirect_post_location',
+						function( $location ) {
+							return add_query_arg( 'message', 306, $location );
+						}
+					);
 					break;
 			}
 
 			return false;
-
 		}
 
 		return true;
-
 	}
 
 	function get_remote_post( $remote_post_id ) {
-
 		$result = $this->query(
 			'wp.getPost',
 			'1',
@@ -442,8 +462,9 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			$remote_post_id
 		);
 
-		if( !$result )
+		if ( ! $result ) {
 			return false;
+		}
 
 		return $this->getResponse();
 	}
@@ -451,33 +472,31 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 	public function is_post_exists( $remote_post_id ) {
 		$remote_post = $this->get_remote_post( $remote_post_id );
 
-		if( ! $remote_post || $remote_post_id != $remote_post['post_id'] ) {
+		if ( ! $remote_post || $remote_post_id != $remote_post['post_id'] ) {
 			return false;
 		}
 
 		return true;
-
 	}
 
 	protected function convert_date_gmt( $date_gmt, $date ) {
-		if ( $date !== '0000-00-00 00:00:00' && $date_gmt === '0000-00-00 00:00:00' ) {
+		if ( '0000-00-00 00:00:00' !== $date && '0000-00-00 00:00:00' === $date_gmt ) {
 			return new IXR_Date( get_gmt_from_date( mysql2date( 'Y-m-d H:i:s', $date, false ), 'Ymd\TH:i:s' ) );
 		}
 		return $this->convert_date( $date_gmt );
 	}
 
 	protected function convert_date( $date ) {
-		if ( $date === '0000-00-00 00:00:00' ) {
+		if ( '0000-00-00 00:00:00' === $date ) {
 			return new IXR_Date( '00000000T00:00:00Z' );
 		}
 		return new IXR_Date( mysql2date( 'Ymd\TH:i:s', $date, false ) );
 	}
 
 	public static function display_settings( $site ) {
-
-		$site_url = get_post_meta( $site->ID, 'syn_site_url', true);
-		$site_username = get_post_meta( $site->ID, 'syn_site_username', true);
-		$site_password = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_password', true) );
+		$site_url      = get_post_meta( $site->ID, 'syn_site_url', true );
+		$site_username = get_post_meta( $site->ID, 'syn_site_username', true );
+		$site_password = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_password', true ) );
 
 		?>
 
@@ -485,7 +504,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			<label for=site_url><?php echo esc_html__( 'Enter a valid site URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_html( $site_url ); ?>" />
+			<input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_url_raw( $site_url ); ?>" />
 		</p>
 		<p>
 			<label for="site_username"><?php echo esc_html__( 'Enter Username', 'push-syndication' ); ?></label>
@@ -502,50 +521,53 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 		<?php
 
-		do_action( 'syn_after_site_form', $site ); 
+		do_action( 'syn_after_site_form', $site );
 	}
 
-	public static function save_settings( $site_ID ) {
-
+	public static function save_settings( $site_id ) {
+		// @TODO: add nonce
 		$_POST['site_url'] = str_replace( '/xmlrpc.php', '', $_POST['site_url'] );
 
-		update_post_meta( $site_ID, 'syn_site_url', esc_url_raw( $_POST['site_url'] ) );
-		update_post_meta( $site_ID, 'syn_site_username', sanitize_text_field( $_POST['site_username'] ) );
-		update_post_meta( $site_ID, 'syn_site_password', push_syndicate_encrypt( sanitize_text_field( $_POST['site_password'] ) ) );
+		update_post_meta( $site_id, 'syn_site_url', isset( $_POST['site_url'] ) ? esc_url_raw( $_POST['site_url'] ) : '' );
+		update_post_meta( $site_id, 'syn_site_username', isset( $_POST['site_username'] ) ? sanitize_text_field( $_POST['site_username'] ) : '' );
+		update_post_meta( $site_id, 'syn_site_password', isset( $_POST['site_password'] ) ? push_syndicate_encrypt( sanitize_text_field( $_POST['site_password'] ) ) : '' );
 
-		if( !filter_var( $_POST['site_url'], FILTER_VALIDATE_URL ) ) {
-			add_filter('redirect_post_location', function($location) {
-				return add_query_arg("message", 301, $location);
-			});
+		if ( ! filter_var( $_POST['site_url'], FILTER_VALIDATE_URL ) ) {
+			add_filter(
+				'redirect_post_location',
+				function( $location ) {
+					return add_query_arg( 'message', 301, $location );
+				}
+			);
 			return false;
 		}
 
 		return true;
-
 	}
 
-	public function get_post( $ext_ID )
-	{
+	public function get_post( $ext_id ) {
 		// TODO: Implement get_post() method.
 	}
 
-	public function get_posts( $args = array() )
-	{
+	public function get_posts( $args = array() ) {
 		// TODO: Implement get_posts() method.
 	}
 
 }
 
+/**
+ * Class Syndication_WP_XMLRPC_Client_Extensions
+ */
 class Syndication_WP_XMLRPC_Client_Extensions {
 
 	public static function init() {
-		add_filter( 'xmlrpc_methods' , array( __CLASS__, 'push_syndicate_methods' ) );
+		add_filter( 'xmlrpc_methods', array( __CLASS__, 'push_syndicate_methods' ) );
 	}
 
 	public static function push_syndicate_methods( $methods ) {
-        $methods['syndication.addThumbnail']    = array( __CLASS__, 'xmlrpc_add_thumbnail' );
-        $methods['syndication.deleteThumbnail']    = array( __CLASS__, 'xmlrpc_delete_thumbnail' );
-        $methods['syndication.postGalleryImage'] = array(__CLASS__, 'xmlrpc_post_gallery_images');
+		$methods['syndication.addThumbnail']     = array( __CLASS__, 'xmlrpc_add_thumbnail' );
+		$methods['syndication.deleteThumbnail']  = array( __CLASS__, 'xmlrpc_delete_thumbnail' );
+		$methods['syndication.postGalleryImage'] = array( __CLASS__, 'xmlrpc_post_gallery_images' );
 
 		return $methods;
 	}
@@ -564,104 +586,114 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		$thumbnail_post_data = $args[6];
 		$thumbnail_alt_text  = $args[7];
 
-		if ( ! $post_ID )
-			return new IXR_Error( 500, __( 'Please specify a valid post_ID.', 'syndication' ) );
+		if ( ! $post_ID ) {
+			return new IXR_Error( 500, __( 'Please specify a valid post_ID.', 'push-syndication' ) );
+		}
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$thumbnail_raw = wp_remote_retrieve_body( wp_remote_get( $thumbnail_url ) );
-		if ( ! $thumbnail_raw )
-			return new IXR_Error( 500, __( 'Sorry, the image URL provided was incorrect.', 'syndication' ) );
+		if ( ! $thumbnail_raw ) {
+			return new IXR_Error( 500, __( 'Sorry, the image URL provided was incorrect.', 'push-syndication' ) );
+		}
 
 		$thumbnail_filename = basename( $thumbnail_url );
-		$thumbnail_type = wp_check_filetype( $thumbnail_filename );
+		$thumbnail_type     = wp_check_filetype( $thumbnail_filename );
 
 		$args = array(
 			$blog_id,
 			$username,
 			$password,
 			array(
-				'name' => $thumbnail_filename,
-				'type' => $thumbnail_type['type'],
-				'bits' => $thumbnail_raw,
+				'name'      => $thumbnail_filename,
+				'type'      => $thumbnail_type['type'],
+				'bits'      => $thumbnail_raw,
 				'overwrite' => false,
 			),
 		);
 
-		// Note: Leting mw_newMediaObject handle our auth and cap checks
+		// Note: Leting mw_newMediaObject handle our auth and cap checks.
 		$image = $wp_xmlrpc_server->mw_newMediaObject( $args );
 
-		if ( ! is_array( $image ) || empty( $image['url'] ) )
+		if ( ! is_array( $image ) || empty( $image['url'] ) ) {
 			return $image;
+		}
 
 		$thumbnail_id = (int) $image['id'];
-		if( empty( $thumbnail_id ) )
-			return new IXR_Error( 500, __( 'Sorry, looks like the image upload failed.', 'syndication' ) );
+		if ( empty( $thumbnail_id ) ) {
+			return new IXR_Error( 500, __( 'Sorry, looks like the image upload failed.', 'push-syndication' ) );
+		}
 
-		if ( '_thumbnail_id' == $meta_key )
+		if ( '_thumbnail_id' == $meta_key ) {
 			$thumbnail_set = set_post_thumbnail( $post_ID, $thumbnail_id );
-		else
+		} else {
 			$thumbnail_set = update_post_meta( $post_ID, $meta_key, $thumbnail_id );
+		}
 
-		if ( ! $thumbnail_set )
-			return new IXR_Error( 403, __( 'Could not attach post thumbnail.' ) );
-		
+		if ( ! $thumbnail_set ) {
+			return new IXR_Error( 403, __( 'Could not attach post thumbnail.', 'push-syndication' ) );
+		}
+
 		$args = array(
 			$blog_id,
 			$username,
 			$password,
 			$thumbnail_id,
 			array(
-				'post_title' => $thumbnail_post_data['post_title'],
+				'post_title'   => $thumbnail_post_data['post_title'],
 				'post_content' => $thumbnail_post_data['post_content'],
 				'post_excerpt' => $thumbnail_post_data['post_excerpt'],
 			),
 		);
-		//update caption and description of the image
+		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
-		if ( $result !== true ) {
-			//failed to update atatchment post details
-			//handle it th way you want it (log it, message it)
+		if ( true !== $result ) {
+			// failed to update atatchment post details
+			// handle it th way you want it (log it, message it).
 		}
-		//update alt text of the image
-		update_post_meta($thumbnail_id, '_wp_attachment_image_alt', $thumbnail_alt_text);
+		// update alt text of the image.
+		update_post_meta( $thumbnail_id, '_wp_attachment_image_alt', $thumbnail_alt_text );
 
 		return $thumbnail_id;
 	}
 
 	public static function xmlrpc_delete_thumbnail( $args ) {
-
 		global $wp_xmlrpc_server;
 		$wp_xmlrpc_server->escape( $args );
 
-		$blog_id	    = (int) $args[0];
-		$username	    = $args[1];
-		$password	    = $args[2];
-		$post_ID            = (int) $args[3];
+		$blog_id  = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$post_ID  = (int) $args[3];
 		$meta_key = ! empty( $args[4] ) ? sanitize_text_field( $args[4] ) : '_thumbnail_id';
 
-		if ( !$user = $wp_xmlrpc_server->login( $username, $password ) )
+		if ( ! $user = $wp_xmlrpc_server->login( $username, $password ) ) {
 			return $wp_xmlrpc_server->error;
+		}
 
-		if ( ! current_user_can( 'edit_post', $post_ID ) )
-			return new IXR_Error( 401, __( 'Sorry, you are not allowed to post on this site.' ) );
+		if ( ! current_user_can( 'edit_post', $post_ID ) ) {
+			return new IXR_Error( 401, __( 'Sorry, you are not allowed to post on this site.', 'push-syndication' ) );
+		}
 
-		if ( '_thumbnail_id' == $meta_key )
+		if ( '_thumbnail_id' == $meta_key ) {
 			$result = delete_post_thumbnail( $post_ID );
-		else
+		} else {
 			$result = delete_post_meta( $post_ID, $meta_key );
+		}
 
-		if ( ! $result )
-			return new IXR_Error( 403, __( 'Could not remove post thumbnail.' ) );
+		if ( ! $result ) {
+			return new IXR_Error( 403, __( 'Could not remove post thumbnail.', 'push-syndication' ) );
+		}
 
 		return true;
-
 	}
 
 	/**
-	* Upload Image for the gallery shortcode
-	* @uses $wp_xmlrpc_server
-	* @param array $args Contains necessary parameters for XMLRCP call: user, paasword, image data
-	* @return integer $thumbnail_id New ID of the newly uploaded image to the remote site
-	*/
+	 * Upload Image for the gallery shortcode
+	 *
+	 * @uses $wp_xmlrpc_server
+	 * @param array $args Contains necessary parameters for XMLRCP call: user, paasword, image data.
+	 * @return int|IXR_Error $thumbnail_id New ID of the newly uploaded image to the remote site
+	 */
 	public static function xmlrpc_post_gallery_images( $args ) {
 		global $wp_xmlrpc_server;
 
@@ -674,57 +706,59 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		$thumbnail_post_data = $args[4];
 		$thumbnail_alt_text  = $args[5];
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$thumbnail_raw = wp_remote_retrieve_body( wp_remote_get( $thumbnail_url ) );
 		if ( ! $thumbnail_raw ) {
-			return new IXR_Error( 500, __( 'Sorry, the image URL provided was incorrect.', 'syndication' ) );
+			return new IXR_Error( 500, __( 'Sorry, the image URL provided was incorrect.', 'push-syndication' ) );
 		}
 
 		$thumbnail_filename = basename( $thumbnail_url );
-		$thumbnail_type = wp_check_filetype( $thumbnail_filename );
+		$thumbnail_type     = wp_check_filetype( $thumbnail_filename );
 
 		$args = array(
 			$blog_id,
 			$username,
 			$password,
 			array(
-				'name' => $thumbnail_filename,
-				'type' => $thumbnail_type['type'],
-				'bits' => $thumbnail_raw,
+				'name'      => $thumbnail_filename,
+				'type'      => $thumbnail_type['type'],
+				'bits'      => $thumbnail_raw,
 				'overwrite' => false,
 			),
 		);
 
-		// Note: Leting mw_newMediaObject handle our auth and cap checks
+		// Note: Leting mw_newMediaObject handle our auth and cap checks.
 		$image = $wp_xmlrpc_server->mw_newMediaObject( $args );
-		if ( ! is_array( $image ) || empty($image['url'] ) ) {
+		if ( ! is_array( $image ) || empty( $image['url'] ) ) {
 			return $image;
 		}
 
 		$thumbnail_id = (int) $image['id'];
 		if ( empty( $thumbnail_id ) ) {
-			return new IXR_Error( 500, __( 'Sorry, looks like the image upload failed.', 'syndication' ) );
+			return new IXR_Error( 500, __( 'Sorry, looks like the image upload failed.', 'push-syndication' ) );
 		}
-		
+
 		$args = array(
 			$blog_id,
 			$username,
 			$password,
 			$thumbnail_id,
 			array(
-				'post_title' => $thumbnail_post_data['post_title'],
+				'post_title'   => $thumbnail_post_data['post_title'],
 				'post_content' => $thumbnail_post_data['post_content'],
 				'post_excerpt' => $thumbnail_post_data['post_excerpt'],
 			),
 		);
 
-		//update caption and description of the image
+		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
-		if ( $result !== true ) {
-			//failed to update atatchment post details
-			//handle it th way you want it (log it, message it)
-			error_log('Syndication. xmlrpc_post_gallery_images Failed to update remote post attachments');
+		if ( true !== $result ) {
+			// failed to update atatchment post details
+			// handle it th way you want it (log it, message it).
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'Syndication. xmlrpc_post_gallery_images Failed to update remote post attachments' );
 		}
-		//update alt text of the image
+		// update alt text of the image.
 		update_post_meta( $thumbnail_id, '_wp_attachment_image_alt', $thumbnail_alt_text );
 
 		return $thumbnail_id;

--- a/includes/class-walker-category-dropdown-multiple.php
+++ b/includes/class-walker-category-dropdown-multiple.php
@@ -1,40 +1,45 @@
 <?php
 /**
  * Create HTML list of categories. Allowing a multiple select list
+ *
  * @uses Walker
  */
 class Walker_CategoryDropdownMultiple extends Walker {
+	// @TODO: phpcs - rename class?
 
-	var $tree_type = 'category';
+	public $tree_type = 'category';
 
-	var $db_fields = array ('parent' => 'parent', 'id' => 'term_id');
+	public $db_fields = array(
+		'parent' => 'parent',
+		'id'     => 'term_id',
+	);
 
 	/**
 	 * Start the element output.
 	 *
-	 * @see Walker::start_el()
-	 *
-	 *
-	 * @param string $output   Passed by reference. Used to append additional content.
+	 * @param string $output Passed by reference. Used to append additional content.
 	 * @param object $category Category data object.
-	 * @param int    $depth    Depth of category in reference to parents. Default 0.
-	 * @param array  $args     An array of arguments. @see wp_list_categories()
-	 * @param int    $id       ID of the current category.
+	 * @param int    $depth Depth of category in reference to parents. Default 0.
+	 * @param array  $args An array of arguments. @see wp_list_categories().
+	 * @param int    $current_object_id The current object ID.
+	 *
+	 * @see Walker::start_el()
 	 */
-	function start_el( &$output, $category, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	public function start_el( &$output, $category, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		$pad = str_repeat( '&nbsp;', $depth * 3 );
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$cat_name = apply_filters( 'list_cats', $category->name, $category );
 
-		$output .= "\t<option class=\"level-$depth\" value=\"".$category->term_id."\"";
+		$output .= '\t<option class="level-' . esc_attr( $depth ) . '" value="' . esc_attr( $category->term_id ) . '"';
 		if ( isset( $args['selected_array'] ) && in_array( $category->term_id, $args['selected_array'] ) ) {
 			$output .= ' selected="selected"';
 		}
 		$output .= '>';
-		$output .= $pad.$cat_name;
+		$output .= $pad . $cat_name;
 
 		if ( $args['show_count'] ) {
-			$output .= '&nbsp;&nbsp;('. $category->count .')';
+			$output .= '&nbsp;&nbsp;(' . esc_html( $category->count ) . ')';
 		}
 		$output .= "</option>\n";
 	}

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -2,6 +2,9 @@
 
 WP_CLI::add_command( 'syndication', 'Syndication_CLI_Command' );
 
+/**
+ * Class Syndication_CLI_Command
+ */
 class Syndication_CLI_Command extends WP_CLI_Command {
 	var $enabled_verbosity = false;
 
@@ -11,24 +14,27 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	 * @subcommand push-all-posts
 	 * @synopsis [--post_type=<post-type>] [--paged=<page>]
 	 */
-	function push_all_posts( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'post_type' 	=> 'post',
-			'paged' 		=> 1
-		) );
+	public function push_all_posts( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'post_type' => 'post',
+				'paged'     => 1,
+			)
+		);
 
 		$query_args = array(
-			'post_type' 		=> $assoc_args[ 'post_type' ],
-			'posts_per_page' 	=> 150,
-			'paged'				=> $assoc_args[ 'paged' ]
+			'post_type'      => $assoc_args['post_type'],
+			'posts_per_page' => 150, //phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+			'paged'          => $assoc_args['paged'],
 		);
 
 		$query = new WP_Query( $query_args );
 
-		while( $query->post_count ) {
-			WP_CLI::line( sprintf( 'Processing page %d', $query_args[ 'paged' ] ) );
+		while ( $query->post_count ) {
+			WP_CLI::line( sprintf( 'Processing page %d', $query_args['paged'] ) );
 
-			foreach( $query->posts as $post ) {
+			foreach ( $query->posts as $post ) {
 				WP_CLI::line( sprintf( 'Processing post %d (%s)', $post->ID, $post->post_title ) );
 
 				$this->push_post( array(), array( 'post_id' => $post->ID ) );
@@ -38,27 +44,30 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 
 			sleep( 2 );
 
-			$query_args[ 'paged' ]++;
+			$query_args['paged']++;
 
 			$query = new WP_Query( $query_args );
 		}
 	}
 
-	function push_post( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'post_id' => 0,
-		) );
+	public function push_post( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'post_id' => 0,
+			)
+		);
 
-		$post_id = intval( $assoc_args[ 'post_id' ] );
-		$post = get_post( $post_id );
+		$post_id = intval( $assoc_args['post_id'] );
+		$post    = get_post( $post_id );
 		if ( ! $post ) {
 			WP_CLI::error( __( 'Invalid post_id', 'push-syndication' ) );
 		}
 
-		$this->_make_em_talk_push();
+		$this->make_em_talk_push();
 
-		$server = $this->_get_syndication_server();
-		$sites = $server->get_sites_by_post_ID( $post_id );
+		$server = $this->get_syndication_server();
+		$sites  = $server->get_sites_by_post_ID( $post_id );
 
 		if ( empty( $sites ) ) {
 			WP_CLI::error( __( 'Post has no selected sitegroups / sites', 'push-syndication' ) );
@@ -67,90 +76,129 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$server->push_content( $sites );
 	}
 
-	function pull_site( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'site_id' => 0,
-		) );
+	public function pull_site( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'site_id' => 0,
+			)
+		);
 
 		$site_id = intval( $assoc_args['site_id'] );
-		$site = get_post( $site_id );
+		$site    = get_post( $site_id );
 
-		if ( ! $site || 'syn_site' !== $site->post_type )
-			WP_CLI::error( "Please select a valid site." );
+		if ( ! $site || 'syn_site' !== $site->post_type ) {
+			WP_CLI::error( 'Please select a valid site.' );
+		}
 
-		// enable verbosity
-		$this->_make_em_talk_pull();
+		// enable verbosity.
+		$this->make_em_talk_pull();
 
-		$this->_get_syndication_server()->pull_content( array( $site ) );
+		$this->get_syndication_server()->pull_content( array( $site ) );
 	}
 
-	function pull_sitegroup( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'sitegroup' => '',
-		) );
+	public function pull_sitegroup( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'sitegroup' => '',
+			)
+		);
 
 		$sitegroup = sanitize_key( $assoc_args['sitegroup'] );
 
-		if ( empty( $sitegroup ) )
-			WP_CLI::error( "Please specify a valid sitegroup" );
+		if ( empty( $sitegroup ) ) {
+			WP_CLI::error( 'Please specify a valid sitegroup' );
+		}
 
-		$server = $this->_get_syndication_server();
-		$sites = $server->get_sites_by_sitegroup( $sitegroup );
+		$server = $this->get_syndication_server();
+		$sites  = $server->get_sites_by_sitegroup( $sitegroup );
 
-		// enable verbosity
-		$this->_make_em_talk_pull();
+		// enable verbosity.
+		$this->make_em_talk_pull();
 
-		// do it, to it
+		// do it, to it.
 		$server->pull_content( $sites );
 	}
 
-	private function _make_em_talk_pull() {
-		if ( $this->enabled_verbosity )
+	private function make_em_talk_pull() {
+		if ( $this->enabled_verbosity ) {
 			return;
+		}
 
 		$this->enabled_verbosity = true;
 
-		// output when a post is new or updated
-		add_filter( 'syn_pre_pull_posts', function( $posts, $site, $client ) {
-			WP_CLI::line( sprintf( 'Processing feed %s (%d)', $site->post_title, $site->ID ) );
-			WP_CLI::line( sprintf( '-- found %s posts', count( $posts ) ) );
+		// output when a post is new or updated.
+		add_filter(
+			'syn_pre_pull_posts',
+			function( $posts, $site, $client ) {
+				WP_CLI::line( sprintf( 'Processing feed %s (%d)', $site->post_title, $site->ID ) );
+				WP_CLI::line( sprintf( '-- found %s posts', count( $posts ) ) );
 
-			return $posts;
-		}, 10, 3 );
+				return $posts;
+			},
+			10,
+			3
+		);
 
-		add_action( 'syn_post_pull_new_post', function( $result, $post, $site, $transport_type, $client ) {
-			WP_CLI::line( sprintf( '-- New post #%d (%s)', $result, $post['post_guid'] ) );
-		}, 10, 5 );
+		add_action(
+			'syn_post_pull_new_post',
+			function( $result, $post, $site, $transport_type, $client ) {
+				WP_CLI::line( sprintf( '-- New post #%d (%s)', $result, $post['post_guid'] ) );
+			},
+			10,
+			5
+		);
 
-		add_action( 'syn_post_pull_edit_post', function( $result, $post, $site, $transport_type, $client ) {
-			WP_CLI::line( sprintf( '-- Updated post #%d (%s)', $result, $post['post_guid'] ) );
-		}, 10, 5 );
+		add_action(
+			'syn_post_pull_edit_post',
+			function( $result, $post, $site, $transport_type, $client ) {
+				WP_CLI::line( sprintf( '-- Updated post #%d (%s)', $result, $post['post_guid'] ) );
+			},
+			10,
+			5
+		);
 	}
 
-	private function _make_em_talk_push() {
-		if ( $this->enabled_verbosity )
+	private function make_em_talk_push() {
+		if ( $this->enabled_verbosity ) {
 			return;
+		}
 
 		$this->enabled_verbosity = true;
 
-		add_filter( 'syn_pre_push_post_sites', function( $sites, $post_id, $slave_states ) {
-			WP_CLI::line( sprintf( "Processing post_id #%d (%s)", $post_id, get_the_title( $post_id ) ) );
-			WP_CLI::line( sprintf( "-- pushing to %s sites and deleting from %s sites", number_format( count( $sites['selected_sites'] ) ), number_format( count( $sites['removed_sites'] ) ) ) );
+		add_filter(
+			'syn_pre_push_post_sites',
+			function( $sites, $post_id, $slave_states ) {
+				WP_CLI::line( sprintf( 'Processing post_id #%d (%s)', $post_id, get_the_title( $post_id ) ) );
+				WP_CLI::line( sprintf( '-- pushing to %s sites and deleting from %s sites', number_format( count( $sites['selected_sites'] ) ), number_format( count( $sites['removed_sites'] ) ) ) );
 
-			return $sites;
-		}, 10, 3 );
+				return $sites;
+			},
+			10,
+			3
+		);
 
-		add_action( 'syn_post_push_new_post', function( $result, $post_ID, $site, $transport_type, $client, $info ) {
-			WP_CLI::line( sprintf( '-- Added remote post #%d (%s)', $post_ID, $site->post_title ) );
-		}, 10, 6 );
+		add_action(
+			'syn_post_push_new_post',
+			function( $result, $post_ID, $site, $transport_type, $client, $info ) {
+				WP_CLI::line( sprintf( '-- Added remote post #%d (%s)', $post_ID, $site->post_title ) );
+			},
+			10,
+			6
+		);
 
-		add_action( 'syn_post_push_edit_post', function( $result, $post_ID, $site, $transport_type, $client, $info ) {
-			WP_CLI::line( sprintf( '-- Updated remote post #%d (%s)', $post_ID, $site->post_title ) );
-		}, 10, 6 );
-
+		add_action(
+			'syn_post_push_edit_post',
+			function( $result, $post_ID, $site, $transport_type, $client, $info ) {
+				WP_CLI::line( sprintf( '-- Updated remote post #%d (%s)', $post_ID, $site->post_title ) );
+			},
+			10,
+			6
+		);
 	}
 
-	private function _get_syndication_server() {
+	private function get_syndication_server() {
 		return $GLOBALS['push_syndication_server'];
 	}
 
@@ -159,15 +207,17 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 
 		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
 
-		if ( !is_object( $wp_object_cache ) )
+		if ( ! is_object( $wp_object_cache ) ) {
 			return;
+		}
 
-		$wp_object_cache->group_ops = array();
-		$wp_object_cache->stats = array();
+		$wp_object_cache->group_ops      = array();
+		$wp_object_cache->stats          = array();
 		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache = array();
+		$wp_object_cache->cache          = array();
 
-		if ( is_callable( $wp_object_cache, '__remoteset' ) )
-			$wp_object_cache->__remoteset(); // important
+		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
+			$wp_object_cache->__remoteset(); // important!
+		}
 	}
 }

--- a/includes/interface-syndication-client.php
+++ b/includes/interface-syndication-client.php
@@ -4,55 +4,56 @@ interface Syndication_Client {
 
 	/**
 	 * Return Client Data
+	 *
 	 * @return array array( 'id' => (string) $transport_name, 'modes' => array( 'push', 'pull' ), 'name' => (string) $name );
 	 */
 	public static function get_client_data();
-	 
+
 	/**
 	 * Creates a new post in the slave site.
 	 *
-	 * @param   int  $post_ID  The post ID to push.
+	 * @param   int $post_id  The post ID to push.
 	 *
 	 * @return  boolean true on success false on failure.
 	 */
-	public function new_post( $post_ID );
+	public function new_post( $post_id );
 
 	/**
 	 * Edits an existing post in the slave site.
 	 *
-	 * @param   int  $post_ID  The post ID to push.
-	 * @param   int  $ext_ID   Slave post ID to edit.
+	 * @param   int $post_id  The post ID to push.
+	 * @param   int $ext_id   Slave post ID to edit.
 	 *
 	 * @return  boolean true on success false on failure.
 	 */
-	public function edit_post( $post_ID, $ext_ID );
+	public function edit_post( $post_id, $ext_id );
 
 	/**
 	 * Deletes an existing post in the slave site.
 	 *
-	 * @param   int  $ext_ID  Slave post ID to delete.
+	 * @param   int $ext_id  Slave post ID to delete.
 	 *
 	 * @return  boolean true on success false on failure.
 	 */
-	public function delete_post( $ext_ID );
+	public function delete_post( $ext_id );
 
-    /**
-     * Retrieves a single post from a slave site.
-     *
-     * @param   int  $ext_ID  Slave post ID to retrieve.
-     *
-     * @return  boolean true on success false on failure.
-     */
-    public function get_post( $ext_ID );
+	/**
+	 * Retrieves a single post from a slave site.
+	 *
+	 * @param   int $ext_id  Slave post ID to retrieve.
+	 *
+	 * @return  boolean true on success false on failure.
+	 */
+	public function get_post( $ext_id );
 
-    /**
-     * Retrieves a list of posts from a slave site.
-     *
-     * @param   array   $args  Arguments when retrieving posts.
-     *
-     * @return  boolean true on success false on failure.
-     */
-    public function get_posts( $args = array() );
+	/**
+	 * Retrieves a list of posts from a slave site.
+	 *
+	 * @param   array $args  Arguments when retrieving posts.
+	 *
+	 * @return  boolean true on success false on failure.
+	 */
+	public function get_posts( $args = array() );
 
 	/**
 	 * Test the connection with the slave site.
@@ -64,26 +65,26 @@ interface Syndication_Client {
 	/**
 	 * Checks whether the given post exists in the slave site.
 	 *
-	 * @param   int  $ext_ID  Slave post ID to check.
+	 * @param   int $ext_id  Slave post ID to check.
 	 *
 	 * @return  boolean  true on success false on failure.
 	 */
-	public function is_post_exists( $ext_ID );
+	public function is_post_exists( $ext_id );
 
 	/**
 	 * Display the client settings for the slave site.
 	 *
-	 * @param   object  $site  The site object to display settings.
+	 * @param   object $site  The site object to display settings.
 	 */
 	public static function display_settings( $site );
 
 	/**
 	 * Save the client settings for the slave site.
 	 *
-	 * @param   int  $site_ID  The site ID to save settings.
+	 * @param   int $site_id  The site ID to save settings.
 	 *
 	 * @return  boolean  true on success false on failure.
 	 */
-	public static function save_settings( $site_ID );
+	public static function save_settings( $site_id );
 
 }

--- a/includes/push-syndicate-encryption.php
+++ b/includes/push-syndicate-encryption.php
@@ -1,18 +1,72 @@
 <?php
 
-function push_syndicate_encrypt( $data ) {
+function push_syndicate_get_cipher() {
+	$cipher = 'aes-256-cbc';
 
-	$data = serialize( $data );
-	return base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_256, md5(PUSH_SYNDICATE_KEY), $data, MCRYPT_MODE_CBC, md5(md5(PUSH_SYNDICATE_KEY))));
+	if ( function_exists( 'mcrypt_encrypt' ) ) {
+		return MCRYPT_RIJNDAEL_256;
+	}
+
+	if ( in_array( $cipher, openssl_get_cipher_methods(), true ) ) {
+		return array(
+			'cipher' => $cipher,
+			'iv'     => substr( md5( md5( PUSH_SYNDICATE_KEY ) ), 0, 16 ),
+			'key'    => md5( PUSH_SYNDICATE_KEY ),
+		);
+	}
+
+	return false; // @TODO: return another default cipher? return exception?
+}
+
+function push_syndicate_encrypt( $data ) {
+	// @todo: replace mcrypt with openssl. problem: Rijndael AES is not available on openssl;s AES-256.
+	// Will most likely break backwards compatibility with older keys
+	// https://stackoverflow.com/questions/49997338/mcrypt-rijndael-256-to-openssl-aes-256-ecb-conversion
+
+	// Backwards compatibility with PHP < 7.2.
+	if ( function_exists( 'mcrypt_encrypt' ) ) {
+		// @codingStandardsIgnoreStart
+		$data = serialize( $data );
+		return base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_256, md5(PUSH_SYNDICATE_KEY), $data, MCRYPT_MODE_CBC, md5(md5(PUSH_SYNDICATE_KEY))));
+		// @codingStandardsIgnoreEnd
+	}
+
+	$data   = wp_json_encode( $data );
+	$cipher = push_syndicate_get_cipher();
+
+	if ( ! $cipher ) {
+		return $data;
+	}
+
+	$encrypted_data = openssl_encrypt( $data, $cipher['cipher'], $cipher['key'], 0, $cipher['iv'] );
+	return base64_encode( $encrypted_data ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 }
 
 function push_syndicate_decrypt( $data ) {
 
-	$data = rtrim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, md5(PUSH_SYNDICATE_KEY), base64_decode($data), MCRYPT_MODE_CBC, md5(md5(PUSH_SYNDICATE_KEY))), "\0");
-	if ( !$data )
+	// Backwards compatibility with PHP < 7.2.
+	if ( function_exists( 'mcrypt_encrypt' ) ) {
+		// @codingStandardsIgnoreStart
+		$data = rtrim( mcrypt_decrypt( MCRYPT_RIJNDAEL_256, md5( PUSH_SYNDICATE_KEY ), base64_decode( $data ), MCRYPT_MODE_CBC, md5( md5( PUSH_SYNDICATE_KEY ) ) ), "\0" );
+		if ( ! $data ) {
+			return false;
+		}
+		return @unserialize( $data );
+		// @codingStandardsIgnoreEnd
+	}
+
+	$cipher = push_syndicate_get_cipher();
+
+	if ( ! $cipher ) {
+		return $data;
+	}
+
+	$data = openssl_decrypt( base64_decode( $data ), $cipher['cipher'], $cipher['key'], 0, $cipher['iv'] ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+	if ( ! $data ) {
 		return false;
+	}
 
-	return @unserialize( $data );
-
+	return json_decode( $data );
 }

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -7,25 +7,28 @@
  * Author:       Automattic
  * Author URI:   http://automattic.com
  * License:      GPLv2 or later
+ * Text Domain:  push-syndication
  */
 
 define( 'SYNDICATION_VERSION', 2.0 );
 
-if ( ! defined( 'PUSH_SYNDICATE_KEY' ) )
+if ( ! defined( 'PUSH_SYNDICATE_KEY' ) ) {
 	define( 'PUSH_SYNDICATE_KEY', 'PUSH_SYNDICATE_KEY' );
+}
 
 /**
  * Load syndication logger
  */
-require_once( dirname( __FILE__ ) . '/includes/class-syndication-logger.php' );
+require_once dirname( __FILE__ ) . '/includes/class-syndication-logger.php';
 Syndication_Logger::init();
 
-require_once( dirname( __FILE__ ) . '/includes/class-wp-push-syndication-server.php' );
+require_once dirname( __FILE__ ) . '/includes/class-wp-push-syndication-server.php';
 
-if ( defined( 'WP_CLI' ) && WP_CLI )
-	require_once( dirname( __FILE__ ) . '/includes/class-wp-cli.php' );
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once dirname( __FILE__ ) . '/includes/class-wp-cli.php';
+}
 
-$GLOBALS['push_syndication_server'] = new WP_Push_Syndication_Server;
+$GLOBALS['push_syndication_server'] = new WP_Push_Syndication_Server();
 
 // Create the event counter.
 require __DIR__ . '/includes/class-syndication-event-counter.php';
@@ -35,6 +38,6 @@ new Syndication_Event_Counter();
 require __DIR__ . '/includes/class-syndication-site-failure-monitor.php';
 new Syndication_Site_Failure_Monitor();
 
-// Create the site auto retry functionality
+// Create the site auto retry functionality.
 require __DIR__ . '/includes/class-syndication-site-auto-retry.php';
 new Failed_Syndication_Auto_Retry();


### PR DESCRIPTION
Initial extensive PHPCS clean-up on the codebase. I tried to address all the WordPress standards where possible and ignored the ones that are valid use cases.

I didn't invest much time in the documentation warnings.

This PR is forked from #159, so it includes the OpenSSL implementation for encryption.

I also added a few TODOs along with the code where we should invest some time to improve (mostly missing nonces and class naming).

(WIP, `class-wp-push-syndication-server.php` is still untouched, and I need to pull the changes from #157)