### PR TITLE
Refresh Composer and tests, increase minimum support PHP and WP versions

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.4"
+          php-version: "latest"
           coverage: none
           tools: cs2pr
 
@@ -37,7 +37,7 @@ jobs:
         uses: korelstar/xmllint-problem-matcher@v1
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -13,33 +13,25 @@ on:
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
-    # Ubuntu-20.x includes MySQL 8.0, which causes `caching_sha2_password` issues with PHP < 7.4
-    # https://www.php.net/manual/en/mysqli.requirements.php
-    # TODO: change to ubuntu-latest when we no longer support PHP < 7.4
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       WP_VERSION: ${{ matrix.wordpress }}
 
     strategy:
       matrix:
-        wordpress: ["5.5", "5.6", "5.7"]
-        php: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4"]
+        wordpress: ["5.9", "6.4"]
+        php: ["7.4", "8.3"]
         include:
-          - php: "8.0"
-            # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-            composer-options: "--ignore-platform-reqs"
+          - php: "8.3"
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
-        exclude:
-          - php: "8.0"
-            wordpress: "5.5"
       fail-fast: false
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -51,15 +43,6 @@ jobs:
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-      # Setup PCOV since we're using PHPUnit < 8 which has it integrated. Requires PHP 7.1.
-      # Ignore platform reqs to make it install on PHP 8.
-      # https://github.com/krakjoe/pcov-clobber
-      - name: Setup PCOV
-        if: ${{ matrix.php == 8.0 }}
-        run: |
-          composer require pcov/clobber --ignore-platform-reqs
-          vendor/bin/pcov clobber
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -76,10 +59,10 @@ jobs:
         run: composer prepare-ci
 
       - name: Run integration tests (single site)
-        if: ${{ matrix.php != 8.0 }}
+        if: ${{ matrix.php != 8.2 }}
         run: composer test
       - name: Run integration tests (single site with code coverage)
-        if: ${{ matrix.php == 8.0 }}
+        if: ${{ matrix.php == 8.2 }}
         run: composer coverage-ci
       - name: Run integration tests (multisite)
         run: composer test-ms

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-composer.lock
+/.phpunit.cache
+/composer.lock
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,13 @@
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "^2.2",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+		"automattic/vipwpcs": "^3",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
-		"squizlabs/php_codesniffer": "^3.5",
-		"wp-coding-standards/wpcs": "^2.3.0",
-	  	"yoast/wp-test-utils": "^0.2.2"
+		"phpunit/phpunit": "^9",
+		"squizlabs/php_codesniffer": "^3.8",
+		"wp-coding-standards/wpcs": "^3.0",
+	  	"yoast/wp-test-utils": "^1.2"
 	},
 	"scripts": {
 		"cbf": [

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.4",
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,11 @@
 	"support": {
 		"issues": "https://github.com/Automattic/syndication/issues",
 		"source": "https://github.com/Automattic/syndication"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 			"bash bin/install-wp-tests.sh wordpress_test root root localhost"
 		],
 		"test": [
-			"@php ./vendor/bin/phpunit --testsuite WP_Tests"
+			"@php ./vendor/bin/phpunit --testsuite WP_Tests --no-coverage"
 		],
 		"test-ms": [
 			"@putenv WP_MULTISITE=1",

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -233,7 +233,7 @@ class Syndication_Logger {
  	 * @param  array  $extra    additional data
 	 */
 	private function log_post( $msg_type, $post_id, $status, $message, $log_time, $extra ) {
-		$this->log( $storage_type = 'object', $msg_type, $object_type = 'post', $object_id = $post_id, $status, $message, $log_time, $extra );
+		$this->log( $storage_type = 'object', $msg_type, 'post', $post_id, $status, $message, $log_time, $extra );
 	}
 
 	/**
@@ -248,7 +248,7 @@ class Syndication_Logger {
   	 * @param  array  $extra    	additional data
 	 * @return mixed                true or WP_Error
 	 */
-	private function log( $storage_type, $msg_type, $object_type = 'post', $object_id = '', $status, $message, $log_time, $extra ) {
+	private function log( $storage_type, $msg_type, $object_type, $object_id, $status, $message, $log_time, $extra ) {
 		// Don't log infos depending on debug level
 		if ( 'info' == $msg_type && 'info' != $this->debug_level ) {
 			return;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,32 @@
-<phpunit
-	bootstrap="tests/bootstrap.php"
-	backupGlobals="false"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         cacheResultFile=".phpunit.cache/test-results"
+		 colors="true"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
 	<php>
 		<const name="WP_TESTS_MULTISITE" value="1" />
 	</php>
-	<testsuites>
-		<testsuite name="WP_Tests">
-			<directory prefix="test-" suffix=".php">./tests/</directory>
-		</testsuite>
-	</testsuites>
+    <testsuites>
+        <testsuite name="WP_Tests">
+            <directory prefix="test-" suffix=".php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+			<file>push-syndication.php</file>
+            <directory suffix=".php">includes</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/class-encryptor-test-case.php
+++ b/tests/class-encryptor-test-case.php
@@ -16,7 +16,7 @@ abstract class EncryptorTestCase extends WPIntegrationTestCase {
 	/**
 	 * Runs before the test, set-up.
 	 */
-	public function setUp() {
+	public function set_up() {
 		$this->simple_string = 'this is a simple string!';
 		$this->complex_array = array(
 			'element' => 'this is a element',

--- a/tests/test-encryption.php
+++ b/tests/test-encryption.php
@@ -14,7 +14,7 @@ class EncryptionTest extends WPIntegrationTestCase {
 	/**
 	 * Runs before the test, set-up.
 	 */
-	public function setUp() {
+	public function set_up() {
 		$this->simple_string = 'this is a simple string!';
 		$this->complex_array = array(
 			'element' => 'this is a element',

--- a/tests/test-encryptor-mcrypt.php
+++ b/tests/test-encryptor-mcrypt.php
@@ -14,8 +14,8 @@ class EncryptorMCryptTest extends EncryptorTestCase {
 	/**
 	 * Runs before the test, set-up.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->encryptor = new \Syndication_Encryptor_MCrypt();
 
 		// Disable deprecation warning for this test, as it will run on PHP 7.1. This test will only ensure functionality of the
@@ -27,10 +27,10 @@ class EncryptorMCryptTest extends EncryptorTestCase {
 	/**
 	 * Runs after the test.
 	 */
-	public function tearDown() {
+	public function tear_down() {
 		// Restore original error reporting.
 		error_reporting( $this->error_reporting ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-encryptor-openssl.php
+++ b/tests/test-encryptor-openssl.php
@@ -11,8 +11,8 @@ class EncryptorOpenSSLTest extends EncryptorTestCase {
 	/**
 	 * Runs before the test, set-up.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->encryptor = new \Syndication_Encryptor_OpenSSL();
 	}


### PR DESCRIPTION
Refreshes the state of the tests a little, and increases the supported minimum PHP version to 7.4.

That said, it currently still includes mcrypt references (removed from PHP 7.2 but available as a PCL module), as I think that having post meta values encrypted with mcrypt, and then trying to decrypt with OpenSSL will fail, and I'm not sure of the consequences of that (duplicate syndications?).

Fixes #161.