### PR TITLE
feat: pass site ID to syn_rss_pull_filter_post filter

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -220,8 +220,18 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 				'post_category'     => $taxonomy['cats'],
 				'tags_input'        => $taxonomy['tags']
 			);
-			// This filter can be used to exclude or alter posts during a pull import
-			$post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item );
+			/**
+			 * Exclude or alter posts during an RSS syndication pull.
+			 *
+			 * Return an array of post data to save this post. Return false to exclude
+			 * this post.
+			 *
+			 * @param array          $post    The post data, as would be passed to wp_insert_post.
+			 * @param array          $args    The arguments passed to get_posts().
+			 * @param SimplePie_Item $item    A SimplePie item object.
+			 * @param int            $site_id The ID of the site post holding the feed data.
+			 */
+			$post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item, $this->site_ID );
 			if ( false === $post )
 				continue;
 			$posts[] = $post;


### PR DESCRIPTION
## Summary

- Adds the site ID as a fourth parameter to the `syn_rss_pull_filter_post` filter
- Enables filter callbacks to access site configuration when processing pulled posts
- Improves inline documentation with proper docblock format

Fixes #71
Supersedes #72

## Test plan

- [ ] Verify the filter receives the site ID as the fourth parameter
- [ ] Confirm existing filter callbacks continue to work (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)