### PR TITLE
chore: update version references from 2.1.0 to 2.2.0

### DIFF
--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -8,7 +8,7 @@
  *
  * @link https://wordpress.org/plugins/push-syndication/
  * @link https://github.com/Automattic/syndication/
- * @since 2.1.0
+ * @since 2.2.0
  *
  * @package WordPress
  * @subpackage Syndication


### PR DESCRIPTION
## Summary

- Updates `@since` tag from 2.1.0 to 2.2.0 in class-syndication-wp-xml-client.php
- Aligns with renamed milestone to avoid confusion with any previous WordPress.org releases

## Test plan

- [ ] Verify no other 2.1 references remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)