### PR TITLE
fix: resolve filtering and pagination issues in Syndication Logs screen

### DIFF
--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -181,7 +181,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		usort( $filtered_data, array( $this, 'usort_reorder' ) );
 
 		// Paginate the filtered and sorted data.
-		$per_page = $this->get_items_per_page( 'per_page' );
+		$per_page = $this->get_items_per_page( 'syndication_logs_per_page', 20 );
 		$current_page = $this->get_pagenum();
 		$total_items = count( $filtered_data );
 
@@ -287,6 +287,7 @@ class Syndication_Logger_Viewer {
 
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'add_menu_items' ) );
+		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
 	}
 
 	public function add_menu_items(){
@@ -294,11 +295,37 @@ class Syndication_Logger_Viewer {
 		add_action( "load-$hook", array( $this, 'initialize_list_table' ) );
 	}
 
+	/**
+	 * Save the screen option value when submitted.
+	 *
+	 * @param mixed  $status The current status (false by default).
+	 * @param string $option The option name.
+	 * @param mixed  $value  The option value.
+	 * @return mixed The value to save, or $status to skip saving.
+	 */
+	public function set_screen_option( $status, $option, $value ) {
+		if ( 'syndication_logs_per_page' === $option ) {
+			return absint( $value );
+		}
+		return $status;
+	}
+
 	public function initialize_list_table() {
 		if ( ! empty( $_POST['log_id'] ) && ( empty( $_GET['log_id'] ) || esc_attr( $_GET['log_id'] ) != esc_attr( $_POST['log_id'] ) ) ) {
 			wp_safe_redirect( add_query_arg( array( 'log_id' => esc_attr( $_REQUEST['log_id'] ) ), wp_unslash($_SERVER['REQUEST_URI'] ) ) );
 			exit;
 		}
+
+		// Add screen options for items per page.
+		add_screen_option(
+			'per_page',
+			array(
+				'label'   => __( 'Log entries', 'push-syndication' ),
+				'default' => 20,
+				'option'  => 'syndication_logs_per_page',
+			)
+		);
+
 		$this->syndication_logger_table = new Syndication_Logger_List_Table();
 	}
 


### PR DESCRIPTION
The Syndication Logs screen had two significant usability problems that made it difficult to navigate and filter large numbers of log entries. Filters were being applied after pagination had already occurred, which meant that the page counts were calculated against the full dataset rather than the filtered results. This led to scenarios where users would select a filter and be presented with empty pages or incorrect pagination controls. Additionally, there was a typo in the types dropdown that checked the wrong request parameter, preventing type filtering from working at all.

These issues arose because the original implementation calculated pagination based on the complete dataset before any filtering took place, and then attempted to apply filters to an already-paginated subset of data. This ordering meant that WordPress couldn't accurately determine how many pages of filtered results existed.

This pull request reorders the data processing pipeline so that filters are applied before pagination. The month and type filters now reduce the dataset first, and then pagination is calculated based on that filtered count. This ensures that the total items count, page calculations, and navigation controls all reflect the actual filtered results. The date dropdown continues to show all available months by calculating min/max dates from the unfiltered dataset, preserving discoverability of the full time range.

The second commit adds Screen Options support, allowing users to customise how many log entries appear per page (defaulting to 20). This brings the Syndication Logs interface in line with standard WordPress admin patterns like the Posts screen, making it more familiar and adaptable for users managing different volumes of syndication activity.

Closes #120