### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        wordpress: ["5.9", "6.4"]
+        wordpress: ["6.4", "latest"]
         php: ["7.4", "8.3"]
         include:
           - php: "8.3"

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.5"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -4,6 +4,8 @@
  * Plugin URI:   http://wordpress.org/extend/plugins/push-syndication/
  * Description:  Syndicate content to and from your sites
  * Version:      2.0
+ * Requires at least: 6.4
+ * Requires PHP: 7.4
  * Author:       Automattic
  * Author URI:   http://automattic.com
  * License:      GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plugin Name ===
 Contributors: automattic, nprasath002, batmoo, betzster, nickdaugherty
 Tags: XMLRPC, WordPress.com REST
-Requires at least: 3.4
+Requires at least: 6.4
 Tested up to: 5.0
 Stable tag: 2.0
 License: GPLv2 or later


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.