### PR TITLE
fix: prevent PHP warning when settings are null

### DIFF
--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -1223,10 +1223,18 @@ class WP_Push_Syndication_Server {
 
 	public function cron_add_pull_time_interval( $schedules ) {
 
+		// Only add custom interval if syndication settings are defined.
+		if (
+			empty( $this->push_syndicate_settings )
+			|| ! array_key_exists( 'pull_time_interval', $this->push_syndicate_settings )
+		) {
+			return $schedules;
+		}
+
 		// Adds the custom time interval to the existing schedules.
 		$schedules['syn_pull_time_interval'] = array(
-			'interval' => isset( $this->push_syndicate_settings ) ? intval( $this->push_syndicate_settings['pull_time_interval'] ) : 0,
-			'display' => __( 'Pull Time Interval', 'push-syndication' )
+			'interval' => intval( $this->push_syndicate_settings['pull_time_interval'] ),
+			'display'  => esc_html__( 'Pull Time Interval', 'push-syndication' ),
 		);
 
 		return $schedules;


### PR DESCRIPTION
## Problem

When another plugin calls `wp_get_schedules()` before the `init` hook fires, the Syndication plugin triggers a PHP warning because `$this->push_syndicate_settings` hasn't been initialised yet and is null. This happens in the `cron_add_pull_time_interval()` method when it attempts to access array keys on a null value.

Additionally, the existing code would register a cron schedule with an interval of 0 when settings weren't available, which serves no useful purpose.

## Solution

This change adds an early return guard in `cron_add_pull_time_interval()` that checks whether `$this->push_syndicate_settings` is empty or whether the `pull_time_interval` key exists before attempting to use it. If either condition is true, the method returns the schedules array unchanged, preventing both the PHP warning and the registration of a useless schedule.

The change also improves the existing code by adding proper output escaping (`esc_html__()`) to the display string, addressing a minor security consideration.

This implements the workaround suggested by @terriann.

Fixes #162