### PR TITLE
chore: PHPCS coding standards fixes

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,4 +1,5 @@
 # Directories
+/.claude/
 /.git/
 /.github/
 /.wordpress-org/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Exclude from release archives
+/.claude/              export-ignore
 /.github/              export-ignore
 /.wordpress-org/       export-ignore
 /bin/                  export-ignore

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -23,10 +23,10 @@ class Syndication_Logger_Admin_Notice {
 	/**
 	 * Create a admin notice
 	 *
-	 * @param text    $message_text       The message you would like to show
-	 * @param string  $message_type       A message type, shown alongside with your message and used to categorize and bundle messages of the same type
-	 * @param string  $class              css class applied to the notice eg. 'updated', 'error', 'update-nag'
-	 * @param boolean $summarize_multiple setting this to true allows summarizing messages of the same message_type into one message. The message text is then passed through the syn_message_text_multiple filter and all messages of this type can be dismissed at once
+	 * @param string  $message_text       The message you would like to show.
+	 * @param string  $message_type       A message type, shown alongside with your message and used to categorize and bundle messages of the same type.
+	 * @param string  $class              CSS class applied to the notice eg. 'updated', 'error', 'update-nag'.
+	 * @param boolean $summarize_multiple Setting this to true allows summarizing messages of the same message_type into one message. The message text is then passed through the syn_message_text_multiple filter and all messages of this type can be dismissed at once.
 	 */
 	public static function add_notice( $message_text, $message_type = 'Syndication', $class = 'updated', $summarize_multiple = false ) {
 		$notices = get_option( self::$notice_option );

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -125,7 +125,7 @@ class Syndication_Logger_Admin_Notice {
 	public static function handle_dismiss_syndication_notice() {
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
-		// add nonce
+		// Add nonce.
 		if ( isset( $_GET[ self::$dismiss_parameter ] ) && current_user_can( $capability ) ) {
 			$dismiss_key   = esc_attr( $_GET[ self::$dismiss_parameter ] );
 			$dismiss_nonce = esc_attr( $_GET['syn_dismiss_nonce'] );

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -5,7 +5,7 @@
  */
 class Syndication_Logger_Admin_Notice {
 
-	private static $notice_option = 'syn_notices';
+	private static $notice_option         = 'syn_notices';
 	private static $notice_bundles_option = 'syn_notice_bundles';
 
 	private static $dismiss_parameter = 'syn_dismiss';
@@ -17,6 +17,7 @@ class Syndication_Logger_Admin_Notice {
 
 	/**
 	 * Create a admin notice
+	 *
 	 * @param text    $message_text       The message you would like to show
 	 * @param string  $message_type       A message type, shown alongside with your message and used to categorize and bundle messages of the same type
 	 * @param string  $class              css class applied to the notice eg. 'updated', 'error', 'update-nag'
@@ -25,16 +26,16 @@ class Syndication_Logger_Admin_Notice {
 	public static function add_notice( $message_text, $message_type = 'Syndication', $class = 'updated', $summarize_multiple = false ) {
 		$notices = get_option( self::$notice_option );
 
-		$changed = false;
+		$changed     = false;
 		$message_key = md5( $message_type . $message_text );
-		if ( ! is_array( $notices ) || ! isset( $notices[$message_type] ) || ! isset( $notices[$message_type][$message_key] ) ) {
-			$notices[$message_type][$message_key] = array(
-				'message_text' => sanitize_text_field( $message_text ),
-				'summarize_multiple' => (boolean) $summarize_multiple,
-				'message_type' => sanitize_text_field( $message_type ),
-				'class' => sanitize_text_field( $class ),
+		if ( ! is_array( $notices ) || ! isset( $notices[ $message_type ] ) || ! isset( $notices[ $message_type ][ $message_key ] ) ) {
+			$notices[ $message_type ][ $message_key ] = array(
+				'message_text'       => sanitize_text_field( $message_text ),
+				'summarize_multiple' => (bool) $summarize_multiple,
+				'message_type'       => sanitize_text_field( $message_type ),
+				'class'              => sanitize_text_field( $class ),
 			);
-			$changed = true;
+			$changed                                  = true;
 		}
 
 		if ( true === $changed ) {
@@ -50,40 +51,40 @@ class Syndication_Logger_Admin_Notice {
 	public static function display_valid_notices() {
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
-		$messages = get_option( self::$notice_option );
-		$notice_bundles = get_option( self::$notice_bundles_option );
-		$messages_to_display = array();
+		$messages               = get_option( self::$notice_option );
+		$notice_bundles         = get_option( self::$notice_bundles_option );
+		$messages_to_display    = array();
 		$notice_bundles_changed = false;
 
-		if ( !is_array( $messages ) || empty( $messages ) ) {
+		if ( ! is_array( $messages ) || empty( $messages ) ) {
 			return;
 		}
 
-		foreach( $messages as $message_type => $message_values ) {
-			foreach( $message_values as $message_key => $message_data ) {
+		foreach ( $messages as $message_type => $message_values ) {
+			foreach ( $message_values as $message_key => $message_data ) {
 				if ( isset( $message_data['summarize_multiple'] ) && true === $message_data['summarize_multiple'] ) {
 					$message_text = apply_filters( 'syn_message_text_multiple', $message_data['message_text'], $message_data );
 				} else {
 					$message_text = apply_filters( 'syn_message_text', $message_data['message_text'], $message_data );
 				}
 
-				$new_message_key = md5( $message_type . $message_text );
+				$new_message_key  = md5( $message_type . $message_text );
 				$new_message_data = array(
-					'message_text' => sanitize_text_field( $message_text ),
-					'summarize_multiple' => (boolean) $message_data['summarize_multiple'],
-					'message_type' => sanitize_text_field( $message_data['message_type'] ),
-					'class' => sanitize_text_field( $message_data['class'] )
+					'message_text'       => sanitize_text_field( $message_text ),
+					'summarize_multiple' => (bool) $message_data['summarize_multiple'],
+					'message_type'       => sanitize_text_field( $message_data['message_type'] ),
+					'class'              => sanitize_text_field( $message_data['class'] ),
 				);
 
 				if ( $new_message_key != $message_key ) {
-					if ( ! isset( $notice_bundles[$new_message_key] ) || ! in_array( $message_key, $notice_bundles[$new_message_key] ) ) {
-						$notice_bundles[$new_message_key][] = $message_key;
-						$notice_bundles_changed = true;
+					if ( ! isset( $notice_bundles[ $new_message_key ] ) || ! in_array( $message_key, $notice_bundles[ $new_message_key ] ) ) {
+						$notice_bundles[ $new_message_key ][] = $message_key;
+						$notice_bundles_changed               = true;
 					}
 				}
 
 				if ( current_user_can( $capability ) ) {
-					$messages_to_display[$message_type][$new_message_key] = $new_message_data;
+					$messages_to_display[ $message_type ][ $new_message_key ] = $new_message_data;
 				}
 			}
 		}
@@ -92,20 +93,27 @@ class Syndication_Logger_Admin_Notice {
 			update_option( self::$notice_bundles_option, $notice_bundles );
 		}
 
-		foreach( $messages_to_display as $message_type => $message_values ) {
-			foreach( $message_values as $message_key => $message_data ) {
+		foreach ( $messages_to_display as $message_type => $message_values ) {
+			foreach ( $message_values as $message_key => $message_data ) {
 				$dismiss_nonce = wp_create_nonce( esc_attr( $message_key ) );
 				printf( '<div class="%s"><p>', esc_attr( $message_data['class'] ) );
 				echo wp_kses(
-				sprintf(
+					sprintf(
 					/* translators: 1: message type, 2: message text, 3: dismiss URL */
-					__( '%1$s : %2$s <a href="%3$s">Hide Notice</a>', 'push-syndication' ),
-					esc_html( $message_type ),
-					wp_kses_post( $message_data['message_text'] ),
-					esc_url( add_query_arg( array( self::$dismiss_parameter => esc_attr( $message_key ), 'syn_dismiss_nonce' => esc_attr( $dismiss_nonce ) ) ) )
-				),
-				array( 'a' => array( 'href' => array() ) )
-			);
+						__( '%1$s : %2$s <a href="%3$s">Hide Notice</a>', 'push-syndication' ),
+						esc_html( $message_type ),
+						wp_kses_post( $message_data['message_text'] ),
+						esc_url(
+							add_query_arg(
+								array(
+									self::$dismiss_parameter => esc_attr( $message_key ),
+									'syn_dismiss_nonce' => esc_attr( $dismiss_nonce ),
+								) 
+							) 
+						)
+					),
+					array( 'a' => array( 'href' => array() ) )
+				);
 				printf( '</p></div>' );
 			}
 		}
@@ -118,38 +126,36 @@ class Syndication_Logger_Admin_Notice {
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
 		// add nonce
-		if ( isset( $_GET[self::$dismiss_parameter] ) && current_user_can( $capability ) ) {
-
-			$dismiss_key = esc_attr( $_GET[self::$dismiss_parameter] );
+		if ( isset( $_GET[ self::$dismiss_parameter ] ) && current_user_can( $capability ) ) {
+			$dismiss_key   = esc_attr( $_GET[ self::$dismiss_parameter ] );
 			$dismiss_nonce = esc_attr( $_GET['syn_dismiss_nonce'] );
 			if ( ! wp_verify_nonce( $dismiss_nonce, $dismiss_key ) ) {
 				wp_die( esc_html__( 'Invalid security check', 'push-syndication' ) );
 			}
-			$messages = get_option( self::$notice_option );
+			$messages       = get_option( self::$notice_option );
 			$notice_bundles = get_option( self::$notice_bundles_option );
 
 			$dismiss_items = array();
-			if ( isset( $notice_bundles[$dismiss_key] ) ) {
-				$dismiss_items = $notice_bundles[$dismiss_key];
+			if ( isset( $notice_bundles[ $dismiss_key ] ) ) {
+				$dismiss_items = $notice_bundles[ $dismiss_key ];
 			} else {
 				$dismiss_items = array( $dismiss_key );
 			}
 
-			foreach( $messages as $message_type => $message_values ) {
+			foreach ( $messages as $message_type => $message_values ) {
 				$message_keys = array_keys( $message_values );
-				$dismiss_it = array_intersect( $message_keys, $dismiss_items );
-				foreach( $dismiss_it as $dismiss_it_key ) {
-					unset( $messages[$message_type][$dismiss_it_key] );
+				$dismiss_it   = array_intersect( $message_keys, $dismiss_items );
+				foreach ( $dismiss_it as $dismiss_it_key ) {
+					unset( $messages[ $message_type ][ $dismiss_it_key ] );
 				}
 			}
 
-			if ( isset( $notice_bundles[$dismiss_key] ) ) {
-				unset( $notice_bundles[$dismiss_key] );
+			if ( isset( $notice_bundles[ $dismiss_key ] ) ) {
+				unset( $notice_bundles[ $dismiss_key ] );
 			}
 
 			update_option( self::$notice_option, $messages );
 			update_option( self::$notice_bundles_option, $notice_bundles );
-
 		}
 	}
 }
@@ -161,5 +167,5 @@ function syn_handle_multiple_error_notices( $message, $message_data ) {
 
 add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10, 2 );
 function syn_add_site_disabled_notice( $site_id, $count ) {
-	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( __( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
+	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( __( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
 }

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -10,6 +10,11 @@ class Syndication_Logger_Admin_Notice {
 
 	private static $dismiss_parameter = 'syn_dismiss';
 
+	/**
+	 * Constructor.
+	 *
+	 * Registers admin hooks for handling and displaying syndication notices.
+	 */
 	public function __construct() {
 		add_action( 'admin_init', array( __CLASS__, 'handle_dismiss_syndication_notice' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'display_valid_notices' ) );
@@ -161,11 +166,24 @@ class Syndication_Logger_Admin_Notice {
 }
 
 add_filter( 'syn_message_text_multiple', 'syn_handle_multiple_error_notices', 10, 2 );
+/**
+ * Filter callback to handle multiple error notices.
+ *
+ * @param string $message      The original message text.
+ * @param array  $message_data Additional message data.
+ * @return string The filtered message text.
+ */
 function syn_handle_multiple_error_notices( $message, $message_data ) {
 	return __( 'There have been multiple errors. Please validate your syndication logs' );
 }
 
 add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10, 2 );
+/**
+ * Display an admin notice when a syndication site is disabled.
+ *
+ * @param int $site_id The ID of the disabled site.
+ * @param int $count   The number of failed pull attempts.
+ */
 function syn_add_site_disabled_notice( $site_id, $count ) {
 	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( __( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
 }

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Admin notices handler for syndication plugin.
+ *
+ * @package Syndication
+ */
 
 /**
- * Class to handle Admin notices for dismissable user notifications
+ * Class Syndication_Logger_Admin_Notice
+ *
+ * Handles dismissable admin notices for user notifications related to
+ * syndication events, errors, and status updates.
  */
 class Syndication_Logger_Admin_Notice {
 

--- a/includes/class-syndication-client-factory.php
+++ b/includes/class-syndication-client-factory.php
@@ -1,10 +1,21 @@
 <?php
+/**
+ * Factory for creating syndication client instances.
+ *
+ * @package Syndication
+ */
 
 require_once __DIR__ . '/class-syndication-wp-xmlrpc-client.php';
 require_once __DIR__ . '/class-syndication-wp-xml-client.php';
 require_once __DIR__ . '/class-syndication-wp-rest-client.php';
 require_once __DIR__ . '/class-syndication-wp-rss-client.php';
 
+/**
+ * Class Syndication_Client_Factory
+ *
+ * Creates syndication client instances based on transport type.
+ * Supports XML-RPC, REST API, RSS, and XML feed transports.
+ */
 class Syndication_Client_Factory {
 
 	/**

--- a/includes/class-syndication-client-factory.php
+++ b/includes/class-syndication-client-factory.php
@@ -1,47 +1,43 @@
 <?php
 
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-xmlrpc-client.php' );
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-xml-client.php' );
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-rest-client.php' );
-include_once( dirname( __FILE__ ) . '/class-syndication-wp-rss-client.php' );
+require_once __DIR__ . '/class-syndication-wp-xmlrpc-client.php';
+require_once __DIR__ . '/class-syndication-wp-xml-client.php';
+require_once __DIR__ . '/class-syndication-wp-rest-client.php';
+require_once __DIR__ . '/class-syndication-wp-rss-client.php';
 
 class Syndication_Client_Factory {
 
 	public static function get_client( $transport_type, $site_ID ) {
 
 		$class = self::get_transport_type_class( $transport_type );
-		if( class_exists( $class ) ) {
+		if ( class_exists( $class ) ) {
 			return new $class( $site_ID );
 		}
 
-		throw new Exception(' transport class not found' );
-
+		throw new Exception( ' transport class not found' );
 	}
 
 	public static function display_client_settings( $site, $transport_type ) {
 
 		$class = self::get_transport_type_class( $transport_type );
-		if( class_exists( $class ) ) {
+		if ( class_exists( $class ) ) {
 			return call_user_func( array( $class, 'display_settings' ), $site );
 		}
 
 		throw new Exception( 'transport class not found: ' . esc_html( $class ) );
-
 	}
 
 	public static function save_client_settings( $site_ID, $transport_type ) {
 
 		$class = self::get_transport_type_class( $transport_type );
-		if( class_exists( $class ) ) {
+		if ( class_exists( $class ) ) {
 			return call_user_func( array( $class, 'save_settings' ), $site_ID );
 		}
 
 		throw new Exception( 'transport class not found' );
-
 	}
 
 	public static function get_transport_type_class( $transport_type ) {
 		return 'Syndication_' . $transport_type . '_Client';
 	}
-
 }

--- a/includes/class-syndication-client-factory.php
+++ b/includes/class-syndication-client-factory.php
@@ -7,6 +7,14 @@ require_once __DIR__ . '/class-syndication-wp-rss-client.php';
 
 class Syndication_Client_Factory {
 
+	/**
+	 * Get a syndication client instance for the given transport type.
+	 *
+	 * @param string $transport_type The transport type (e.g., 'WP_XMLRPC', 'WP_REST').
+	 * @param int    $site_ID        The site post ID.
+	 * @return Syndication_Client The client instance.
+	 * @throws Exception If the transport class is not found.
+	 */
 	public static function get_client( $transport_type, $site_ID ) {
 
 		$class = self::get_transport_type_class( $transport_type );
@@ -17,6 +25,14 @@ class Syndication_Client_Factory {
 		throw new Exception( ' transport class not found' );
 	}
 
+	/**
+	 * Display the settings form for a client type.
+	 *
+	 * @param WP_Post $site           The site post object.
+	 * @param string  $transport_type The transport type.
+	 * @return mixed The result of the display_settings call.
+	 * @throws Exception If the transport class is not found.
+	 */
 	public static function display_client_settings( $site, $transport_type ) {
 
 		$class = self::get_transport_type_class( $transport_type );
@@ -27,6 +43,14 @@ class Syndication_Client_Factory {
 		throw new Exception( 'transport class not found: ' . esc_html( $class ) );
 	}
 
+	/**
+	 * Save the settings for a client type.
+	 *
+	 * @param int    $site_ID        The site post ID.
+	 * @param string $transport_type The transport type.
+	 * @return mixed The result of the save_settings call.
+	 * @throws Exception If the transport class is not found.
+	 */
 	public static function save_client_settings( $site_ID, $transport_type ) {
 
 		$class = self::get_transport_type_class( $transport_type );
@@ -37,6 +61,12 @@ class Syndication_Client_Factory {
 		throw new Exception( 'transport class not found' );
 	}
 
+	/**
+	 * Get the class name for a transport type.
+	 *
+	 * @param string $transport_type The transport type.
+	 * @return string The fully qualified class name.
+	 */
 	public static function get_transport_type_class( $transport_type ) {
 		return 'Syndication_' . $transport_type . '_Client';
 	}

--- a/includes/class-syndication-encryption.php
+++ b/includes/class-syndication-encryption.php
@@ -43,5 +43,4 @@ class Syndication_Encryption {
 	public function decrypt( $data, $associative = true ) {
 		return $this->encryptor->decrypt( $data, $associative );
 	}
-
 }

--- a/includes/class-syndication-encryption.php
+++ b/includes/class-syndication-encryption.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Encryption facade for syndication data.
+ *
+ * @package Syndication
+ */
 
 /**
  * Class Syndication_Encryption
+ *
+ * Provides a facade for encryption operations, delegating to a configured
+ * Syndication_Encryptor implementation (OpenSSL or MCrypt).
  */
 class Syndication_Encryption {
 

--- a/includes/class-syndication-encryptor-mcrypt.php
+++ b/includes/class-syndication-encryptor-mcrypt.php
@@ -6,7 +6,11 @@
 class Syndication_Encryptor_MCrypt implements Syndication_Encryptor {
 
 	/**
-	 * @inheritDoc
+	 * Encrypts data using MCrypt.
+	 *
+	 * @param mixed $data Data to encrypt.
+	 *
+	 * @return string Encrypted data.
 	 */
 	public function encrypt( $data ) {
 		$data = serialize( $data ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
@@ -15,7 +19,12 @@ class Syndication_Encryptor_MCrypt implements Syndication_Encryptor {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Decrypts data using MCrypt.
+	 *
+	 * @param string $data        Encrypted data to decrypt.
+	 * @param bool   $associative Unused parameter for interface compatibility.
+	 *
+	 * @return mixed|false Decrypted data or false on failure.
 	 */
 	public function decrypt( $data, $associative = true ) {
 		// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_decryptDeprecatedRemoved,PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved,PHPCompatibility.Constants.RemovedConstants.mcrypt_rijndael_256DeprecatedRemoved,PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_cbcDeprecatedRemoved
@@ -28,7 +37,9 @@ class Syndication_Encryptor_MCrypt implements Syndication_Encryptor {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Gets the cipher constant.
+	 *
+	 * @return int MCrypt cipher constant.
 	 */
 	public function get_cipher() {
 		return MCRYPT_RIJNDAEL_256; // phpcs:ignore PHPCompatibility.Constants.RemovedConstants.mcrypt_rijndael_256DeprecatedRemoved

--- a/includes/class-syndication-encryptor-mcrypt.php
+++ b/includes/class-syndication-encryptor-mcrypt.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * MCrypt encryption implementation for syndication data.
+ *
+ * @package Syndication
+ */
 
 /**
  * Class Syndication_Encryptor_MCrypt
+ *
+ * Provides encryption and decryption using the deprecated MCrypt extension.
+ * This class is maintained for backwards compatibility with older PHP versions.
+ *
+ * @deprecated MCrypt was deprecated in PHP 7.1 and removed in PHP 7.2.
+ * @see Syndication_Encryptor_OpenSSL For the recommended encryption implementation.
  */
 class Syndication_Encryptor_MCrypt implements Syndication_Encryptor {
 

--- a/includes/class-syndication-encryptor-openssl.php
+++ b/includes/class-syndication-encryptor-openssl.php
@@ -13,7 +13,11 @@ class Syndication_Encryptor_OpenSSL implements Syndication_Encryptor {
 	private $cipher = 'aes-256-cbc';
 
 	/**
-	 * @inheritDoc
+	 * Encrypts data using OpenSSL.
+	 *
+	 * @param mixed $data Data to encrypt.
+	 *
+	 * @return string Encrypted data.
 	 */
 	public function encrypt( $data ) {
 		$data   = wp_json_encode( $data );
@@ -28,7 +32,12 @@ class Syndication_Encryptor_OpenSSL implements Syndication_Encryptor {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Decrypts data using OpenSSL.
+	 *
+	 * @param string $data        Encrypted data to decrypt.
+	 * @param bool   $associative Whether to return associative array. Default true.
+	 *
+	 * @return mixed|false Decrypted data or false on failure.
 	 */
 	public function decrypt( $data, $associative = true ) {
 		$cipher = $this->get_cipher();
@@ -47,7 +56,9 @@ class Syndication_Encryptor_OpenSSL implements Syndication_Encryptor {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Gets the cipher configuration.
+	 *
+	 * @return array|false Cipher configuration array or false if cipher unavailable.
 	 */
 	public function get_cipher() {
 		if ( in_array( $this->cipher, openssl_get_cipher_methods(), true ) ) {

--- a/includes/class-syndication-encryptor-openssl.php
+++ b/includes/class-syndication-encryptor-openssl.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * OpenSSL encryption implementation for syndication data.
+ *
+ * @package Syndication
+ */
 
 /**
  * Class Syndication_Encryptor_OpenSSL
+ *
+ * Provides encryption and decryption using the OpenSSL extension.
+ * This is the recommended encryption implementation for PHP 7.2+.
  */
 class Syndication_Encryptor_OpenSSL implements Syndication_Encryptor {
 

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -19,18 +19,18 @@ class Syndication_Event_Counter {
 	/**
 	 * Increments an event counter.
 	 *
-	 * @param string $event_slug An identifier for the event.
+	 * @param string     $event_slug An identifier for the event.
 	 * @param string|int $event_object_id An identifier for the object the event is associated with. Should be unique across all objects associated with the given $event_slug.
 	 */
 	public function count_event( $event_slug, $event_object_id = null ) {
 		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
-		$event_slug = (string) $event_slug;
+		$event_slug      = (string) $event_slug;
 		$event_object_id = (string) $event_object_id;
 
 		// Increment the event counter.
 		$option_name = $this->_get_safe_option_name( $event_slug, $event_object_id );
-		$count = get_option( $option_name, 0 );
-		$count = $count + 1;
+		$count       = get_option( $option_name, 0 );
+		$count       = $count + 1;
 		update_option( $option_name, $count );
 
 		/**
@@ -61,7 +61,7 @@ class Syndication_Event_Counter {
 	 */
 	public function reset_event( $event_slug, $event_object_id ) {
 		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
-		$event_slug = (string) $event_slug;
+		$event_slug      = (string) $event_slug;
 		$event_object_id = (string) $event_object_id;
 
 		delete_option( $this->_get_safe_option_name( $event_slug, $event_object_id ) );

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -4,7 +4,6 @@
  *
  * This allows for generic events to be captured and counted. Use the push_syndication_event and push_syndication_reset_event actions to capture and reset counters. Use push_syndication_after_event to handle events once they've occurred, and to see the number of times the event has occurred.
  */
-
 class Syndication_Event_Counter {
 
 	/**

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -56,8 +56,8 @@ class Syndication_Event_Counter {
 	/**
 	 * Resets an event counter.
 	 *
-	 * @param $event_slug
-	 * @param $event_object_id
+	 * @param string     $event_slug      An identifier for the event.
+	 * @param string|int $event_object_id An identifier for the object the event is associated with.
 	 */
 	public function reset_event( $event_slug, $event_object_id ) {
 		// Coerce the slug and ID to strings. PHP will fire appropriate warnings if the given slug and ID are not coercible.
@@ -70,11 +70,14 @@ class Syndication_Event_Counter {
 	/**
 	 * Creates a safe option name for the event counter options.
 	 *
-	 * The main thing this does is make sure that the option name does not exceed the limit of 64 characters, regardless of the length of $event_slug and $event_object_id. The downside here is that we cannot easily determine which options belong to which slugs when examine the option names directly.
+	 * The main thing this does is make sure that the option name does not exceed the limit of 64 characters,
+	 * regardless of the length of $event_slug and $event_object_id. The downside here is that we cannot easily
+	 * determine which options belong to which slugs when examine the option names directly.
 	 *
-	 * @param $event_slug
-	 * @param $event_object_id
-	 * @return string
+	 * @param string     $event_slug      An identifier for the event.
+	 * @param string|int $event_object_id An identifier for the object the event is associated with.
+	 *
+	 * @return string Safe option name.
 	 */
 	protected function _get_safe_option_name( $event_slug, $event_object_id ) {
 		return 'push_syndication_event_counter_' . md5( $event_slug . $event_object_id );

--- a/includes/class-syndication-event-counter.php
+++ b/includes/class-syndication-event-counter.php
@@ -1,8 +1,17 @@
 <?php
 /**
- * Event Counter
+ * Event counter for syndication tracking.
  *
- * This allows for generic events to be captured and counted. Use the push_syndication_event and push_syndication_reset_event actions to capture and reset counters. Use push_syndication_after_event to handle events once they've occurred, and to see the number of times the event has occurred.
+ * @package Syndication
+ */
+
+/**
+ * Class Syndication_Event_Counter
+ *
+ * Captures and counts generic syndication events. Use the push_syndication_event
+ * and push_syndication_reset_event actions to capture and reset counters.
+ * Use push_syndication_after_event to handle events once they've occurred
+ * and to see the number of times the event has occurred.
  */
 class Syndication_Event_Counter {
 

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -1,9 +1,20 @@
 <?php
+/**
+ * Log viewer for syndication events.
+ *
+ * @package Syndication
+ */
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
+/**
+ * Class Syndication_Logger_List_Table
+ *
+ * Extends WP_List_Table to display syndication log entries in the WordPress
+ * admin interface, with filtering, sorting, and pagination support.
+ */
 class Syndication_Logger_List_Table extends WP_List_Table {
 
 	public $prepared_data = array();

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -1,7 +1,7 @@
 <?php
 
-if( ! class_exists( 'WP_List_Table' ) ) {
-	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 class Syndication_Logger_List_Table extends WP_List_Table {
@@ -16,22 +16,25 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 
 	protected $_max_date = null;
 
-	public function __construct(){
+	public function __construct() {
 		global $status, $page;
 
-		parent::__construct( array(
-			'singular'  => __( 'log', 'push-syndication' ),
-			'plural'    => __( 'logs', 'push-syndication' ),
-			'ajax'      => false
-		) );
+		parent::__construct(
+			array(
+				'singular' => __( 'log', 'push-syndication' ),
+				'plural'   => __( 'logs', 'push-syndication' ),
+				'ajax'     => false,
+			) 
+		);
 
 		add_action( 'admin_head', array( $this, 'admin_header' ) );
 	}
 
 	public function admin_header() {
 		$current_page = ( isset( $_GET['page'] ) ) ? (int) $_GET['page'] : false;
-		if( 'syndication_dashboard' != $current_page )
+		if ( 'syndication_dashboard' != $current_page ) {
 			return;
+		}
 
 		?>
 		<style type="text/css">
@@ -50,7 +53,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	}
 
 	public function column_default( $item, $column_name ) {
-		switch( $column_name ) {
+		switch ( $column_name ) {
 			case 'object_id':
 			case 'log_id':
 			case 'time':
@@ -66,37 +69,37 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 
 	public function get_sortable_columns() {
 		$sortable_columns = array(
-			'object_id' => array( 'object_id',	false ),
-			'log_id'	=> array( 'log_id', 	false ),
-			'time'		=> array( 'time', 		false ),
-			'msg_type' 	=> array( 'msg_type',	false ),
-			'message'  	=> array( 'message', 	false ),
-			'status'   	=> array( 'status',		false )
-			);
+			'object_id' => array( 'object_id', false ),
+			'log_id'    => array( 'log_id', false ),
+			'time'      => array( 'time', false ),
+			'msg_type'  => array( 'msg_type', false ),
+			'message'   => array( 'message', false ),
+			'status'    => array( 'status', false ),
+		);
 		return $sortable_columns;
 	}
 
-	public function get_columns(){
+	public function get_columns() {
 		$columns = array(
-			'object_id'	=> __( 'Object ID', 'push-syndication' ),
-			'log_id'	=> __( 'Log ID', 	'push-syndication' ),
-			'time'		=> __( 'Time', 		'push-syndication' ),
-			'msg_type'	=> __( 'Type', 		'push-syndication' ),
-			'status'	=> __( 'Status', 	'push-syndication' ),
-			'message'	=> __( 'Message', 	'push-syndication' ),
-			);
+			'object_id' => __( 'Object ID', 'push-syndication' ),
+			'log_id'    => __( 'Log ID', 'push-syndication' ),
+			'time'      => __( 'Time', 'push-syndication' ),
+			'msg_type'  => __( 'Type', 'push-syndication' ),
+			'status'    => __( 'Status', 'push-syndication' ),
+			'message'   => __( 'Message', 'push-syndication' ),
+		);
 		return $columns;
 	}
 
 	public function usort_reorder( $a, $b ) {
 		$orderby = ( ! empty( $_GET['orderby'] ) ) ? esc_attr( $_GET['orderby'] ) : 'time';
-		$order = ( ! empty($_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc';
-		$result = strcmp( $a[$orderby], $b[$orderby] );
+		$order   = ( ! empty( $_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc';
+		$result  = strcmp( $a[ $orderby ], $b[ $orderby ] );
 		return ( $order === 'asc' ) ? $result : -$result;
 	}
 
-	public function column_log_id($item){
-		return sprintf('%1$s', substr( $item['log_id'], 0, 3 ) . '&hellip;' . substr( $item['log_id'], -3 ) );
+	public function column_log_id( $item ) {
+		return sprintf( '%1$s', substr( $item['log_id'], 0, 3 ) . '&hellip;' . substr( $item['log_id'], -3 ) );
 	}
 
 	public function get_bulk_actions() {
@@ -112,34 +115,34 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	 * reflects the filtered result count accurately.
 	 */
 	public function prepare_items() {
-		$columns  = $this->get_columns();
-		$hidden   = array();
-		$sortable = $this->get_sortable_columns();
+		$columns               = $this->get_columns();
+		$hidden                = array();
+		$sortable              = $this->get_sortable_columns();
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 
-		$log_id = ( isset( $_REQUEST['log_id'] ) ) ? esc_attr( $_REQUEST['log_id'] ) : null;
-		$msg_type = null;
-		$object_id = null;
-		$object_type = 'post';
-		$log_status = null;
-		$date_start = null;
-		$date_end = null;
-		$message = null;
+		$log_id       = ( isset( $_REQUEST['log_id'] ) ) ? esc_attr( $_REQUEST['log_id'] ) : null;
+		$msg_type     = null;
+		$object_id    = null;
+		$object_type  = 'post';
+		$log_status   = null;
+		$date_start   = null;
+		$date_end     = null;
+		$message      = null;
 		$storage_type = 'object';
 
 		$log_data = Syndication_Logger::instance()->get_messages(
-				$log_id,
-				$msg_type,
-				$object_id,
-				$object_type,
-				$log_status,
-				$date_start,
-				$date_end,
-				$message,
-				$storage_type
+			$log_id,
+			$msg_type,
+			$object_id,
+			$object_type,
+			$log_status,
+			$date_start,
+			$date_end,
+			$message,
+			$storage_type
 		);
 
-		foreach( $log_data as $site_id => $log_items ) {
+		foreach ( $log_data as $site_id => $log_items ) {
 			$this->prepared_data = array_merge( $this->prepared_data, $log_items );
 		}
 
@@ -147,9 +150,12 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		if ( $this->prepared_data ) {
 			$items_sorted_by_time = $this->prepared_data;
 
-			usort( $items_sorted_by_time, function ( $a, $b ) {
-				return strtotime( $a['time'] ) - strtotime( $b['time'] );
-			} );
+			usort(
+				$items_sorted_by_time,
+				function ( $a, $b ) {
+					return strtotime( $a['time'] ) - strtotime( $b['time'] );
+				} 
+			);
 
 			$this->_max_date = strtotime( end( $items_sorted_by_time )['time'] );
 			$this->_min_date = strtotime( reset( $items_sorted_by_time )['time'] );
@@ -161,17 +167,23 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		// Filter by month.
 		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null;
 		if ( $requested_month ) {
-			$filtered_data = array_filter( $filtered_data, function ( $item ) use ( $requested_month ) {
-				return date( 'Y-m', strtotime( $item['time'] ) ) === $requested_month;
-			} );
+			$filtered_data = array_filter(
+				$filtered_data,
+				function ( $item ) use ( $requested_month ) {
+					return date( 'Y-m', strtotime( $item['time'] ) ) === $requested_month;
+				} 
+			);
 		}
 
 		// Filter by type.
 		$requested_type = isset( $_REQUEST['type'] ) ? esc_attr( $_REQUEST['type'] ) : null;
 		if ( $requested_type ) {
-			$filtered_data = array_filter( $filtered_data, function ( $item ) use ( $requested_type ) {
-				return $requested_type === $item['msg_type'];
-			} );
+			$filtered_data = array_filter(
+				$filtered_data,
+				function ( $item ) use ( $requested_type ) {
+					return $requested_type === $item['msg_type'];
+				} 
+			);
 		}
 
 		// Re-index array after filtering.
@@ -181,16 +193,18 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		usort( $filtered_data, array( $this, 'usort_reorder' ) );
 
 		// Paginate the filtered and sorted data.
-		$per_page = $this->get_items_per_page( 'syndication_logs_per_page', 20 );
+		$per_page     = $this->get_items_per_page( 'syndication_logs_per_page', 20 );
 		$current_page = $this->get_pagenum();
-		$total_items = count( $filtered_data );
+		$total_items  = count( $filtered_data );
 
 		$this->found_data = array_slice( $filtered_data, ( ( $current_page - 1 ) * $per_page ), $per_page );
 
-		$this->set_pagination_args( array(
-			'total_items' => $total_items,
-			'per_page'    => $per_page
-		) );
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+			) 
+		);
 		$this->items = $this->found_data;
 	}
 
@@ -198,8 +212,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		?>
 		<div class="alignleft actions">
 			<?php
-			if ( 'top' == $which && !is_singular() ) {
-
+			if ( 'top' == $which && ! is_singular() ) {
 				$this->create_log_id_dropdown();
 				$this->_create_months_dropdown();
 				$this->_create_types_dropdown();
@@ -221,12 +234,14 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 			<?php
 			$log_ids = array();
 			foreach ( $this->prepared_data as $row ) {
-				if ( 0 == $row['log_id'] )
+				if ( 0 == $row['log_id'] ) {
 					continue;
+				}
 
 				$log_id = esc_attr( $row['log_id'] );
-				if ( ! isset( $log_ids[$log_id] ) ) {
-					$log_ids[$log_id] = sprintf( "<option %s value='%s'>%s</option>\n",
+				if ( ! isset( $log_ids[ $log_id ] ) ) {
+					$log_ids[ $log_id ] = sprintf(
+						"<option %s value='%s'>%s</option>\n",
 						selected( $requested_log_id, $log_id, false ),
 						esc_attr( $log_id ),
 						esc_attr( $this->column_log_id( $row ) )
@@ -252,9 +267,10 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 			<?php
 			if ( $this->_min_date && $this->_max_date ) {
 				$month_pointer = new DateTime( '@' . $this->_min_date );
-				$max_month = new DateTime( '@' . $this->_max_date );
+				$max_month     = new DateTime( '@' . $this->_max_date );
 
-				while ( $month_pointer <= $max_month ) { ?>
+				while ( $month_pointer <= $max_month ) { 
+					?>
 					<option
 						value='<?php echo esc_attr( $month_pointer->format( 'Y-m' ) ); ?>' <?php selected( $requested_month, $month_pointer->format( 'Y-m' ) ); ?>><?php echo esc_html( $month_pointer->format( 'F Y' ) ); ?></option>
 					<?php
@@ -272,7 +288,13 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-type">Filter by type</label>
 		<select name="type" id="filter-by-type">
 			<option value="">All types</option>
-			<?php foreach( array( 'success' => 'Success', 'info' => 'Information', 'error' => 'Error' ) as $key => $label ): ?>
+			<?php 
+			foreach ( array(
+				'success' => 'Success',
+				'info'    => 'Information',
+				'error'   => 'Error',
+			) as $key => $label ) : 
+				?>
 				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $requested_type, $key ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
@@ -290,7 +312,7 @@ class Syndication_Logger_Viewer {
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
 	}
 
-	public function add_menu_items(){
+	public function add_menu_items() {
 		$hook = add_submenu_page( 'edit.php?post_type=syn_site', 'Logs', 'Logs', 'activate_plugins', 'syndication_dashboard', array( $this, 'render_list_page' ) );
 		add_action( "load-$hook", array( $this, 'initialize_list_table' ) );
 	}
@@ -312,7 +334,7 @@ class Syndication_Logger_Viewer {
 
 	public function initialize_list_table() {
 		if ( ! empty( $_POST['log_id'] ) && ( empty( $_GET['log_id'] ) || esc_attr( $_GET['log_id'] ) != esc_attr( $_POST['log_id'] ) ) ) {
-			wp_safe_redirect( add_query_arg( array( 'log_id' => esc_attr( $_REQUEST['log_id'] ) ), wp_unslash($_SERVER['REQUEST_URI'] ) ) );
+			wp_safe_redirect( add_query_arg( array( 'log_id' => esc_attr( $_REQUEST['log_id'] ) ), wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 			exit;
 		}
 
@@ -329,7 +351,7 @@ class Syndication_Logger_Viewer {
 		$this->syndication_logger_table = new Syndication_Logger_List_Table();
 	}
 
-	public function render_list_page(){
+	public function render_list_page() {
 		?>
 		<div class="wrap"><h2><?php esc_html_e( 'Syndication Logs', 'push-syndication' ); ?></h2>
 			<?php

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -16,6 +16,11 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 
 	protected $_max_date = null;
 
+	/**
+	 * Constructor.
+	 *
+	 * Sets up the list table and registers admin hooks.
+	 */
 	public function __construct() {
 		global $status, $page;
 
@@ -30,6 +35,9 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		add_action( 'admin_head', array( $this, 'admin_header' ) );
 	}
 
+	/**
+	 * Output CSS styles for the log list table columns.
+	 */
 	public function admin_header() {
 		$current_page = ( isset( $_GET['page'] ) ) ? (int) $_GET['page'] : false;
 		if ( 'syndication_dashboard' != $current_page ) {
@@ -48,10 +56,20 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
+	/**
+	 * Display a message when no log items are found.
+	 */
 	public function no_items() {
 		esc_html_e( 'No log entries found.', 'push-syndication' );
 	}
 
+	/**
+	 * Render the default column output.
+	 *
+	 * @param array  $item        The current log item.
+	 * @param string $column_name The column name being rendered.
+	 * @return string The column value or debug output.
+	 */
 	public function column_default( $item, $column_name ) {
 		switch ( $column_name ) {
 			case 'object_id':
@@ -67,6 +85,11 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		}
 	}
 
+	/**
+	 * Get the list of sortable columns.
+	 *
+	 * @return array Associative array of sortable column data.
+	 */
 	public function get_sortable_columns() {
 		$sortable_columns = array(
 			'object_id' => array( 'object_id', false ),
@@ -79,6 +102,11 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		return $sortable_columns;
 	}
 
+	/**
+	 * Get the list of columns for the table.
+	 *
+	 * @return array Associative array of column names and labels.
+	 */
 	public function get_columns() {
 		$columns = array(
 			'object_id' => __( 'Object ID', 'push-syndication' ),
@@ -91,6 +119,13 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		return $columns;
 	}
 
+	/**
+	 * Custom sorting callback for log items.
+	 *
+	 * @param array $a First item to compare.
+	 * @param array $b Second item to compare.
+	 * @return int Comparison result.
+	 */
 	public function usort_reorder( $a, $b ) {
 		$orderby = ( ! empty( $_GET['orderby'] ) ) ? esc_attr( $_GET['orderby'] ) : 'time';
 		$order   = ( ! empty( $_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc';
@@ -98,10 +133,21 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		return ( $order === 'asc' ) ? $result : -$result;
 	}
 
+	/**
+	 * Render the log_id column with truncation.
+	 *
+	 * @param array $item The current log item.
+	 * @return string The truncated log ID.
+	 */
 	public function column_log_id( $item ) {
 		return sprintf( '%1$s', substr( $item['log_id'], 0, 3 ) . '&hellip;' . substr( $item['log_id'], -3 ) );
 	}
 
+	/**
+	 * Get the list of bulk actions available for this table.
+	 *
+	 * @return array Empty array as no bulk actions are supported.
+	 */
 	public function get_bulk_actions() {
 		$actions = array();
 		return $actions;
@@ -208,6 +254,11 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		$this->items = $this->found_data;
 	}
 
+	/**
+	 * Output extra table navigation controls.
+	 *
+	 * @param string $which The location of the extra table nav ('top' or 'bottom').
+	 */
 	protected function extra_tablenav( $which ) {
 		?>
 		<div class="alignleft actions">
@@ -225,6 +276,9 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
+	/**
+	 * Output the log ID filter dropdown.
+	 */
 	private function create_log_id_dropdown() {
 		$requested_log_id = isset( $_REQUEST['log_id'] ) ? esc_attr( $_REQUEST['log_id'] ) : 0;
 		?>
@@ -257,6 +311,9 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
+	/**
+	 * Output the month filter dropdown.
+	 */
 	protected function _create_months_dropdown() {
 		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null;
 		?>
@@ -282,6 +339,9 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		<?php
 	}
 
+	/**
+	 * Output the message type filter dropdown.
+	 */
 	protected function _create_types_dropdown() {
 		$requested_type = isset( $_REQUEST['type'] ) ? esc_attr( $_REQUEST['type'] ) : null;
 		?>
@@ -307,11 +367,19 @@ class Syndication_Logger_Viewer {
 
 	public $syndication_logger_table;
 
+	/**
+	 * Constructor.
+	 *
+	 * Registers admin menu and screen option hooks.
+	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'add_menu_items' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
 	}
 
+	/**
+	 * Register the Logs submenu page under Syndication Sites.
+	 */
 	public function add_menu_items() {
 		$hook = add_submenu_page( 'edit.php?post_type=syn_site', 'Logs', 'Logs', 'activate_plugins', 'syndication_dashboard', array( $this, 'render_list_page' ) );
 		add_action( "load-$hook", array( $this, 'initialize_list_table' ) );
@@ -332,6 +400,11 @@ class Syndication_Logger_Viewer {
 		return $status;
 	}
 
+	/**
+	 * Initialize the list table and add screen options.
+	 *
+	 * Handles redirect for log ID filter and sets up the list table instance.
+	 */
 	public function initialize_list_table() {
 		if ( ! empty( $_POST['log_id'] ) && ( empty( $_GET['log_id'] ) || esc_attr( $_GET['log_id'] ) != esc_attr( $_POST['log_id'] ) ) ) {
 			wp_safe_redirect( add_query_arg( array( 'log_id' => esc_attr( $_REQUEST['log_id'] ) ), wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
@@ -351,6 +424,9 @@ class Syndication_Logger_Viewer {
 		$this->syndication_logger_table = new Syndication_Logger_List_Table();
 	}
 
+	/**
+	 * Render the syndication logs list page.
+	 */
 	public function render_list_page() {
 		?>
 		<div class="wrap"><h2><?php esc_html_e( 'Syndication Logs', 'push-syndication' ); ?></h2>

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -130,7 +130,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 		$orderby = ( ! empty( $_GET['orderby'] ) ) ? esc_attr( $_GET['orderby'] ) : 'time';
 		$order   = ( ! empty( $_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc';
 		$result  = strcmp( $a[ $orderby ], $b[ $orderby ] );
-		return ( $order === 'asc' ) ? $result : -$result;
+		return ( 'asc' === $order ) ? $result : -$result;
 	}
 
 	/**

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -103,7 +103,7 @@ class Syndication_Logger {
 	 * Use this singleton to address non-static methods
 	 */
 	public static function instance() {
-		if ( self::$__instance == null ) {
+		if ( null === self::$__instance ) {
 			self::$__instance = new self();
 		}
 		return self::$__instance;

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -99,8 +99,10 @@ class Syndication_Logger {
 		}
 	}
 
-	/*
-	 * Use this singleton to address non-static methods
+	/**
+	 * Use this singleton to address non-static methods.
+	 *
+	 * @return Syndication_Logger The singleton instance.
 	 */
 	public static function instance() {
 		if ( null === self::$__instance ) {

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Logging system for syndication events.
+ *
+ * @package Syndication
+ */
 
 /**
- * Syndication_Logger implements a unified logging mechanism for the syndication plugin.
+ * Class Syndication_Logger
  *
- * @todo implement removal of old log messages, cron to remove messages older than X?
+ * Implements a unified logging mechanism for the syndication plugin,
+ * tracking push/pull events, errors, and syndication status changes.
+ *
+ * @todo Implement removal of old log messages, cron to remove messages older than X?
  */
 class Syndication_Logger {
 

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -49,6 +49,11 @@ class Syndication_Logger {
 	 */
 	private $log_id = null;
 
+	/**
+	 * Constructor.
+	 *
+	 * Sets up logging action hooks for syndication events and configures the debug level.
+	 */
 	public function __construct() {
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'log_new' ), 10, 5 );
 		add_action( 'syn_post_pull_edit_post', array( __CLASS__, 'log_update' ), 10, 5 );

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -61,9 +61,9 @@ class Syndication_Logger {
 
 		if ( false === $this->debug_level ) {
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
-				$this->debug_level = 'info';    // log everything
+				$this->debug_level = 'info';    // Log everything.
 			} else {
-				$this->debug_level = 'default'; // log only errors + success
+				$this->debug_level = 'default'; // Log only errors + success.
 			}
 		}
 
@@ -72,9 +72,9 @@ class Syndication_Logger {
 
 		if ( false === $this->use_php_error_logging ) {
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
-				$this->use_php_error_logging = true;    // log also with error_log()
+				$this->use_php_error_logging = true;    // Log also with error_log().
 			} else {
-				$this->use_php_error_logging = false;   // log only in db
+				$this->use_php_error_logging = false;   // Log only in db.
 			}
 		}
 	}
@@ -261,7 +261,7 @@ class Syndication_Logger {
 	 * @return mixed                true or WP_Error
 	 */
 	private function log( $storage_type, $msg_type, $object_type, $object_id, $status, $message, $log_time, $extra ) {
-		// Don't log infos depending on debug level
+		// Don't log infos depending on debug level.
 		if ( 'info' == $msg_type && 'info' != $this->debug_level ) {
 			return;
 		}
@@ -294,7 +294,7 @@ class Syndication_Logger {
 		}
 
 		if ( ! empty( $extra ) && is_array( $extra ) ) {
-			// @TODO sanitize extra data
+			// @TODO sanitize extra data.
 			// $log_entry['extra'] = array_map( 'sanitize_text_field', $extra );
 		}
 
@@ -304,7 +304,7 @@ class Syndication_Logger {
 		}
 
 		if ( 'object' == $storage_type ) {
-			// Storing the log alongside the object
+			// Storing the log alongside the object.
 
 			if ( 'post' == $object_type ) {
 				if ( ! is_integer( $object_id ) ) {
@@ -328,7 +328,7 @@ class Syndication_Logger {
 					$log[0] = $log_entry;
 				} else {
 					if ( count( $log ) >= $this->log_entry_limit ) {
-						// Slice the array to keep the log size in the limits
+						// Slice the array to keep the log size in the limits.
 						$offset = count( $log ) - $this->log_entry_limit;
 						$log    = array_slice( $log, $offset + 1 );
 					}
@@ -340,19 +340,19 @@ class Syndication_Logger {
 				if ( 'success' == $msg_type ) {
 					update_post_meta( $post->ID, 'syn_log_errors', 0 );
 				} elseif ( 'error' == $msg_type ) {
-					// track failures since last success
+					// track failures since last success.
 					$errors = get_post_meta( $post->ID, 'syn_log_errors', true );
 					$errors = (int) $errors + 1;
 					update_post_meta( $post->ID, 'syn_log_errors', $errors );
-					// track overall failures
+					// track overall failures.
 					$errors = get_post_meta( $post->ID, 'syn_log_errors_overall', true );
 					$errors = (int) $errors + 1;
 					update_post_meta( $post->ID, 'syn_log_errors_overall', $errors );
 				}
 
-				// @TODO log error counter
+				// @TODO log error counter.
 			} elseif ( 'term' == $object_type ) {
-				// @TODO implement if needed
+				// @TODO implement if needed.
 			}
 		} elseif ( 'option' == $storage_type ) {
 			// Storing the log in an option value.
@@ -363,7 +363,7 @@ class Syndication_Logger {
 				$log[0] = $log_entry;
 			} else {
 				if ( count( $log ) >= $this->log_entry_limit ) {
-					// Slice the array to keep the log size in the limits
+					// Slice the array to keep the log size in the limits.
 					$offset = count( $log ) - $this->log_entry_limit;
 					$log    = array_slice( $log, $offset + 1 );
 				}
@@ -375,11 +375,11 @@ class Syndication_Logger {
 			if ( 'success' == $msg_type ) {
 				update_option( 'syn_log_errors', 0 );
 			} elseif ( 'error' == $msg_type ) {
-				// track failures since last success
+				// track failures since last success.
 				$errors = get_option( 'syn_log_errors' );
 				$errors = (int) $errors + 1;
 				update_option( 'syn_log_errors', $errors );
-				// track overall failures
+				// track overall failures.
 				$errors = get_option( 'syn_log_errors_overall' );
 				$errors = (int) $errors + 1;
 				update_option( 'syn_log_errors_overall', $errors );
@@ -432,7 +432,7 @@ class Syndication_Logger {
 					 *
 					 * @TODO implement walker
 					 */
-					$all_log_entries = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'syn_log' GROUP BY post_id ORDER BY meta_id DESC LIMIT 0, 100" ); // cache pass (see note above)
+					$all_log_entries = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'syn_log' GROUP BY post_id ORDER BY meta_id DESC LIMIT 0, 100" ); // Cache pass (see note above).
 					foreach ( $all_log_entries as $log_entry ) {
 						$log_entries[ $log_entry->post_id ] = unserialize( $log_entry->meta_value );
 					}

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -8,42 +8,42 @@
 class Syndication_Logger {
 
 	/**
-	 * singleton handle
+	 * Singleton handle.
 	 *
 	 * @var object
 	 */
 	private static $__instance = null;
 
 	/**
-	 * maximum amount of rows to keep for single object log entries
+	 * Maximum amount of rows to keep for single object log entries.
 	 *
 	 * @var integer
 	 */
 	private $log_entry_limit = 150;
 
 	/**
-	 * level of information to log. Can be info for all and default for errors/success
+	 * Level of information to log. Can be info for all and default for errors/success.
 	 *
 	 * @var string
 	 */
 	private $debug_level = null;
 
 	/**
-	 * if true log messages will also be sent to php error log
+	 * If true log messages will also be sent to php error log.
 	 *
 	 * @var boolean
 	 */
 	private $use_php_error_logging = null;
 
 	/**
-	 * filter variables for retrieving log messages
+	 * Filter variables for retrieving log messages.
 	 *
 	 * @var array
 	 */
 	private $log_filter = array();
 
 	/**
-	 * a unique identifier for each page load / logging session
+	 * A unique identifier for each page load / logging session.
 	 *
 	 * @var string
 	 */
@@ -116,11 +116,11 @@ class Syndication_Logger {
 	 * do_action( 'syn_post_pull_new_post', $result, $post, $site, $transport_type, $client );
 	 * do_action( 'syn_post_push_new_post', $result, $post_ID, $site, $transport_type, $client, $info );
 	 *
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	public static function log_new( $result, $post, $site, $transport_type, $client ) {
 		self::instance()->log_post_event( 'new', $result, $post, $site, $transport_type, $client );
@@ -132,11 +132,11 @@ class Syndication_Logger {
 	 * do_action( 'syn_post_pull_edit_post', $result, $post, $site, $transport_type, $client );
 	 * do_action( 'syn_post_push_edit_post', $result, $post_ID, $site, $transport_type, $client, $info );
 	 *
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	public static function log_update( $result, $post, $site, $transport_type, $client ) {
 		self::instance()->log_post_event( 'update', $result, $post, $site, $transport_type, $client );
@@ -147,12 +147,12 @@ class Syndication_Logger {
 	 * usually implemented via action hook
 	 * do_action( 'syn_post_push_delete_post', $result, $ext_ID, $post_ID, $site_ID, $transport_type, $client );
 	 *
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
-	 * @param  mixed  $external_id    External post post_id
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $external_id    External post post_id.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	public static function log_delete( $result, $external_id, $post, $site, $transport_type, $client ) {
 		self::instance()->log_post_event( 'delete', $result, $post, $site, $transport_type, $client );
@@ -161,12 +161,12 @@ class Syndication_Logger {
 	/**
 	 * Prepares data for the post level log events
 	 *
-	 * @param  string $event          Type of event new/update/delete
-	 * @param  mixed  $result         Result object of previous wp_insert_post action
-	 * @param  mixed  $post           Post object or post_id
-	 * @param  object $site           Post object for the site doing the syndication
-	 * @param  string $transport_type Post meta syn_transport_type for site
-	 * @param  object $client         Syndication_Client class
+	 * @param  string $event          Type of event new/update/delete.
+	 * @param  mixed  $result         Result object of previous wp_insert_post action.
+	 * @param  mixed  $post           Post object or post_id.
+	 * @param  object $site           Post object for the site doing the syndication.
+	 * @param  string $transport_type Post meta syn_transport_type for site.
+	 * @param  object $client         Syndication_Client class.
 	 */
 	private function log_post_event( $event, $result, $post, $site, $transport_type, $client ) {
 		if ( is_int( $post ) ) {
@@ -202,11 +202,11 @@ class Syndication_Logger {
 	/**
 	 * Log a faulty post level event
 	 *
-	 * @param  int    $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 * @param  int    $post_id  Post ID to attach the log entry to.
+	 * @param  string $status   Status entry.
+	 * @param  string $message  Log message.
+	 * @param  string $log_time Time of event.
+	 * @param  array  $extra    Additional data.
 	 */
 	public static function log_post_error( $post_id, $status = 'error', $message = '', $log_time = '', $extra = array() ) {
 		self::instance()->log_post( 'error', $post_id, $status, $message, $log_time, $extra );
@@ -215,11 +215,11 @@ class Syndication_Logger {
 	/**
 	 * Log a successful post level event
 	 *
-	 * @param  int    $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 * @param  int    $post_id  Post ID to attach the log entry to.
+	 * @param  string $status   Status entry.
+	 * @param  string $message  Log message.
+	 * @param  string $log_time Time of event.
+	 * @param  array  $extra    Additional data.
 	 */
 	public function log_post_success( $post_id, $status = 'ok', $message = '', $log_time = '', $extra = array() ) {
 		self::instance()->log_post( 'success', $post_id, $status, $message, $log_time, $extra );
@@ -228,11 +228,11 @@ class Syndication_Logger {
 	/**
 	 * Log a post level informal event
 	 *
-	 * @param  int    $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 * @param  int    $post_id  Post ID to attach the log entry to.
+	 * @param  string $status   Status entry.
+	 * @param  string $message  Log message.
+	 * @param  string $log_time Time of event.
+	 * @param  array  $extra    Additional data.
 	 */
 	public static function log_post_info( $post_id, $status = '', $message = '', $log_time = '', $extra = array() ) {
 		self::instance()->log_post( 'info', $post_id, $status, $message, $log_time, $extra );
@@ -241,12 +241,12 @@ class Syndication_Logger {
 	/**
 	 * Pass post level events to logger function
 	 *
-	 * @param  string $msg_type event type success/error/info
-	 * @param  int    $post_id  post_id to attach the log entry to
-	 * @param  string $status   status entry
-	 * @param  string $message  log message
-	 * @param  string $log_time time of event
-	 * @param  array  $extra    additional data
+	 * @param  string $msg_type Event type success/error/info.
+	 * @param  int    $post_id  Post ID to attach the log entry to.
+	 * @param  string $status   Status entry.
+	 * @param  string $message  Log message.
+	 * @param  string $log_time Time of event.
+	 * @param  array  $extra    Additional data.
 	 */
 	private function log_post( $msg_type, $post_id, $status, $message, $log_time, $extra ) {
 		$this->log( $storage_type = 'object', $msg_type, 'post', $post_id, $status, $message, $log_time, $extra );
@@ -255,14 +255,14 @@ class Syndication_Logger {
 	/**
 	 * Log an entry to the database
 	 *
-	 * @param  string $storage_type Where the log entry will be stored. object / option
-	 * @param  string $msg_type     event type success/error/info
-	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported
-	 * @param  int    $object_id    object_id (post_id) to attach the log entry to
-	 * @param  string $status       status entry
-	 * @param  string $message      log message
-	 * @param  string $log_time     time of event
-	 * @param  array  $extra        additional data
+	 * @param  string $storage_type Where the log entry will be stored. object / option.
+	 * @param  string $msg_type     Event type success/error/info.
+	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported.
+	 * @param  int    $object_id    Object ID (post_id) to attach the log entry to.
+	 * @param  string $status       Status entry.
+	 * @param  string $message      Log message.
+	 * @param  string $log_time     Time of event.
+	 * @param  array  $extra        Additional data.
 	 * @return mixed                true or WP_Error
 	 */
 	private function log( $storage_type, $msg_type, $object_type, $object_id, $status, $message, $log_time, $extra ) {
@@ -396,8 +396,8 @@ class Syndication_Logger {
 	/**
 	 * Format log message for error_log()
 	 *
-	 * @param  string $msg_type  Type of message
-	 * @param  array  $log_entry Prepared log_entry array
+	 * @param  string $msg_type  Type of message.
+	 * @param  array  $log_entry Prepared log_entry array.
 	 * @return string            Formatted log message
 	 */
 	private function format_log_message( $msg_type, $log_entry ) {
@@ -408,15 +408,15 @@ class Syndication_Logger {
 	/**
 	 * Retrieve and filter log messages from database
 	 *
-	 * @param  string $log_id       unique log session id
-	 * @param  string $msg_type     event type success/error/info
-	 * @param  int    $object_id    object_id (post_id) to attach the log entry to
-	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported
-	 * @param  string $status       status entry
-	 * @param  string $date_start   Date string for starting date filter
-	 * @param  string $date_end     Date string for starting date filter
-	 * @param  string $message      regular expression for message text matching
-	 * @param  string $storage_type Where the log entry will be stored. object / option
+	 * @param  string $log_id       Unique log session ID.
+	 * @param  string $msg_type     Event type success/error/info.
+	 * @param  int    $object_id    Object ID (post_id) to attach the log entry to.
+	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported.
+	 * @param  string $status       Status entry.
+	 * @param  string $date_start   Date string for starting date filter.
+	 * @param  string $date_end     Date string for ending date filter.
+	 * @param  string $message      Regular expression for message text matching.
+	 * @param  string $storage_type Where the log entry will be stored. Object or option.
 	 * @return array                Array of matching log entries
 	 */
 	public static function get_messages( $log_id = null, $msg_type = null, $object_id = null, $object_type = 'post', $status = null, $date_start = null, $date_end = null, $message = null, $storage_type = 'object' ) {
@@ -473,7 +473,7 @@ class Syndication_Logger {
 	 * Filter retrieved log entries by log_filter conditions
 	 *
 	 * @uses array_filter()
-	 * @param  array $data Array Element
+	 * @param  array $data Array element.
 	 * @return boolean     True to keep the entry, false to skip it
 	 */
 	public function filter_log_entries( $data ) {

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -9,36 +9,42 @@ class Syndication_Logger {
 
 	/**
 	 * singleton handle
+	 *
 	 * @var object
 	 */
 	private static $__instance = null;
 
 	/**
 	 * maximum amount of rows to keep for single object log entries
+	 *
 	 * @var integer
 	 */
 	private $log_entry_limit = 150;
 
 	/**
 	 * level of information to log. Can be info for all and default for errors/success
+	 *
 	 * @var string
 	 */
 	private $debug_level = null;
 
 	/**
 	 * if true log messages will also be sent to php error log
+	 *
 	 * @var boolean
 	 */
 	private $use_php_error_logging = null;
 
 	/**
 	 * filter variables for retrieving log messages
+	 *
 	 * @var array
 	 */
 	private $log_filter = array();
 
 	/**
 	 * a unique identifier for each page load / logging session
+	 *
 	 * @var string
 	 */
 	private $log_id = null;
@@ -55,9 +61,9 @@ class Syndication_Logger {
 
 		if ( false === $this->debug_level ) {
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
-				$this->debug_level = 'info';	// log everything
+				$this->debug_level = 'info';    // log everything
 			} else {
-				$this->debug_level = 'default';	// log only errors + success
+				$this->debug_level = 'default'; // log only errors + success
 			}
 		}
 
@@ -66,9 +72,9 @@ class Syndication_Logger {
 
 		if ( false === $this->use_php_error_logging ) {
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
-				$this->use_php_error_logging = true;	// log also with error_log()
+				$this->use_php_error_logging = true;    // log also with error_log()
 			} else {
-				$this->use_php_error_logging = false;	// log only in db
+				$this->use_php_error_logging = false;   // log only in db
 			}
 		}
 	}
@@ -79,12 +85,12 @@ class Syndication_Logger {
 	public static function init() {
 		self::instance()->log_id = md5( uniqid() . microtime() );
 
-		require_once( dirname( __FILE__ ) . '/class-syndication-admin-notices.php' );
-		new Syndication_Logger_Admin_Notice;
+		require_once __DIR__ . '/class-syndication-admin-notices.php';
+		new Syndication_Logger_Admin_Notice();
 
 		if ( is_admin() ) {
-			require_once( dirname( __FILE__ ) . '/class-syndication-logger-viewer.php' );
-			$viewer = new Syndication_Logger_Viewer;
+			require_once __DIR__ . '/class-syndication-logger-viewer.php';
+			$viewer = new Syndication_Logger_Viewer();
 		}
 	}
 
@@ -137,7 +143,7 @@ class Syndication_Logger {
 	 * do_action( 'syn_post_push_delete_post', $result, $ext_ID, $post_ID, $site_ID, $transport_type, $client );
 	 *
 	 * @param  mixed  $result         Result object of previous wp_insert_post action
- 	 * @param  mixed  $external_id    External post post_id
+	 * @param  mixed  $external_id    External post post_id
 	 * @param  mixed  $post           Post object or post_id
 	 * @param  object $site           Post object for the site doing the syndication
 	 * @param  string $transport_type Post meta syn_transport_type for site
@@ -149,12 +155,13 @@ class Syndication_Logger {
 
 	/**
 	 * Prepares data for the post level log events
+	 *
 	 * @param  string $event          Type of event new/update/delete
 	 * @param  mixed  $result         Result object of previous wp_insert_post action
- 	 * @param  mixed  $post           Post object or post_id
- 	 * @param  object $site           Post object for the site doing the syndication
- 	 * @param  string $transport_type Post meta syn_transport_type for site
- 	 * @param  object $client         Syndication_Client class
+	 * @param  mixed  $post           Post object or post_id
+	 * @param  object $site           Post object for the site doing the syndication
+	 * @param  string $transport_type Post meta syn_transport_type for site
+	 * @param  object $client         Syndication_Client class
 	 */
 	private function log_post_event( $event, $result, $post, $site, $transport_type, $client ) {
 		if ( is_int( $post ) ) {
@@ -168,10 +175,10 @@ class Syndication_Logger {
 		}
 
 		$extra = array(
-			'post' 			 => $post,
-			'result' 		 => $result,
+			'post'           => $post,
+			'result'         => $result,
 			'transpost_type' => $transport_type,
-			'client' 		 => $client
+			'client'         => $client,
 		);
 
 		if ( false == $result || is_wp_error( $result ) ) {
@@ -180,16 +187,17 @@ class Syndication_Logger {
 			} else {
 				$message = 'fail';
 			}
-			Syndication_Logger::log_post_error( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			self::log_post_error( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
 		} else {
 			$message = sprintf( '%s,%d', sanitize_text_field( $post['post_guid'] ), intval( $result ) );
-			Syndication_Logger::log_post_success( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			self::log_post_success( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
 		}
 	}
 
 	/**
 	 * Log a faulty post level event
-	 * @param  int 	  $post_id  post_id to attach the log entry to
+	 *
+	 * @param  int    $post_id  post_id to attach the log entry to
 	 * @param  string $status   status entry
 	 * @param  string $message  log message
 	 * @param  string $log_time time of event
@@ -201,7 +209,8 @@ class Syndication_Logger {
 
 	/**
 	 * Log a successful post level event
-	 * @param  int 	  $post_id  post_id to attach the log entry to
+	 *
+	 * @param  int    $post_id  post_id to attach the log entry to
 	 * @param  string $status   status entry
 	 * @param  string $message  log message
 	 * @param  string $log_time time of event
@@ -213,7 +222,8 @@ class Syndication_Logger {
 
 	/**
 	 * Log a post level informal event
-	 * @param  int 	  $post_id  post_id to attach the log entry to
+	 *
+	 * @param  int    $post_id  post_id to attach the log entry to
 	 * @param  string $status   status entry
 	 * @param  string $message  log message
 	 * @param  string $log_time time of event
@@ -225,12 +235,13 @@ class Syndication_Logger {
 
 	/**
 	 * Pass post level events to logger function
+	 *
 	 * @param  string $msg_type event type success/error/info
-	 * @param  int 	  $post_id  post_id to attach the log entry to
- 	 * @param  string $status   status entry
- 	 * @param  string $message  log message
- 	 * @param  string $log_time time of event
- 	 * @param  array  $extra    additional data
+	 * @param  int    $post_id  post_id to attach the log entry to
+	 * @param  string $status   status entry
+	 * @param  string $message  log message
+	 * @param  string $log_time time of event
+	 * @param  array  $extra    additional data
 	 */
 	private function log_post( $msg_type, $post_id, $status, $message, $log_time, $extra ) {
 		$this->log( $storage_type = 'object', $msg_type, 'post', $post_id, $status, $message, $log_time, $extra );
@@ -238,14 +249,15 @@ class Syndication_Logger {
 
 	/**
 	 * Log an entry to the database
+	 *
 	 * @param  string $storage_type Where the log entry will be stored. object / option
- 	 * @param  string $msg_type 	event type success/error/info
+	 * @param  string $msg_type     event type success/error/info
 	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported
- 	 * @param  int 	  $object_id  	object_id (post_id) to attach the log entry to
-  	 * @param  string $status   	status entry
-  	 * @param  string $message  	log message
-  	 * @param  string $log_time 	time of event
-  	 * @param  array  $extra    	additional data
+	 * @param  int    $object_id    object_id (post_id) to attach the log entry to
+	 * @param  string $status       status entry
+	 * @param  string $message      log message
+	 * @param  string $log_time     time of event
+	 * @param  array  $extra        additional data
 	 * @return mixed                true or WP_Error
 	 */
 	private function log( $storage_type, $msg_type, $object_type, $object_id, $status, $message, $log_time, $extra ) {
@@ -255,8 +267,8 @@ class Syndication_Logger {
 		}
 
 		$log_entry = array(
-			'log_id' 	=> $this->log_id,
-			'msg_type'  => $msg_type,
+			'log_id'   => $this->log_id,
+			'msg_type' => $msg_type,
 		);
 
 		if ( ! empty( $object_type ) ) {
@@ -276,9 +288,9 @@ class Syndication_Logger {
 		}
 
 		if ( ! empty( $log_time ) ) {
-			$log_entry['time'] = date('Y-m-d H:i:s', strtotime( $log_time ) );
+			$log_entry['time'] = date( 'Y-m-d H:i:s', strtotime( $log_time ) );
 		} else {
-			$log_entry['time'] = current_time('mysql');
+			$log_entry['time'] = current_time( 'mysql' );
 		}
 
 		if ( ! empty( $extra ) && is_array( $extra ) ) {
@@ -295,7 +307,6 @@ class Syndication_Logger {
 			// Storing the log alongside the object
 
 			if ( 'post' == $object_type ) {
-
 				if ( ! is_integer( $object_id ) ) {
 					return new WP_Error( 'logger_no_post_id', __( 'You need to provide a valid post_id or use log_option instead', 'push-syndication' ) );
 				}
@@ -318,8 +329,8 @@ class Syndication_Logger {
 				} else {
 					if ( count( $log ) >= $this->log_entry_limit ) {
 						// Slice the array to keep the log size in the limits
-						$offset = count ( $log ) - $this->log_entry_limit;
-						$log = array_slice( $log, $offset + 1 );
+						$offset = count( $log ) - $this->log_entry_limit;
+						$log    = array_slice( $log, $offset + 1 );
 					}
 
 					$log[] = $log_entry;
@@ -328,7 +339,7 @@ class Syndication_Logger {
 
 				if ( 'success' == $msg_type ) {
 					update_post_meta( $post->ID, 'syn_log_errors', 0 );
-				} else if ( 'error' == $msg_type ) {
+				} elseif ( 'error' == $msg_type ) {
 					// track failures since last success
 					$errors = get_post_meta( $post->ID, 'syn_log_errors', true );
 					$errors = (int) $errors + 1;
@@ -340,11 +351,10 @@ class Syndication_Logger {
 				}
 
 				// @TODO log error counter
-			} else if ( 'term' == $object_type ) {
+			} elseif ( 'term' == $object_type ) {
 				// @TODO implement if needed
 			}
-
-		} else if ( 'option' == $storage_type ) {
+		} elseif ( 'option' == $storage_type ) {
 			// Storing the log in an option value.
 			// Default to empty array when option doesn't exist.
 			$log = get_option( 'syn_log', array() );
@@ -354,8 +364,8 @@ class Syndication_Logger {
 			} else {
 				if ( count( $log ) >= $this->log_entry_limit ) {
 					// Slice the array to keep the log size in the limits
-					$offset = count ( $log ) - $this->log_entry_limit;
-					$log = array_slice( $log, $offset + 1 );
+					$offset = count( $log ) - $this->log_entry_limit;
+					$log    = array_slice( $log, $offset + 1 );
 				}
 
 				$log[] = $log_entry;
@@ -364,7 +374,7 @@ class Syndication_Logger {
 
 			if ( 'success' == $msg_type ) {
 				update_option( 'syn_log_errors', 0 );
-			} else if ( 'error' == $msg_type ) {
+			} elseif ( 'error' == $msg_type ) {
 				// track failures since last success
 				$errors = get_option( 'syn_log_errors' );
 				$errors = (int) $errors + 1;
@@ -380,6 +390,7 @@ class Syndication_Logger {
 
 	/**
 	 * Format log message for error_log()
+	 *
 	 * @param  string $msg_type  Type of message
 	 * @param  array  $log_entry Prepared log_entry array
 	 * @return string            Formatted log message
@@ -391,16 +402,17 @@ class Syndication_Logger {
 
 	/**
 	 * Retrieve and filter log messages from database
- 	 * @param  string $log_id		unique log session id
- 	 * @param  string $msg_type 	event type success/error/info
- 	 * @param  int 	  $object_id  	object_id (post_id) to attach the log entry to
+	 *
+	 * @param  string $log_id       unique log session id
+	 * @param  string $msg_type     event type success/error/info
+	 * @param  int    $object_id    object_id (post_id) to attach the log entry to
 	 * @param  string $object_type  Type of object to attach log entry to. Currently only "post" is supported
-  	 * @param  string $status   	status entry
+	 * @param  string $status       status entry
 	 * @param  string $date_start   Date string for starting date filter
 	 * @param  string $date_end     Date string for starting date filter
 	 * @param  string $message      regular expression for message text matching
 	 * @param  string $storage_type Where the log entry will be stored. object / option
-  	 * @return array                Array of matching log entries
+	 * @return array                Array of matching log entries
 	 */
 	public static function get_messages( $log_id = null, $msg_type = null, $object_id = null, $object_type = 'post', $status = null, $date_start = null, $date_end = null, $message = null, $storage_type = 'object' ) {
 
@@ -409,7 +421,7 @@ class Syndication_Logger {
 		if ( 'object' == $storage_type ) {
 			if ( 'post' == $object_type ) {
 				if ( ! empty( $object_id ) ) {
-					$log_entries[$object_id] = get_post_meta( $object_id, 'syn_log' );
+					$log_entries[ $object_id ] = get_post_meta( $object_id, 'syn_log' );
 				} else {
 					global $wpdb;
 					/**
@@ -417,33 +429,35 @@ class Syndication_Logger {
 					 * This call may return objects larger than 1 MB and is usually only called infrequently
 					 * from the admin dashboard. Implementing a segmented object caching for this result seems
 					 * unnecessary.
+					 *
 					 * @TODO implement walker
 					 */
 					$all_log_entries = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'syn_log' GROUP BY post_id ORDER BY meta_id DESC LIMIT 0, 100" ); // cache pass (see note above)
-					foreach( $all_log_entries as $log_entry ) {
-						$log_entries[$log_entry->post_id] = unserialize( $log_entry->meta_value );
+					foreach ( $all_log_entries as $log_entry ) {
+						$log_entries[ $log_entry->post_id ] = unserialize( $log_entry->meta_value );
 					}
 				}
 			}
 		}
 
 		$filter = array();
-		foreach( array( 'log_id', 'msg_type', 'object_type', 'status', 'date_start', 'date_end', 'message' ) as $filter_key ) {
+		foreach ( array( 'log_id', 'msg_type', 'object_type', 'status', 'date_start', 'date_end', 'message' ) as $filter_key ) {
 			if ( ! empty( ${$filter_key} ) ) {
-				$filter[$filter_key] = ${$filter_key};
+				$filter[ $filter_key ] = ${$filter_key};
 			}
 		}
 		self::instance()->log_filter = $filter;
 
-		foreach( $log_entries as $object_id => $entries ) {
-			$entries = array_filter( $entries, array( self::instance(), 'filter_log_entries' ) );
-			$log_entries[$object_id] = $entries;
+		foreach ( $log_entries as $object_id => $entries ) {
+			$entries                   = array_filter( $entries, array( self::instance(), 'filter_log_entries' ) );
+			$log_entries[ $object_id ] = $entries;
 		}
 		return $log_entries;
 	}
 
 	/**
 	 * Retrieve log_filter variable
+	 *
 	 * @return array Log filter conditions
 	 */
 	public function get_log_filter() {
@@ -452,6 +466,7 @@ class Syndication_Logger {
 
 	/**
 	 * Filter retrieved log entries by log_filter conditions
+	 *
 	 * @uses array_filter()
 	 * @param  array $data Array Element
 	 * @return boolean     True to keep the entry, false to skip it
@@ -459,13 +474,13 @@ class Syndication_Logger {
 	public function filter_log_entries( $data ) {
 		$filter = $this->get_log_filter();
 
-		foreach( $filter as $key => $value ) {
-			switch( $key ) {
+		foreach ( $filter as $key => $value ) {
+			switch ( $key ) {
 				case 'log_id':
 				case 'msg_type':
 				case 'object_type':
 				case 'status':
-					if ( ! isset( $data[$key] ) || $data[$key] <> $value ) {
+					if ( ! isset( $data[ $key ] ) || $data[ $key ] <> $value ) {
 						return false;
 					}
 					break;

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -300,8 +300,8 @@ class Syndication_Logger {
 			$log_entry['time'] = current_time( 'mysql' );
 		}
 
+		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf -- TODO: sanitize extra data.
 		if ( ! empty( $extra ) && is_array( $extra ) ) {
-			// @TODO sanitize extra data.
 			// $log_entry['extra'] = array_map( 'sanitize_text_field', $extra );
 		}
 
@@ -358,8 +358,9 @@ class Syndication_Logger {
 				}
 
 				// @TODO log error counter.
-			} elseif ( 'term' == $object_type ) {
-				// @TODO implement if needed.
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif -- TODO: implement if needed.
+			} elseif ( 'term' === $object_type ) {
+				// Placeholder for future term object type support.
 			}
 		} elseif ( 'option' == $storage_type ) {
 			// Storing the log in an option value.

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -103,7 +103,7 @@ class Failed_Syndication_Auto_Retry {
 				// Run in one minute by default.
 				$auto_retry_interval = apply_filters( 'syndication_failure_auto_retry_interval', $time_now + MINUTE_IN_SECONDS );
 
-				Syndication_Logger::log_post_info( $site->ID, $status = 'start_auto_retry', $message = sprintf( __( 'Connection retry %d of %d to %s in %s..', 'push-syndication' ), $site_auto_retry_count + 1, $auto_retry_limit, $site_url, human_time_diff( $time_now, $auto_retry_interval ) ), $log_time, $extra = array() );
+				Syndication_Logger::log_post_info( $site->ID, $status = 'start_auto_retry', $message = sprintf( __( 'Connection retry %1$d of %2$d to %3$s in %4$s..', 'push-syndication' ), $site_auto_retry_count + 1, $auto_retry_limit, $site_url, human_time_diff( $time_now, $auto_retry_interval ) ), $log_time, $extra = array() );
 
 				// Schedule a pull retry for one minute in the future.
 				wp_schedule_single_event(
@@ -113,11 +113,10 @@ class Failed_Syndication_Auto_Retry {
 				);
 
 				// Increment our auto retry counter.
-				$site_auto_retry_count++;
+				++$site_auto_retry_count;
 
 				// And update the post meta auto retry count.
 				update_post_meta( $site->ID, 'syn_failed_auto_retry_attempts', $site_auto_retry_count );
-
 			} else {
 
 				// Auto Retry limit met.
@@ -137,7 +136,7 @@ class Failed_Syndication_Auto_Retry {
 			// Remove the auto retry if there was one.
 			delete_post_meta( $site->ID, 'syn_failed_auto_retry_attempts' );
 
-			Syndication_Logger::log_post_error( $site->ID, $status = 'end_auto_retry', $message = sprintf( __( 'Failed %d times to reconnect to %s', 'push-syndication' ), $site_auto_retry_count, $site_url ), $log_time, $extra = array() );
+			Syndication_Logger::log_post_error( $site->ID, $status = 'end_auto_retry', $message = sprintf( __( 'Failed %1$d times to reconnect to %2$s', 'push-syndication' ), $site_auto_retry_count, $site_url ), $log_time, $extra = array() );
 		}
 	}
 

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -32,12 +32,10 @@ class Failed_Syndication_Auto_Retry {
 	}
 
 	/**
-	 * Handle a site pull failure event
+	 * Handle a site pull failure event.
 	 *
-	 * @param $site_id         int    The post id of the site we need to retry
-	 * @param $failed_attempts int    The number of pull failures this site has experienced
-	 *
-	 * @return null
+	 * @param int $site_id         The post ID of the site we need to retry.
+	 * @param int $failed_attempts The number of pull failures this site has experienced.
 	 */
 	public function handle_pull_failure_event( $site_id = 0, $failed_attempts = 0 ) {
 
@@ -141,11 +139,10 @@ class Failed_Syndication_Auto_Retry {
 	}
 
 	/**
-	 * Handle a site pull success event
+	 * Handle a site pull success event.
 	 *
-	 * @param $site_id         int    The post id of the site which just successfully pulled
-	 * @param $failed_attempts int    The number of pull failures this site has experienced
-	 * @return null
+	 * @param int $site_id         The post ID of the site which just successfully pulled.
+	 * @param int $failed_attempts The number of pull failures this site has experienced.
 	 */
 	public function handle_pull_success_event( $site_id = 0, $failed_attempts = 0 ) {
 

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -16,7 +16,6 @@
  *
  * @uses Syndication_Logger
  */
-
 class Failed_Syndication_Auto_Retry {
 
 	/**

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -24,10 +24,10 @@ class Failed_Syndication_Auto_Retry {
 	 */
 	public function __construct() {
 
-		// Watch the push_syndication_event action for site pull failures
+		// Watch the push_syndication_event action for site pull failures.
 		add_action( 'push_syndication_after_event_pull_failure', array( $this, 'handle_pull_failure_event' ), 10, 2 );
 
-		// Watch the push_syndication_event action for site pull successes
+		// Watch the push_syndication_event action for site pull successes.
 		add_action( 'push_syndication_after_event_pull_success', array( $this, 'handle_pull_success_event' ), 10, 2 );
 	}
 
@@ -46,15 +46,15 @@ class Failed_Syndication_Auto_Retry {
 		$failed_attempts       = (int) $failed_attempts;
 		$cleanup               = false;
 
-		// Fetch the allowable number of max pull attempts before the site is marked as 'disabled'
+		// Fetch the allowable number of max pull attempts before the site is marked as 'disabled'.
 		$max_pull_attempts = (int) get_option( 'push_syndication_max_pull_attempts', 0 );
 
-		// Bail if we've already met the max pull attempt count
+		// Bail if we've already met the max pull attempt count.
 		if ( ! $max_pull_attempts ) {
 			return;
 		}
 
-		// Only proceed if we have a valid site id
+		// Only proceed if we have a valid site id.
 		if ( 0 === $site_id ) {
 			return;
 		}
@@ -89,9 +89,9 @@ class Failed_Syndication_Auto_Retry {
 			$time_now = time();
 
 			// Create a string time to be sent to the logger.
-			// Add 1 so our log items appear to occur a second later
+			// Add 1 so our log items appear to occur a second later.
 			// and hence order better in the log viewer.
-			// Without this, sometimes when the pull occurs quickly
+			// Without this, sometimes when the pull occurs quickly.
 			// these log items appear to occur at the same time as the failure.
 			$log_time = gmdate( 'Y-m-d H:i:s', $time_now + 1 );
 
@@ -107,9 +107,9 @@ class Failed_Syndication_Auto_Retry {
 
 				// Schedule a pull retry for one minute in the future.
 				wp_schedule_single_event(
-					$auto_retry_interval,     // retry in X time
-					'syn_pull_content',       // fire the syndication_auto_retry hook
-					array( array( $site ) )   // the site which failed to pull
+					$auto_retry_interval,     // Retry in X time.
+					'syn_pull_content',       // Fire the syndication_auto_retry hook.
+					array( array( $site ) )   // The site which failed to pull.
 				);
 
 				// Increment our auto retry counter.
@@ -149,7 +149,7 @@ class Failed_Syndication_Auto_Retry {
 	 */
 	public function handle_pull_success_event( $site_id = 0, $failed_attempts = 0 ) {
 
-		// Remove the auto retry if there was one
+		// Remove the auto retry if there was one.
 		delete_post_meta( $site_id, 'syn_failed_auto_retry_attempts' );
 	}
 }

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -1,9 +1,14 @@
 <?php
+/**
+ * Automatic retry handler for failed syndication pulls.
+ *
+ * @package Syndication
+ */
 
 /**
- * Failed Syndication Auto Retry
+ * Class Failed_Syndication_Auto_Retry
  *
- * Watches syndication events and handles site-related failures.
+ * Watches syndication events and handles site-related failures with automatic retries.
  *
  * There is a cron setup in class-wp-push-syndication-server.php:1266 which will
  * retry a failed pull X times (set in admin settings) and when that limit is met

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -17,10 +17,12 @@ class Syndication_Site_Failure_Monitor {
 	}
 
 	/**
-	 * Handle the pull failure event. If the number of failures exceeds the maximum attempts set in the options, then disable the site.
+	 * Handle the pull failure event.
 	 *
-	 * @param $site_id
-	 * @param $count
+	 * If the number of failures exceeds the maximum attempts set in the options, then disable the site.
+	 *
+	 * @param int $site_id The site ID.
+	 * @param int $count   The failure count.
 	 */
 	public function handle_pull_failure_event( $site_id, $count ) {
 		$site_id = (int) $site_id;

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -1,8 +1,15 @@
 <?php
 /**
- * Site Failure Moniture
+ * Site failure monitor for syndication.
  *
- * Watches syndication events and handles site-related failures.
+ * @package Syndication
+ */
+
+/**
+ * Class Syndication_Site_Failure_Monitor
+ *
+ * Monitors syndication events and handles site-related failures by tracking
+ * pull attempts and disabling sites that exceed the maximum failure threshold.
  *
  * @uses Syndication_Logger
  */

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -39,7 +39,7 @@ class Syndication_Site_Failure_Monitor {
 			do_action( 'push_syndication_reset_event', 'pull_failure', $site_id );
 
 			// Log what happened.
-			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( __( 'Site %d disabled after %d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ) );
+			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( __( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ) );
 
 			do_action( 'push_syndication_site_disabled', $site_id, $count );
 		}

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -6,7 +6,6 @@
  *
  * @uses Syndication_Logger
  */
-
 class Syndication_Site_Failure_Monitor {
 
 	/**

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -1,7 +1,7 @@
 <?php
 
-include_once(dirname(__FILE__) . '/interface-syndication-client.php');
-include_once( dirname( __FILE__ ) . '/push-syndicate-encryption.php' );
+require_once __DIR__ . '/interface-syndication-client.php';
+require_once __DIR__ . '/push-syndicate-encryption.php';
 
 class Syndication_WP_REST_Client implements Syndication_Client {
 
@@ -14,16 +14,19 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 	function __construct( $site_ID, $port = 80, $timeout = 45 ) {
 
-		$this->access_token = push_syndicate_decrypt( get_post_meta( $site_ID, 'syn_site_token', true) );
-		$this->blog_ID	  = get_post_meta( $site_ID, 'syn_site_id', true);
-		$this->timeout	  = $timeout;
-		$this->useragent	= 'push-syndication-plugin';
-		$this->port		 = $port;
-
+		$this->access_token = push_syndicate_decrypt( get_post_meta( $site_ID, 'syn_site_token', true ) );
+		$this->blog_ID      = get_post_meta( $site_ID, 'syn_site_id', true );
+		$this->timeout      = $timeout;
+		$this->useragent    = 'push-syndication-plugin';
+		$this->port         = $port;
 	}
 
 	public static function get_client_data() {
-		return array( 'id' => 'WP_REST', 'modes' => array( 'push' ), 'name' => 'WordPress.com REST' );
+		return array(
+			'id'    => 'WP_REST',
+			'modes' => array( 'push' ),
+			'name'  => 'WordPress.com REST',
+		);
 	}
 
 	/**
@@ -79,36 +82,40 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 	public function new_post( $post_ID ) {
 
-		$post = (array)get_post( $post_ID );
+		$post = (array) get_post( $post_ID );
 
 		// This filter can be used to exclude or alter posts during a content push
 		$post = apply_filters( 'syn_rest_push_filter_new_post', $post, $post_ID );
-		if ( false === $post )
+		if ( false === $post ) {
 			return true;
+		}
 
-		$body = array (
-			'title'		 => $post['post_title'],
-			'content'	   => $post['post_content'],
-			'excerpt'	   => $post['post_excerpt'],
-			'status'		=> $post['post_status'],
-			'password'	  => $post['post_password'],
-			'date'		  => $this->format_date_for_api( $post['post_date_gmt'] ),
-			'categories'	=> $this->_prepare_terms( wp_get_object_terms( $post_ID, 'category', array('fields' => 'names') ) ),
-			'tags'		  => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'post_tag', array('fields' => 'names') ) )
+		$body = array(
+			'title'      => $post['post_title'],
+			'content'    => $post['post_content'],
+			'excerpt'    => $post['post_excerpt'],
+			'status'     => $post['post_status'],
+			'password'   => $post['post_password'],
+			'date'       => $this->format_date_for_api( $post['post_date_gmt'] ),
+			'categories' => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'category', array( 'fields' => 'names' ) ) ),
+			'tags'       => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'post_tag', array( 'fields' => 'names' ) ) ),
 		);
 
 		$body = apply_filters( 'syn_rest_push_filter_new_post_body', $body, $post_ID );
 
-		$response = wp_remote_post( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/new/', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-				'Content-Type'  => 'application/x-www-form-urlencoded'
-			),
-			'body' => $body,
-		) );
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/new/',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+					'Content-Type'  => 'application/x-www-form-urlencoded',
+				),
+				'body'       => $body,
+			) 
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -116,46 +123,49 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return $response->ID;
 		} else {
 			return new WP_Error( 'rest-push-new-fail', $response->message );
 		}
-
 	}
 
 	public function edit_post( $post_ID, $ext_ID ) {
 
-		$post = (array)get_post( $post_ID );
+		$post = (array) get_post( $post_ID );
 
 		// This filter can be used to exclude or alter posts during a content push
 		$post = apply_filters( 'syn_rest_push_filter_edit_post', $post, $post_ID );
-		if ( false === $post )
+		if ( false === $post ) {
 			return true;
+		}
 
-		$body = array (
-			'title'		 => $post['post_title'],
-			'content'	   => $post['post_content'],
-			'excerpt'	   => $post['post_excerpt'],
-			'status'		=> $post['post_status'],
-			'password'	  => $post['post_password'],
-			'date'		  => $this->format_date_for_api( $post['post_date_gmt'] ),
-			'categories'	=> $this->_prepare_terms( wp_get_object_terms( $post_ID, 'category', array('fields' => 'names') ) ),
-			'tags'		  => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'post_tag', array('fields' => 'names') ) )
+		$body = array(
+			'title'      => $post['post_title'],
+			'content'    => $post['post_content'],
+			'excerpt'    => $post['post_excerpt'],
+			'status'     => $post['post_status'],
+			'password'   => $post['post_password'],
+			'date'       => $this->format_date_for_api( $post['post_date_gmt'] ),
+			'categories' => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'category', array( 'fields' => 'names' ) ) ),
+			'tags'       => $this->_prepare_terms( wp_get_object_terms( $post_ID, 'post_tag', array( 'fields' => 'names' ) ) ),
 		);
 
 		$body = apply_filters( 'syn_rest_push_filter_edit_post_body', $body, $post_ID );
 
-		$response = wp_remote_post( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $ext_ID . '/', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-				'Content-Type'  => 'application/x-www-form-urlencoded'
-			),
-			'body' => $body,
-		) );
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $ext_ID . '/',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+					'Content-Type'  => 'application/x-www-form-urlencoded',
+				),
+				'body'       => $body,
+			) 
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -163,12 +173,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return $post_ID;
 		} else {
 			return new WP_Error( 'rest-push-edit-fail', $response->message );
 		}
-
 	}
 
 	// get an array of values and convert it to CSV
@@ -176,12 +185,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$terms_csv = '';
 
-		foreach( $terms as $term ) {
+		foreach ( $terms as $term ) {
 			$terms_csv .= $term . ',';
 		}
 
 		return $terms_csv;
-
 	}
 
 	/**
@@ -206,14 +214,17 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 	public function delete_post( $ext_ID ) {
 
-		$response = wp_remote_post( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $ext_ID . '/delete', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-			),
-		) );
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $ext_ID . '/delete',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			) 
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -221,24 +232,26 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return true;
 		} else {
 			return new WP_Error( 'rest-push-delete-fail', $response->message );
 		}
-
 	}
 
 	public function test_connection() {
 		// @TODo find a better method
-		$response = wp_remote_get( 'https://public-api.wordpress.com/rest/v1/me/?pretty=1', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-			),
-		) );
+		$response = wp_remote_get(
+			'https://public-api.wordpress.com/rest/v1/me/?pretty=1',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			) 
+		);
 
 		// TODO: return WP_Error
 		if ( is_wp_error( $response ) ) {
@@ -247,24 +260,26 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty( $response->error ) ) {
+		if ( empty( $response->error ) ) {
 			return true;
 		} else {
 			return false;
 		}
-
 	}
 
 	public function is_post_exists( $post_ID ) {
 
-		$response = wp_remote_get( 'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $post_ID . '/?pretty=1', array(
-			'timeout'	   => $this->timeout,
-			'user-agent'	=> $this->useragent,
-			'sslverify'	 => false,
-			'headers'	   => array (
-				'authorization' => 'Bearer ' . $this->access_token,
-			),
-		) );
+		$response = wp_remote_get(
+			'https://public-api.wordpress.com/rest/v1/sites/' . $this->blog_ID . '/posts/' . $post_ID . '/?pretty=1',
+			array(
+				'timeout'    => $this->timeout,
+				'user-agent' => $this->useragent,
+				'sslverify'  => false,
+				'headers'    => array(
+					'authorization' => 'Bearer ' . $this->access_token,
+				),
+			) 
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return false;
@@ -272,19 +287,18 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$response = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if( empty($response->error) ) {
+		if ( empty( $response->error ) ) {
 			return true;
 		} else {
 			return false;
 		}
-
 	}
 
 	public static function display_settings( $site ) {
 
-		$site_token = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_token', true) );
-		$site_id	= get_post_meta( $site->ID, 'syn_site_id', true);
-		$site_url   = get_post_meta( $site->ID, 'syn_site_url', true);
+		$site_token = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_token', true ) );
+		$site_id    = get_post_meta( $site->ID, 'syn_site_id', true );
+		$site_url   = get_post_meta( $site->ID, 'syn_site_url', true );
 
 		// @TODO refresh UI
 
@@ -331,13 +345,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		return true;
 	}
 
-	public function get_post( $ext_ID )
-	{
+	public function get_post( $ext_ID ) {
 		// TODO: Implement get_post() method.
 	}
 
-	public function get_posts( $args = array() )
-	{
+	public function get_posts( $args = array() ) {
 		// TODO: Implement get_posts() method.
 	}
 }

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -84,7 +84,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$post = (array) get_post( $post_ID );
 
-		// This filter can be used to exclude or alter posts during a content push
+		// This filter can be used to exclude or alter posts during a content push.
 		$post = apply_filters( 'syn_rest_push_filter_new_post', $post, $post_ID );
 		if ( false === $post ) {
 			return true;
@@ -134,7 +134,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		$post = (array) get_post( $post_ID );
 
-		// This filter can be used to exclude or alter posts during a content push
+		// This filter can be used to exclude or alter posts during a content push.
 		$post = apply_filters( 'syn_rest_push_filter_edit_post', $post, $post_ID );
 		if ( false === $post ) {
 			return true;
@@ -180,7 +180,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		}
 	}
 
-	// get an array of values and convert it to CSV
+	// Get an array of values and convert it to CSV.
 	function _prepare_terms( $terms ) {
 
 		$terms_csv = '';
@@ -240,7 +240,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 	}
 
 	public function test_connection() {
-		// @TODo find a better method
+		// @TODo find a better method.
 		$response = wp_remote_get(
 			'https://public-api.wordpress.com/rest/v1/me/?pretty=1',
 			array(
@@ -253,7 +253,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			) 
 		);
 
-		// TODO: return WP_Error
+		// TODO: return WP_Error.
 		if ( is_wp_error( $response ) ) {
 			return false;
 		}
@@ -300,7 +300,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		$site_id    = get_post_meta( $site->ID, 'syn_site_id', true );
 		$site_url   = get_post_meta( $site->ID, 'syn_site_url', true );
 
-		// @TODO refresh UI
+		// @TODO refresh UI.
 
 		?>
 

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -205,8 +205,14 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		}
 	}
 
-	// Get an array of values and convert it to CSV.
-	function _prepare_terms( $terms ) {
+	/**
+	 * Get an array of values and convert it to CSV.
+	 *
+	 * @param array $terms Array of term values.
+	 *
+	 * @return string CSV formatted string of terms.
+	 */
+	private function _prepare_terms( $terms ) {
 
 		$terms_csv = '';
 

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -12,7 +12,14 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 	private $useragent;
 	private $timeout;
 
-	function __construct( $site_ID, $port = 80, $timeout = 45 ) {
+	/**
+	 * Constructor.
+	 *
+	 * @param int $site_ID The site post ID.
+	 * @param int $port    The port number. Default 80.
+	 * @param int $timeout The request timeout in seconds. Default 45.
+	 */
+	public function __construct( $site_ID, $port = 80, $timeout = 45 ) {
 
 		$this->access_token = push_syndicate_decrypt( get_post_meta( $site_ID, 'syn_site_token', true ) );
 		$this->blog_ID      = get_post_meta( $site_ID, 'syn_site_id', true );
@@ -21,6 +28,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		$this->port         = $port;
 	}
 
+	/**
+	 * Get the client type data.
+	 *
+	 * @return array Client ID, supported modes, and display name.
+	 */
 	public static function get_client_data() {
 		return array(
 			'id'    => 'WP_REST',
@@ -80,6 +92,12 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		return false;
 	}
 
+	/**
+	 * Create a new post on the remote site.
+	 *
+	 * @param int $post_ID The local post ID to syndicate.
+	 * @return int|WP_Error|true The remote post ID on success, WP_Error on failure, or true if filtered out.
+	 */
 	public function new_post( $post_ID ) {
 
 		$post = (array) get_post( $post_ID );
@@ -130,6 +148,13 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		}
 	}
 
+	/**
+	 * Update an existing post on the remote site.
+	 *
+	 * @param int $post_ID The local post ID.
+	 * @param int $ext_ID  The remote post ID.
+	 * @return int|WP_Error|true The local post ID on success, WP_Error on failure, or true if filtered out.
+	 */
 	public function edit_post( $post_ID, $ext_ID ) {
 
 		$post = (array) get_post( $post_ID );
@@ -212,6 +237,12 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		return mysql2date( 'c', $mysql_date, false );
 	}
 
+	/**
+	 * Delete a post on the remote site.
+	 *
+	 * @param int $ext_ID The remote post ID.
+	 * @return true|WP_Error True on success, WP_Error on failure.
+	 */
 	public function delete_post( $ext_ID ) {
 
 		$response = wp_remote_post(
@@ -239,6 +270,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		}
 	}
 
+	/**
+	 * Test the connection to the remote WordPress.com site.
+	 *
+	 * @return bool True if connection is successful, false otherwise.
+	 */
 	public function test_connection() {
 		// @TODo find a better method.
 		$response = wp_remote_get(
@@ -267,6 +303,12 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		}
 	}
 
+	/**
+	 * Check if a post exists on the remote site.
+	 *
+	 * @param int $post_ID The remote post ID.
+	 * @return bool True if post exists, false otherwise.
+	 */
 	public function is_post_exists( $post_ID ) {
 
 		$response = wp_remote_get(
@@ -294,6 +336,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		}
 	}
 
+	/**
+	 * Display the site settings form fields.
+	 *
+	 * @param WP_Post $site The site post object.
+	 */
 	public static function display_settings( $site ) {
 
 		$site_token = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_token', true ) );
@@ -332,6 +379,12 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		do_action( 'syn_after_site_form', $site );
 	}
 
+	/**
+	 * Save the site settings from POST data.
+	 *
+	 * @param int $site_ID The site post ID.
+	 * @return bool True on success.
+	 */
 	public static function save_settings( $site_ID ) {
 		// Use wp_strip_all_tags() for the token instead of sanitize_text_field()
 		// because sanitize_text_field() converts encoded octets (e.g., %B2) which
@@ -345,10 +398,20 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		return true;
 	}
 
+	/**
+	 * Get a post from the remote site.
+	 *
+	 * @param int $ext_ID The remote post ID.
+	 */
 	public function get_post( $ext_ID ) {
 		// TODO: Implement get_post() method.
 	}
 
+	/**
+	 * Get posts from the remote site.
+	 *
+	 * @param array $args Optional arguments.
+	 */
 	public function get_posts( $args = array() ) {
 		// TODO: Implement get_posts() method.
 	}

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -1,8 +1,19 @@
 <?php
+/**
+ * WordPress REST API client for content syndication.
+ *
+ * @package Syndication
+ */
 
 require_once __DIR__ . '/interface-syndication-client.php';
 require_once __DIR__ . '/push-syndicate-encryption.php';
 
+/**
+ * Class Syndication_WP_REST_Client
+ *
+ * Implements the Syndication_Client interface using the WordPress REST API
+ * for pushing and pulling content between sites.
+ */
 class Syndication_WP_REST_Client implements Syndication_Client {
 
 	private $access_token;

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -1,7 +1,7 @@
 <?php
 
-include_once( ABSPATH . 'wp-includes/class-simplepie.php' );
-include_once( dirname(__FILE__) . '/interface-syndication-client.php' );
+require_once ABSPATH . 'wp-includes/class-simplepie.php';
+require_once __DIR__ . '/interface-syndication-client.php';
 
 class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client {
 
@@ -15,7 +15,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 	function __construct( $site_ID ) {
 
-		switch( SIMPLEPIE_VERSION ) {
+		switch ( SIMPLEPIE_VERSION ) {
 			case '1.2.1':
 				parent::SimplePie();
 				break;
@@ -35,11 +35,11 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		
 		$this->set_cache_class( 'WP_Feed_Cache' );
 
-		$this->default_post_type        = get_post_meta( $site_ID, 'syn_default_post_type', true );
-		$this->default_post_status      = get_post_meta( $site_ID, 'syn_default_post_status', true );
-		$this->default_comment_status   = get_post_meta( $site_ID, 'syn_default_comment_status', true );
-		$this->default_ping_status      = get_post_meta( $site_ID, 'syn_default_ping_status', true );
-		$this->default_cat_status       = get_post_meta( $site_ID, 'syn_default_cat_status', true );
+		$this->default_post_type      = get_post_meta( $site_ID, 'syn_default_post_type', true );
+		$this->default_post_status    = get_post_meta( $site_ID, 'syn_default_post_status', true );
+		$this->default_comment_status = get_post_meta( $site_ID, 'syn_default_comment_status', true );
+		$this->default_ping_status    = get_post_meta( $site_ID, 'syn_default_ping_status', true );
+		$this->default_cat_status     = get_post_meta( $site_ID, 'syn_default_cat_status', true );
 
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'save_meta' ), 10, 5 );
 		add_action( 'syn_post_pull_new_post', array( __CLASS__, 'save_tax' ), 10, 5 );
@@ -48,20 +48,24 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 	}
 
 	public static function get_client_data() {
-		return array( 'id' => 'WP_RSS', 'modes' => array( 'pull' ), 'name' => 'RSS' );
+		return array(
+			'id'    => 'WP_RSS',
+			'modes' => array( 'pull' ),
+			'name'  => 'RSS',
+		);
 	}
 
-	public function new_post($post_ID) {
+	public function new_post( $post_ID ) {
 		// Not supported
 		return false;
 	}
 
-	public function edit_post($post_ID, $ext_ID) {
+	public function edit_post( $post_ID, $ext_ID ) {
 		// Not supported
 		return false;
 	}
 
-	public function delete_post($ext_ID) {
+	public function delete_post( $ext_ID ) {
 		// Not supported
 		return false;
 	}
@@ -71,19 +75,19 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		return true;
 	}
 
-	public function is_post_exists($ext_ID) {
+	public function is_post_exists( $ext_ID ) {
 		// Not supported
 		return false;
 	}
 
-	public static function display_settings($site) {
+	public static function display_settings( $site ) {
 
-		$feed_url                   = get_post_meta( $site->ID, 'syn_feed_url', true );
-		$default_post_type          = get_post_meta( $site->ID, 'syn_default_post_type', true );
-		$default_post_status        = get_post_meta( $site->ID, 'syn_default_post_status', true );
-		$default_comment_status     = get_post_meta( $site->ID, 'syn_default_comment_status', true );
-		$default_ping_status        = get_post_meta( $site->ID, 'syn_default_ping_status', true );
-		$default_cat_status         = get_post_meta( $site->ID, 'syn_default_cat_status', true );
+		$feed_url               = get_post_meta( $site->ID, 'syn_feed_url', true );
+		$default_post_type      = get_post_meta( $site->ID, 'syn_default_post_type', true );
+		$default_post_status    = get_post_meta( $site->ID, 'syn_default_post_status', true );
+		$default_comment_status = get_post_meta( $site->ID, 'syn_default_comment_status', true );
+		$default_ping_status    = get_post_meta( $site->ID, 'syn_default_ping_status', true );
+		$default_cat_status     = get_post_meta( $site->ID, 'syn_default_cat_status', true );
 
 		?>
 
@@ -103,8 +107,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 			$post_types = get_post_types();
 
-			foreach( $post_types as $post_type ) {
-				echo '<option value="' . esc_attr( $post_type ) . '"' . selected( $post_type, $default_post_type ) . '>' . esc_html( $post_type )  . '</option>';
+			foreach ( $post_types as $post_type ) {
+				echo '<option value="' . esc_attr( $post_type ) . '"' . selected( $post_type, $default_post_type ) . '>' . esc_html( $post_type ) . '</option>';
 			}
 
 			?>
@@ -119,10 +123,10 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 			<?php
 
-			$post_statuses  = get_post_statuses();
+			$post_statuses = get_post_statuses();
 
-			foreach( $post_statuses as $key => $value ) {
-				echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $default_post_status ) . '>' . esc_html( $key )  . '</option>';
+			foreach ( $post_statuses as $key => $value ) {
+				echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $default_post_status ) . '>' . esc_html( $key ) . '</option>';
 			}
 
 			?>
@@ -134,8 +138,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_comment_status" id="default_comment_status" />
-				<option value="open" <?php selected( 'open', $default_comment_status )  ?> >open</option>
-				<option value="closed" <?php selected( 'closed', $default_comment_status )  ?> >closed</option>
+				<option value="open" <?php selected( 'open', $default_comment_status ); ?> >open</option>
+				<option value="closed" <?php selected( 'closed', $default_comment_status ); ?> >closed</option>
 			</select>
 		</p>
 		<p>
@@ -143,8 +147,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_ping_status" id="default_ping_status" />
-			<option value="open" <?php selected( 'open', $default_ping_status )  ?> >open</option>
-			<option value="closed" <?php selected( 'closed', $default_ping_status )  ?> >closed</option>
+			<option value="open" <?php selected( 'open', $default_ping_status ); ?> >open</option>
+			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?> >closed</option>
 			</select>
 		</p>
 		<p>
@@ -152,8 +156,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_cat_status" id="default_cat_status" />
-			<option value="yes" <?php selected( 'yes', $default_cat_status )  ?> ><?php echo esc_html__( 'import categories', 'push-syndication' ); ?></option>
-			<option value="no" <?php selected( 'no', $default_cat_status )  ?> ><?php echo esc_html__( 'ignore categories', 'push-syndication' ); ?></option>
+			<option value="yes" <?php selected( 'yes', $default_cat_status ); ?> ><?php echo esc_html__( 'import categories', 'push-syndication' ); ?></option>
+			<option value="no" <?php selected( 'no', $default_cat_status ); ?> ><?php echo esc_html__( 'ignore categories', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 
@@ -167,11 +171,10 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		update_post_meta( $site_ID, 'syn_feed_url', esc_url_raw( $_POST['feed_url'] ) );
 		update_post_meta( $site_ID, 'syn_default_post_type', sanitize_text_field( $_POST['default_post_type'] ) );
 		update_post_meta( $site_ID, 'syn_default_post_status', sanitize_text_field( $_POST['default_post_status'] ) );
-		update_post_meta( $site_ID, 'syn_default_comment_status', sanitize_text_field($_POST['default_comment_status'] ) );
+		update_post_meta( $site_ID, 'syn_default_comment_status', sanitize_text_field( $_POST['default_comment_status'] ) );
 		update_post_meta( $site_ID, 'syn_default_ping_status', sanitize_text_field( $_POST['default_ping_status'] ) );
 		update_post_meta( $site_ID, 'syn_default_cat_status', sanitize_text_field( $_POST['default_cat_status'] ) );
 		return true;
-
 	}
 
 	public function get_post( $ext_ID ) {
@@ -199,26 +202,29 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		$this->handle_content_type();
 
 		// hold all the posts
-		$posts = array();
-		$taxonomy = array( 'cats' => array(), 'tags' => array() );
+		$posts    = array();
+		$taxonomy = array(
+			'cats' => array(),
+			'tags' => array(),
+		);
 
-		foreach( $this->get_items() as $item ) {
+		foreach ( $this->get_items() as $item ) {
 			if ( 'yes' == $this->default_cat_status ) {
 				$taxonomy = $this->set_taxonomy( $item );
 			}
 
 			$post = array(
-				'post_title'        => $item->get_title(),
-				'post_content'      => $item->get_content(),
-				'post_excerpt'      => $item->get_description(),
-				'post_type'         => $this->default_post_type,
-				'post_status'       => $this->default_post_status,
-				'post_date'         => date( 'Y-m-d H:i:s', strtotime( $item->get_date() ) ),
-				'comment_status'    => $this->default_comment_status,
-				'ping_status'       => $this->default_ping_status,
-				'post_guid'         => $item->get_id(),
-				'post_category'     => $taxonomy['cats'],
-				'tags_input'        => $taxonomy['tags']
+				'post_title'     => $item->get_title(),
+				'post_content'   => $item->get_content(),
+				'post_excerpt'   => $item->get_description(),
+				'post_type'      => $this->default_post_type,
+				'post_status'    => $this->default_post_status,
+				'post_date'      => date( 'Y-m-d H:i:s', strtotime( $item->get_date() ) ),
+				'comment_status' => $this->default_comment_status,
+				'ping_status'    => $this->default_ping_status,
+				'post_guid'      => $item->get_id(),
+				'post_category'  => $taxonomy['cats'],
+				'tags_input'     => $taxonomy['tags'],
 			);
 			/**
 			 * Exclude or alter posts during an RSS syndication pull.
@@ -232,20 +238,20 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			 * @param int            $site_id The ID of the site post holding the feed data.
 			 */
 			$post = apply_filters( 'syn_rss_pull_filter_post', $post, $args, $item, $this->site_ID );
-			if ( false === $post )
+			if ( false === $post ) {
 				continue;
+			}
 			$posts[] = $post;
 		}
 
 		return $posts;
-
 	}
 
 	public function set_taxonomy( $item ) {
 		$cats = $item->get_categories();
-		$ids = array(
-			'cats'    => array(),
-			'tags'            => array()
+		$ids  = array(
+			'cats' => array(),
+			'tags' => array(),
 		);
 
 		foreach ( $cats as $cat ) {
@@ -276,28 +282,28 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			return false;
 		}
 		$categories = $post['post_category'];
-		wp_set_post_terms($result, $categories, 'category', true);
+		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		//handle enclosures separately first
-		$enc_field = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
+		// handle enclosures separately first
+		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
-		if ( isset( $enclosures ) && isset ( $enc_field ) ) {
+		if ( isset( $enclosures ) && isset( $enc_field ) ) {
 			// first remove all enclosures for the post (for updates) if any
-			delete_post_meta( $result, $enc_field);
-			foreach( $enclosures as $enclosure ) {
-				if (defined('ENCLOSURES_AS_STRINGS') && constant('ENCLOSURES_AS_STRINGS')) {
-					$enclosure = implode("\n", $enclosure);
+			delete_post_meta( $result, $enc_field );
+			foreach ( $enclosures as $enclosure ) {
+				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
+					$enclosure = implode( "\n", $enclosure );
 				}
-				add_post_meta($result, $enc_field, $enclosure, false);
+				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
 			// now remove them from the rest of the metadata before saving the rest
-			unset($metas['enclosures']);
+			unset( $metas['enclosures'] );
 		}
 
-		foreach ($metas as $meta_key => $meta_value) {
-			add_post_meta($result, $meta_key, $meta_value, true);
+		foreach ( $metas as $meta_key => $meta_value ) {
+			add_post_meta( $result, $meta_key, $meta_value, true );
 		}
 	}
 
@@ -306,28 +312,28 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			return false;
 		}
 		$categories = $post['post_category'];
-		wp_set_post_terms($result, $categories, 'category', true);
+		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
 		// handle enclosures separately first
-		$enc_field = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
+		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
 			// first remove all enclosures for the post (for updates)
-			delete_post_meta( $result, $enc_field);
-			foreach( $enclosures as $enclosure ) {
-				if (defined('ENCLOSURES_AS_STRINGS') && constant('ENCLOSURES_AS_STRINGS')) {
-					$enclosure = implode("\n", $enclosure);
+			delete_post_meta( $result, $enc_field );
+			foreach ( $enclosures as $enclosure ) {
+				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
+					$enclosure = implode( "\n", $enclosure );
 				}
-				add_post_meta($result, $enc_field, $enclosure, false);
+				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
 			// now remove them from the rest of the metadata before saving the rest
-			unset($metas['enclosures']);
+			unset( $metas['enclosures'] );
 		}
 
-		foreach ($metas as $meta_key => $meta_value) {
-			update_post_meta($result, $meta_key, $meta_value);
+		foreach ( $metas as $meta_key => $meta_value ) {
+			update_post_meta( $result, $meta_key, $meta_value );
 		}
 	}
 
@@ -341,7 +347,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
-			wp_set_object_terms($result, (string)$tax_value, $tax_name, true);
+			wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 		}
 	}
 
@@ -349,20 +355,20 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {
 			return false;
 		}
-		$taxonomies = $post['tax'];
+		$taxonomies       = $post['tax'];
 		$replace_tax_list = array();
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			//post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
-			if ( !in_array($tax_name, $replace_tax_list ) ) {
-				//if we haven't processed this taxonomy before, replace any terms on the post with the first new one
-				wp_set_object_terms($result, (string)$tax_value, $tax_name );
+			if ( ! in_array( $tax_name, $replace_tax_list ) ) {
+				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one
+				wp_set_object_terms( $result, (string) $tax_value, $tax_name );
 				$replace_tax_list[] = $tax_name;
 			} else {
-				//if we've already added one term for this taxonomy, append any others
-				wp_set_object_terms($result, (string)$tax_value, $tax_name, true);
+				// if we've already added one term for this taxonomy, append any others
+				wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 			}
 		}
 	}

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -56,17 +56,17 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 	}
 
 	public function new_post( $post_ID ) {
-		// Not supported
+		// Not supported.
 		return false;
 	}
 
 	public function edit_post( $post_ID, $ext_ID ) {
-		// Not supported
+		// Not supported.
 		return false;
 	}
 
 	public function delete_post( $ext_ID ) {
-		// Not supported
+		// Not supported.
 		return false;
 	}
 
@@ -76,7 +76,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 	}
 
 	public function is_post_exists( $ext_ID ) {
-		// Not supported
+		// Not supported.
 		return false;
 	}
 
@@ -201,7 +201,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 		$this->handle_content_type();
 
-		// hold all the posts
+		// hold all the posts.
 		$posts    = array();
 		$taxonomy = array(
 			'cats' => array(),
@@ -255,7 +255,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		);
 
 		foreach ( $cats as $cat ) {
-			// checks if term exists
+			// checks if term exists.
 			if ( $result = get_term_by( 'name', $cat->term, 'category' ) ) {
 				if ( isset( $result->term_id ) ) {
 					$ids['cats'][] = $result->term_id;
@@ -265,7 +265,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 					$ids['tags'][] = $result->term_id;
 				}
 			} else {
-				// creates if not
+				// creates if not.
 				$result = wp_insert_term( $cat->term, 'category' );
 				if ( isset( $result->term_id ) ) {
 					$ids['cats'][] = $result->term_id;
@@ -273,7 +273,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			}
 		}
 
-		// returns array ready for post creation
+		// returns array ready for post creation.
 		return $ids;
 	}
 
@@ -285,11 +285,11 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		// handle enclosures separately first
+		// handle enclosures separately first.
 		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates) if any
+			// First remove all enclosures for the post (for updates) if any.
 			delete_post_meta( $result, $enc_field );
 			foreach ( $enclosures as $enclosure ) {
 				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
@@ -298,7 +298,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
+			// now remove them from the rest of the metadata before saving the rest.
 			unset( $metas['enclosures'] );
 		}
 
@@ -315,11 +315,11 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		// handle enclosures separately first
+		// handle enclosures separately first.
 		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates)
+			// First remove all enclosures for the post (for updates).
 			delete_post_meta( $result, $enc_field );
 			foreach ( $enclosures as $enclosure ) {
 				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
@@ -328,7 +328,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
+			// now remove them from the rest of the metadata before saving the rest.
 			unset( $metas['enclosures'] );
 		}
 
@@ -343,7 +343,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		}
 		$taxonomies = $post['tax'];
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			// post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
@@ -358,16 +358,16 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		$taxonomies       = $post['tax'];
 		$replace_tax_list = array();
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			// post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
 			if ( ! in_array( $tax_name, $replace_tax_list ) ) {
-				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one
+				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one.
 				wp_set_object_terms( $result, (string) $tax_value, $tax_name );
 				$replace_tax_list[] = $tax_name;
 			} else {
-				// if we've already added one term for this taxonomy, append any others
+				// if we've already added one term for this taxonomy, append any others.
 				wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 			}
 		}

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -13,7 +13,12 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 
 	private $site_ID;
 
-	function __construct( $site_ID ) {
+	/**
+	 * Constructor.
+	 *
+	 * @param int $site_ID The site post ID.
+	 */
+	public function __construct( $site_ID ) {
 
 		switch ( SIMPLEPIE_VERSION ) {
 			case '1.2.1':
@@ -47,6 +52,11 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		add_action( 'syn_post_pull_edit_post', array( __CLASS__, 'update_tax' ), 10, 5 );
 	}
 
+	/**
+	 * Get the client type data.
+	 *
+	 * @return array Client ID, supported modes, and display name.
+	 */
 	public static function get_client_data() {
 		return array(
 			'id'    => 'WP_RSS',
@@ -55,31 +65,66 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		);
 	}
 
+	/**
+	 * Create a new post on the remote site.
+	 *
+	 * @param int $post_ID The local post ID.
+	 * @return false Not supported for RSS client.
+	 */
 	public function new_post( $post_ID ) {
 		// Not supported.
 		return false;
 	}
 
+	/**
+	 * Update an existing post on the remote site.
+	 *
+	 * @param int $post_ID The local post ID.
+	 * @param int $ext_ID  The remote post ID.
+	 * @return false Not supported for RSS client.
+	 */
 	public function edit_post( $post_ID, $ext_ID ) {
 		// Not supported.
 		return false;
 	}
 
+	/**
+	 * Delete a post on the remote site.
+	 *
+	 * @param int $ext_ID The remote post ID.
+	 * @return false Not supported for RSS client.
+	 */
 	public function delete_post( $ext_ID ) {
 		// Not supported.
 		return false;
 	}
 
+	/**
+	 * Test the connection to the remote site.
+	 *
+	 * @return bool True (always succeeds for RSS).
+	 */
 	public function test_connection() {
 		// TODO: Implement test_connection() method.
 		return true;
 	}
 
+	/**
+	 * Check if a post exists on the remote site.
+	 *
+	 * @param int $ext_ID The remote post ID.
+	 * @return false Not supported for RSS client.
+	 */
 	public function is_post_exists( $ext_ID ) {
 		// Not supported.
 		return false;
 	}
 
+	/**
+	 * Display the site settings form fields.
+	 *
+	 * @param WP_Post $site The site post object.
+	 */
 	public static function display_settings( $site ) {
 
 		$feed_url               = get_post_meta( $site->ID, 'syn_feed_url', true );
@@ -166,6 +211,12 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		do_action( 'syn_after_site_form', $site );
 	}
 
+	/**
+	 * Save the site settings from POST data.
+	 *
+	 * @param int $site_ID The site post ID.
+	 * @return bool True on success.
+	 */
 	public static function save_settings( $site_ID ) {
 
 		update_post_meta( $site_ID, 'syn_feed_url', esc_url_raw( $_POST['feed_url'] ) );
@@ -177,10 +228,21 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		return true;
 	}
 
+	/**
+	 * Get a post from the remote site.
+	 *
+	 * @param int $ext_ID The remote post ID.
+	 */
 	public function get_post( $ext_ID ) {
 		// TODO: Implement get_post() method.
 	}
 
+	/**
+	 * Get posts from the RSS feed.
+	 *
+	 * @param array $args Optional arguments.
+	 * @return array Array of post data arrays.
+	 */
 	public function get_posts( $args = array() ) {
 
 		$site_post = get_post( $this->site_ID );
@@ -247,6 +309,12 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		return $posts;
 	}
 
+	/**
+	 * Set taxonomy terms from a feed item.
+	 *
+	 * @param SimplePie_Item $item The feed item.
+	 * @return array Array of category and tag IDs.
+	 */
 	public function set_taxonomy( $item ) {
 		$cats = $item->get_categories();
 		$ids  = array(
@@ -277,6 +345,16 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		return $ids;
 	}
 
+	/**
+	 * Save post meta for a newly created post.
+	 *
+	 * @param int|WP_Error $result         The post ID or WP_Error.
+	 * @param array        $post           The post data array.
+	 * @param WP_Post      $site           The site post object.
+	 * @param string       $transport_type The transport type.
+	 * @param object       $client         The client instance.
+	 * @return false|void False if conditions not met.
+	 */
 	public static function save_meta( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['postmeta'] ) ) {
 			return false;
@@ -307,6 +385,16 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		}
 	}
 
+	/**
+	 * Update post meta for an existing post.
+	 *
+	 * @param int|WP_Error $result         The post ID or WP_Error.
+	 * @param array        $post           The post data array.
+	 * @param WP_Post      $site           The site post object.
+	 * @param string       $transport_type The transport type.
+	 * @param object       $client         The client instance.
+	 * @return false|void False if conditions not met.
+	 */
 	public static function update_meta( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['postmeta'] ) ) {
 			return false;
@@ -337,6 +425,16 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		}
 	}
 
+	/**
+	 * Save taxonomy terms for a newly created post.
+	 *
+	 * @param int|WP_Error $result         The post ID or WP_Error.
+	 * @param array        $post           The post data array.
+	 * @param WP_Post      $site           The site post object.
+	 * @param string       $transport_type The transport type.
+	 * @param object       $client         The client instance.
+	 * @return false|void False if conditions not met.
+	 */
 	public static function save_tax( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {
 			return false;
@@ -351,6 +449,16 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		}
 	}
 
+	/**
+	 * Update taxonomy terms for an existing post.
+	 *
+	 * @param int|WP_Error $result         The post ID or WP_Error.
+	 * @param array        $post           The post data array.
+	 * @param WP_Post      $site           The site post object.
+	 * @param string       $transport_type The transport type.
+	 * @param object       $client         The client instance.
+	 * @return false|void False if conditions not met.
+	 */
 	public static function update_tax( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {
 			return false;

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -1,8 +1,19 @@
 <?php
+/**
+ * RSS client for content syndication.
+ *
+ * @package Syndication
+ */
 
 require_once ABSPATH . 'wp-includes/class-simplepie.php';
 require_once __DIR__ . '/interface-syndication-client.php';
 
+/**
+ * Class Syndication_WP_RSS_Client
+ *
+ * Implements the Syndication_Client interface using RSS feeds for pulling
+ * content from remote sites. Extends SimplePie for feed parsing.
+ */
 class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client {
 
 	private $default_post_type;

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -753,7 +753,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Rewrite wp_dropdown_categories output to enable a multiple select
 	 *
-	 * @param  string $result rendered category dropdown list
+	 * @param  string $result Rendered category dropdown list.
 	 * @return string altered category dropdown list
 	 */
 	public static function make_multiple_categories_dropdown( $result ) {

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The XML pull client for the Syndication plugin
+ * XML feed client for content syndication.
  *
  * Client for the Syndication plugin to pull in XML feeds for consumption.
  * This was added after the initial 1.0.0 release, but no other releases
@@ -10,22 +10,18 @@
  * @link https://github.com/Automattic/syndication/
  * @since 2.2.0
  *
- * @package WordPress
- * @subpackage Syndication
+ * @package Syndication
  */
 
-/**
- * Load the {@see Walker_CategoryDropdownMultiple}
- */
 require_once __DIR__ . '/class-walker-category-dropdown-multiple.php';
-
-/**
- * Load the {@see Syndication_Client} interface.
- */
 require_once __DIR__ . '/interface-syndication-client.php';
 
 /**
  * Class Syndication_WP_XML_Client
+ *
+ * Implements the Syndication_Client interface for pulling content from
+ * generic XML feeds. Supports configurable node mappings for flexible
+ * feed parsing.
  */
 class Syndication_WP_XML_Client implements Syndication_Client {
 

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -141,8 +141,9 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $post_ID
-	 * @return bool
+	 * @param int $post_ID The post ID.
+	 *
+	 * @return bool Always false as not supported.
 	 */
 	public function new_post( $post_ID ) {
 		return false; // Not supported.
@@ -151,9 +152,10 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $post_ID
-	 * @param int $ext_ID
-	 * @return bool
+	 * @param int $post_ID The local post ID.
+	 * @param int $ext_ID  The external post ID.
+	 *
+	 * @return bool Always false as not supported.
 	 */
 	public function edit_post( $post_ID, $ext_ID ) {
 		return false; // Not supported.
@@ -162,8 +164,9 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $ext_ID
-	 * @return bool
+	 * @param int $ext_ID The external post ID.
+	 *
+	 * @return bool Always false as not supported.
 	 */
 	public function delete_post( $ext_ID ) {
 		return false; // Not supported.
@@ -172,8 +175,9 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Required by the interface, but not used here.
 	 *
-	 * @param int $ext_ID
-	 * @return bool
+	 * @param int $ext_ID The external post ID.
+	 *
+	 * @return bool Always false as not supported.
 	 */
 	public function get_post( $ext_ID ) {
 		return false; // Not supported.
@@ -823,11 +827,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Publish the remote post to the local site.
 	 *
-	 * @param $result
-	 * @param $post
-	 * @param $site
-	 * @param $transport_type
-	 * @param $client
+	 * @param int                          $result         The local post ID.
+	 * @param array                        $post           The post data.
+	 * @param WP_Post                      $site           The site post object.
+	 * @param string                       $transport_type The transport type identifier.
+	 * @param Syndication_Client_Interface $client         The syndication client.
 	 */
 	public static function publish_pulled_post( $result, $post, $site, $transport_type, $client ) {
 		wp_publish_post( $result );
@@ -836,12 +840,13 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Save post meta for the specified post.
 	 *
-	 * @param $result
-	 * @param $post
-	 * @param $site
-	 * @param $transport_type
-	 * @param $client
-	 * @return mixed False if an error of if the data to save isn't passed.
+	 * @param int|WP_Error                 $result         The local post ID or error.
+	 * @param array                        $post           The post data.
+	 * @param WP_Post                      $site           The site post object.
+	 * @param string                       $transport_type The transport type identifier.
+	 * @param Syndication_Client_Interface $client         The syndication client.
+	 *
+	 * @return mixed|false False if an error or if the data to save isn't passed.
 	 */
 	public static function save_meta( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['postmeta'] ) ) {
@@ -876,12 +881,13 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	/**
 	 * Update post meta for the specified post.
 	 *
-	 * @param $result
-	 * @param $post
-	 * @param $site
-	 * @param $transport_type
-	 * @param $client
-	 * @return mixed False if an error of if the data to save isn't passed.
+	 * @param int|WP_Error                 $result         The local post ID or error.
+	 * @param array                        $post           The post data.
+	 * @param WP_Post                      $site           The site post object.
+	 * @param string                       $transport_type The transport type identifier.
+	 * @param Syndication_Client_Interface $client         The syndication client.
+	 *
+	 * @return mixed|false False if an error or if the data to save isn't passed.
 	 */
 	public static function update_meta( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['postmeta'] ) ) {
@@ -914,12 +920,15 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	}
 
 	/**
-	 * @param $result
-	 * @param $post
-	 * @param $site
-	 * @param $transport_type
-	 * @param $client
-	 * @return mixed False if an error of if the data to save isn't passed.
+	 * Save taxonomy terms for the specified post.
+	 *
+	 * @param int|WP_Error                 $result         The local post ID or error.
+	 * @param array                        $post           The post data.
+	 * @param WP_Post                      $site           The site post object.
+	 * @param string                       $transport_type The transport type identifier.
+	 * @param Syndication_Client_Interface $client         The syndication client.
+	 *
+	 * @return mixed|false False if an error or if the data to save isn't passed.
 	 */
 	public static function save_tax( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {
@@ -936,12 +945,15 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	}
 
 	/**
-	 * @param $result
-	 * @param $post
-	 * @param $site
-	 * @param $transport_type
-	 * @param $client
-	 * @return mixed False if an error of if the data to save isn't passed.
+	 * Update taxonomy terms for the specified post.
+	 *
+	 * @param int|WP_Error                 $result         The local post ID or error.
+	 * @param array                        $post           The post data.
+	 * @param WP_Post                      $site           The site post object.
+	 * @param string                       $transport_type The transport type identifier.
+	 * @param Syndication_Client_Interface $client         The syndication client.
+	 *
+	 * @return mixed|false False if an error or if the data to save isn't passed.
 	 */
 	public static function update_tax( $result, $post, $site, $transport_type, $client ) {
 		if ( ! $result || is_wp_error( $result ) || ! isset( $post['tax'] ) ) {

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -89,7 +89,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 *
 	 * @param int $site_ID The ID of the site to pull feeds from.
 	 */
-	function __construct( $site_ID ) {
+	public function __construct( $site_ID ) {
 		$this->site_ID = $site_ID;
 		$this->set_feed_url( get_post_meta( $site_ID, 'syn_feed_url', true ) );
 

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -145,7 +145,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return bool
 	 */
 	public function new_post( $post_ID ) {
-		return false; // Not supported
+		return false; // Not supported.
 	}
 
 	/**
@@ -156,7 +156,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return bool
 	 */
 	public function edit_post( $post_ID, $ext_ID ) {
-		return false; // Not supported
+		return false; // Not supported.
 	}
 
 	/**
@@ -166,7 +166,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return bool
 	 */
 	public function delete_post( $ext_ID ) {
-		return false; // Not supported
+		return false; // Not supported.
 	}
 
 	/**
@@ -176,7 +176,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return bool
 	 */
 	public function get_post( $ext_ID ) {
-		return false; // Not supported
+		return false; // Not supported.
 	}
 
 	/**
@@ -186,11 +186,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return  boolean true on success false on failure.
 	 */
 	public function get_posts( $args = array() ) {
-		// create $post with values from $this::node_to_post
-		// create $post_meta with values from $this::node_to_meta
+		// create $post with values from $this::node_to_post.
+		// create $post_meta with values from $this::node_to_meta.
 
-		// TODO: required fields for post
-		// TODO: handle categories
+		// TODO: required fields for post.
+		// TODO: handle categories.
 
 		$abs_nodes       = array();
 		$item_nodes      = array();
@@ -219,8 +219,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$enclosures_as_strings = isset( $nodes['enclosures_as_strings'] ) ? true : false;
 		unset( $nodes['enclosures_as_strings'] );
 
-		// TODO: add checkbox on feed config to allow enclosures to be saved as strings as SI does
-		// TODO: add tags here and in feed set up UI
+		// TODO: add checkbox on feed config to allow enclosures to be saved as strings as SI does.
+		// TODO: add tags here and in feed set up UI.
 		foreach ( $nodes['nodes'] as $key => $storage_locations ) {
 			foreach ( $storage_locations as $storage_location ) {
 				$storage_location['xpath'] = $key;
@@ -239,7 +239,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$feed = $this->fetch_feed();
 
 		// Catch attempts to pull content from a file which doesn't exist.
-		// TODO: kill feed client if too many failures
+		// TODO: kill feed client if too many failures.
 		$site_post = get_post( $this->site_ID );
 		if ( is_wp_error( $feed ) ) {
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Could not reach feed at: %1$s | Error: %2$s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = null, $extra = array() );
@@ -282,7 +282,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 		$abs_post_fields['enclosures_as_strings'] = $enclosures_as_strings;
 
-		// TODO: handle constant strings in XML
+		// TODO: handle constant strings in XML.
 		foreach ( $abs_nodes as $abs_node ) {
 			$value_array = array();
 			try {
@@ -300,8 +300,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 					$abs_post_fields[ $abs_node['field'] ] = (string) $value_array[0];
 				}
 			} catch ( Exception $e ) {
-				// TODO: catch value not found here and alert for error
-				// TODO: catch multiple values returned here and alert for error
+				// TODO: catch value not found here and alert for error.
+				// TODO: catch multiple values returned here and alert for error.
 				return array();
 			}
 		}
@@ -326,7 +326,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			$item_fields['post_type'] = $this->default_post_type;
 
-			// save photos as enclosures in meta
+			// save photos as enclosures in meta.
 			if ( ( isset( $enc_parent ) && strlen( $enc_parent ) ) && ! empty( $enc_nodes ) ) {
 				$meta_data['enclosures'] = $this->get_encs( $item->xpath( $enc_parent ), $enc_nodes );
 			}
@@ -339,17 +339,17 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 						$value_array = $item->xpath( stripslashes( $save_location['xpath'] ) );
 					}
 					if ( isset( $save_location['is_meta'] ) && $save_location['is_meta'] ) {
-						// SimpleXMLElement::xpath returns either an array or false if an element isn't returned
-						// checking $value_array first avoids the warning we get if the field isn't found
+						// SimpleXMLElement::xpath returns either an array or false if an element isn't returned.
+						// checking $value_array first avoids the warning we get if the field isn't found.
 						if ( $value_array && ( count( $value_array ) > 1 ) ) {
 							$value_array                          = array_map( 'strval', $value_array );
 							$meta_data[ $save_location['field'] ] = $value_array;
 						} elseif ( $value_array ) {
-							// return a string if $value_array contains only a single element
+							// return a string if $value_array contains only a single element.
 							$meta_data[ $save_location['field'] ] = (string) $value_array[0];
 						}
 					} elseif ( isset( $save_location['is_tax'] ) && $save_location['is_tax'] ) {
-						// for some taxonomies, multiple values may be supplied in the field
+						// for some taxonomies, multiple values may be supplied in the field.
 						foreach ( $value_array as $value ) {
 							$tax_data[ $save_location['field'] ] = (string) $value;
 						}
@@ -357,8 +357,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 						$item_fields[ $save_location['field'] ] = (string) $value_array[0];
 					}
 				} catch ( Exception $e ) {
-					// TODO: catch value not found here and alert for error
-					// TODO: catch multiple values returned here and alert for error
+					// TODO: catch value not found here and alert for error.
+					// TODO: catch multiple values returned here and alert for error.
 					return array();
 				}
 			}
@@ -430,11 +430,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 					}
 					$enc_array[ $post_value['field'] ] = esc_attr( (string) $enc_value[0] );
 				} catch ( Exception $e ) {
-					// TODO: catch value not found here and alert for error or not
+					// TODO: catch value not found here and alert for error or not.
 					return true;
 				}
 			}
-			// if position is not provided in the feed, use the order in which they appear in the feed
+			// if position is not provided in the feed, use the order in which they appear in the feed.
 			if ( empty( $enc_array['position'] ) ) {
 				$enc_array['position'] = $count;
 			}
@@ -460,7 +460,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return bool
 	 */
 	public function is_post_exists( $ext_ID ) {
-		return false; // Not supported
+		return false; // Not supported.
 	}
 
 	/**
@@ -469,9 +469,9 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @param   object $site The site object to display settings.
 	 */
 	public static function display_settings( $site ) {
-		// TODO: JS if is_meta show text box, if is_photo show photo select with numbers as values, else show select of post fields
-		// TODO: JS Validation
-		// TODO: deal with ability to select, i.e. media:group/media:thumbnail[@width="75"]/@url (can't be unserialized as is with quotes around 75)
+		// TODO: JS if is_meta show text box, if is_photo show photo select with numbers as values, else show select of post fields.
+		// TODO: JS Validation.
+		// TODO: deal with ability to select, i.e. media:group/media:thumbnail[@width="75"]/@url (can't be unserialized as is with quotes around 75).
 		$feed_url               = get_post_meta( $site->ID, 'syn_feed_url', true );
 		$default_post_type      = get_post_meta( $site->ID, 'syn_default_post_type', true );
 		$default_post_status    = get_post_meta( $site->ID, 'syn_default_post_status', true );
@@ -486,7 +486,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			$namespace = $node_config['namespace'];
 		}
 
-		// unset is outside of isset() test to remove the item from the array if the key is there with no value
+		// Unset is outside of isset() test to remove the item from the array if the key is there with no value.
 		$namespace = isset( $node_config['namespace'] ) ? $node_config['namespace'] : null;
 		unset( $node_config['namespace'] );
 
@@ -764,9 +764,9 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 	 * @return  bool True on success; false on failure.
 	 */
 	public static function save_settings( $site_ID ) {
-		// TODO: adjust to save all settings required by XML feed
+		// TODO: adjust to save all settings required by XML feed.
 		// TODO: validate saved values (e.g. valid post_type? valid status?)
-		// TODO: actually check if saving was successful or not and return a proper bool
+		// TODO: actually check if saving was successful or not and return a proper bool.
 
 		update_post_meta( $site_ID, 'syn_feed_url', esc_url_raw( $_POST['feed_url'] ) );
 		update_post_meta( $site_ID, 'syn_default_post_type', sanitize_text_field( $_POST['default_post_type'] ) );
@@ -785,7 +785,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			foreach ( $node_changes as $row ) {
 				$row_data = array();
 
-				// if no new has been added to the empty row at the end, ignore it
+				// if no new has been added to the empty row at the end, ignore it.
 				if ( ! empty( $row['xpath'] ) ) {
 					foreach ( array( 'is_item', 'is_meta', 'is_tax', 'is_photo' ) as $field ) {
 						$row_data[ $field ] = isset( $row[ $field ] ) && in_array(
@@ -851,11 +851,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		// handle enclosures separately first
+		// handle enclosures separately first.
 		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates) if any
+			// First remove all enclosures for the post (for updates) if any.
 			delete_post_meta( $result, $enc_field );
 			foreach ( $enclosures as $enclosure ) {
 				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
@@ -864,7 +864,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
+			// now remove them from the rest of the metadata before saving the rest.
 			unset( $metas['enclosures'] );
 		}
 
@@ -891,11 +891,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		wp_set_post_terms( $result, $categories, 'category', true );
 		$metas = $post['postmeta'];
 
-		// handle enclosures separately first
+		// handle enclosures separately first.
 		$enc_field  = isset( $metas['enc_field'] ) ? $metas['enc_field'] : null;
 		$enclosures = isset( $metas['enclosures'] ) ? $metas['enclosures'] : null;
 		if ( isset( $enclosures ) && isset( $enc_field ) ) {
-			// first remove all enclosures for the post (for updates)
+			// First remove all enclosures for the post (for updates).
 			delete_post_meta( $result, $enc_field );
 			foreach ( $enclosures as $enclosure ) {
 				if ( defined( 'ENCLOSURES_AS_STRINGS' ) && constant( 'ENCLOSURES_AS_STRINGS' ) ) {
@@ -904,7 +904,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 				add_post_meta( $result, $enc_field, $enclosure, false );
 			}
 
-			// now remove them from the rest of the metadata before saving the rest
+			// now remove them from the rest of the metadata before saving the rest.
 			unset( $metas['enclosures'] );
 		}
 
@@ -927,7 +927,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		}
 		$taxonomies = $post['tax'];
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			// post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
@@ -950,16 +950,16 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$taxonomies       = $post['tax'];
 		$replace_tax_list = array();
 		foreach ( $taxonomies as $tax_name => $tax_value ) {
-			// post cannot be used to create new taxonomy
+			// post cannot be used to create new taxonomy.
 			if ( ! taxonomy_exists( $tax_name ) ) {
 				continue;
 			}
 			if ( ! in_array( $tax_name, $replace_tax_list ) ) {
-				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one
+				// if we haven't processed this taxonomy before, replace any terms on the post with the first new one.
 				wp_set_object_terms( $result, (string) $tax_value, $tax_name );
 				$replace_tax_list[] = $tax_name;
 			} else {
-				// if we've already added one term for this taxonomy, append any others
+				// if we've already added one term for this taxonomy, append any others.
 				wp_set_object_terms( $result, (string) $tax_value, $tax_name, true );
 			}
 		}

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -1,10 +1,21 @@
 <?php
+/**
+ * XML-RPC client for content syndication.
+ *
+ * @package Syndication
+ */
 
 require_once ABSPATH . 'wp-includes/class-IXR.php';
 require_once ABSPATH . 'wp-includes/class-wp-http-ixr-client.php';
 require_once __DIR__ . '/interface-syndication-client.php';
 require_once __DIR__ . '/push-syndicate-encryption.php';
 
+/**
+ * Class Syndication_WP_XMLRPC_Client
+ *
+ * Implements the Syndication_Client interface using WordPress XML-RPC API
+ * for pushing and pulling content between sites.
+ */
 class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndication_Client {
 
 	private $username;

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -538,14 +538,14 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 	}
 
 	protected function convert_date_gmt( $date_gmt, $date ) {
-		if ( $date !== '0000-00-00 00:00:00' && $date_gmt === '0000-00-00 00:00:00' ) {
+		if ( '0000-00-00 00:00:00' !== $date && '0000-00-00 00:00:00' === $date_gmt ) {
 			return new IXR_Date( get_gmt_from_date( mysql2date( 'Y-m-d H:i:s', $date, false ), 'Ymd\TH:i:s' ) );
 		}
 		return $this->convert_date( $date_gmt );
 	}
 
 	protected function convert_date( $date ) {
-		if ( $date === '0000-00-00 00:00:00' ) {
+		if ( '0000-00-00 00:00:00' === $date ) {
 			return new IXR_Date( '00000000T00:00:00Z' );
 		}
 		return new IXR_Date( mysql2date( 'Ymd\TH:i:s', $date, false ) );
@@ -707,7 +707,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		);
 		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
-		if ( $result !== true ) {
+		if ( true !== $result ) {
 			// failed to update atatchment post details.
 			// Handle it the way you want it (log it, message it).
 		}
@@ -813,7 +813,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 
 		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
-		if ( $result !== true ) {
+		if ( true !== $result ) {
 			// failed to update atatchment post details.
 			// Handle it the way you want it (log it, message it).
 			error_log( 'Syndication. xmlrpc_post_gallery_images Failed to update remote post attachments' );

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -14,7 +14,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 	function __construct( $site_ID ) {
 
-		// @TODO check port, timeout etc
+		// @TODO check port, timeout etc.
 		$server = untrailingslashit( get_post_meta( $site_ID, 'syn_site_url', true ) );
 		if ( false === strpos( $server, 'xmlrpc.php' ) ) {
 			$server = esc_url_raw( trailingslashit( $server ) . 'xmlrpc.php' );
@@ -31,12 +31,12 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		if ( true === apply_filters( 'syn_xmlrpc_push_send_thumbnail', true, $site_ID, $this ) ) {
 			add_action( 'syn_xmlrpc_push_new_post_success', array( $this, 'post_push_send_thumbnail' ), 10, 6 );
 			add_action( 'syn_xmlrpc_push_edit_post_success', array( $this, 'post_push_send_thumbnail' ), 10, 6 );
-			// TODO: on delete post, delete thumbnail
+			// TODO: on delete post, delete thumbnail.
 		}
 	}
 
 	private function get_thumbnail_meta_keys( $post_id ) {
-		// Support for non-core images, like from the Multiple Post Thumbnail plugin
+		// Support for non-core images, like from the Multiple Post Thumbnail plugin.
 		return apply_filters( 'syn_xmlrpc_push_thumbnail_metas', array( '_thumbnail_id' ), $post_id );
 	}
 
@@ -77,8 +77,8 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			}
 
 			list( $thumbnail_url ) = wp_get_attachment_image_src( $thumbnail_id, 'full' );
-			// pass thumbnail data and meta into the addThumnail to sync caption, description and alt-text
-			// has to be this way since mw_newMediaObject doesn't allow to pass description and caption along
+			// pass thumbnail data and meta into the addThumnail to sync caption, description and alt-text.
+			// has to be this way since mw_newMediaObject doesn't allow to pass description and caption along.
 			$thumbnail_post_data = get_post( $thumbnail_id );
 			$thumbnail_alt_text  = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
 			
@@ -113,16 +113,16 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 		$post = (array) get_post( $post_ID );
 
-		// This filter can be used to exclude or alter posts during a content push
+		// This filter can be used to exclude or alter posts during a content push.
 		$post = apply_filters( 'syn_xmlrpc_push_filter_new_post', $post, $post_ID );
 		if ( false === $post ) {
 			return true;
 		}
 		
-		// Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs
+		// Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs.
 		$post['post_content'] = $this->syndicate_gallery_images( $post['post_content'] );
 
-		// rearranging arguments
+		// rearranging arguments.
 		$args                  = array();
 		$args['post_title']    = $post['post_title'];
 		$args['post_content']  = $post['post_content'];
@@ -163,7 +163,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 		$post = (array) get_post( $post_ID );
 
-		// This filter can be used to exclude or alter posts during a content push
+		// This filter can be used to exclude or alter posts during a content push.
 		$post = apply_filters( 'syn_xmlrpc_push_filter_edit_post', $post, $post_ID );
 		if ( false === $post ) {
 			return true;
@@ -175,7 +175,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			return new WP_Error( 'syn-remote-post-not-found', esc_html__( 'Remote post doesn\'t exist.', 'push-syndication' ) );
 		}
 
-		// Delete existing metadata to avoid duplicates
+		// Delete existing metadata to avoid duplicates.
 		$args['custom_fields'] = array();
 		foreach ( $remote_post['custom_fields'] as $custom_field ) {
 			$args['custom_fields'][] = array( 
@@ -198,8 +198,8 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			$syndicated_thumbnail_id = isset( $syndicated_thumbnails_by_site[ $this->site_ID ] ) ? $syndicated_thumbnails_by_site[ $this->site_ID ] : false;
 
 			if ( $syndicated_thumbnail_id == $thumbnail_id ) {
-				// need to preserve old meta custom_type_thumbnail_id if it wasn't changed during update
-				// hence we remove ID from the custom_fileds list in order to avoid its deletion
+				// need to preserve old meta custom_type_thumbnail_id if it wasn't changed during update.
+				// hence we remove ID from the custom_fileds list in order to avoid its deletion.
 				foreach ( $args['custom_fields'] as $index => $value ) {
 					if ( $value['meta_key_lookup'] == $thumbnail_meta_key ) {
 						unset( $args['custom_fields'][ $index ] );
@@ -208,10 +208,10 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			}
 		}
 
-		// Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs
+		// Uploads all gallery images to the remote site and replaces [gallery] tags with new IDs.
 		$post['post_content'] = $this->syndicate_gallery_images( $post['post_content'] );
 
-		// rearranging arguments
+		// rearranging arguments.
 		$args['post_title']    = $post['post_title'];
 		$args['post_content']  = $post['post_content'];
 		$args['post_excerpt']  = $post['post_excerpt'];
@@ -256,7 +256,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 	private function syndicate_gallery_images( $post_content ) {
 		$attachment_ids = array();
 		global $shortcode_tags;
-		// overwrite global shortcodes for gallery only and then revert back to original
+		// overwrite global shortcodes for gallery only and then revert back to original.
 		$temp           = $shortcode_tags;
 		$shortcode_tags = array( 'gallery' => 'gallery_shortcode' );
 		$pattern        = get_shortcode_regex();
@@ -279,7 +279,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		if ( ! empty( $image_ids ) ) {
 			foreach ( $image_ids as $key => $gallery_ids ) {
 				foreach ( $gallery_ids as $index => $id ) {
-					// do upload, get new ID back
+					// do upload, get new ID back.
 					list( $thumbnail_url ) = wp_get_attachment_image_src( $id, 'full' );
 					$thumbnail_post_data   = get_post( $id );
 					$thumbnail_alt_text    = trim( get_post_meta( $id, '_wp_attachment_image_alt', true ) );
@@ -302,12 +302,12 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			}
 		}
 
-		// new IDs needs to be injected into the post content
-		// replace old gallery code with a new one
+		// new IDs needs to be injected into the post content.
+		// replace old gallery code with a new one.
 		$lenght = count( $matches[0] );
 		for ( $i = 0; $i < $lenght; $i++ ) {
 			$shortcode = $matches[0][ $i ];
-			// WP regex matches attribute with leading space, required here
+			// WP regex matches attribute with leading space, required here.
 			$attribute     = ' ids="' . implode( ',', $image_ids[ $i ] ) . '"';
 			$new_attribute = ' ids="' . implode( ',', $new_image_ids[ $i ] ) . '"';
 			$new_shortcode = str_replace( $attribute, $new_attribute, $shortcode );
@@ -347,7 +347,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			}
 
 			foreach ( $post_meta_values as $post_meta_value ) {
-				$post_meta_value = maybe_unserialize( $post_meta_value ); // get_post_custom returns serialized data
+				$post_meta_value = maybe_unserialize( $post_meta_value ); // get_post_custom returns serialized data.
 
 				$custom_fields[] = array(
 					'key'   => $post_meta_key,
@@ -384,7 +384,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			$terms_names['post_tag'] = wp_get_object_terms( $post_id, 'post_tag', array( 'fields' => 'names' ) );
 		}
 
-		// TODO: custom taxonomy
+		// TODO: custom taxonomy.
 
 		return $terms_names;
 	}
@@ -672,7 +672,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			),
 		);
 
-		// Note: Leting mw_newMediaObject handle our auth and cap checks
+		// Note: Leting mw_newMediaObject handle our auth and cap checks.
 		$image = $wp_xmlrpc_server->mw_newMediaObject( $args );
 
 		if ( ! is_array( $image ) || empty( $image['url'] ) ) {
@@ -705,13 +705,13 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 				'post_excerpt' => $thumbnail_post_data['post_excerpt'],
 			),
 		);
-		// update caption and description of the image
+		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
 		if ( $result !== true ) {
-			// failed to update atatchment post details
-			// handle it th way you want it (log it, message it)
+			// failed to update atatchment post details.
+			// Handle it the way you want it (log it, message it).
 		}
-		// update alt text of the image
+		// update alt text of the image.
 		update_post_meta( $thumbnail_id, '_wp_attachment_image_alt', $thumbnail_alt_text );
 
 		return $thumbnail_id;
@@ -788,7 +788,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			),
 		);
 
-		// Note: Leting mw_newMediaObject handle our auth and cap checks
+		// Note: Leting mw_newMediaObject handle our auth and cap checks.
 		$image = $wp_xmlrpc_server->mw_newMediaObject( $args );
 		if ( ! is_array( $image ) || empty( $image['url'] ) ) {
 			return $image;
@@ -811,14 +811,14 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			),
 		);
 
-		// update caption and description of the image
+		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
 		if ( $result !== true ) {
-			// failed to update atatchment post details
-			// handle it th way you want it (log it, message it)
+			// failed to update atatchment post details.
+			// Handle it the way you want it (log it, message it).
 			error_log( 'Syndication. xmlrpc_post_gallery_images Failed to update remote post attachments' );
 		}
-		// update alt text of the image
+		// update alt text of the image.
 		update_post_meta( $thumbnail_id, '_wp_attachment_image_alt', $thumbnail_alt_text );
 
 		return $thumbnail_id;

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -12,7 +12,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 	private $site_ID;
 
-	function __construct( $site_ID ) {
+	public function __construct( $site_ID ) {
 
 		// @TODO check port, timeout etc.
 		$server = untrailingslashit( get_post_meta( $site_ID, 'syn_site_url', true ) );
@@ -40,7 +40,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		return apply_filters( 'syn_xmlrpc_push_thumbnail_metas', array( '_thumbnail_id' ), $post_id );
 	}
 
-	function post_push_send_thumbnail( $remote_post_id, $post_id ) {
+	public function post_push_send_thumbnail( $remote_post_id, $post_id ) {
 
 		$thumbnail_meta_keys = $this->get_thumbnail_meta_keys( $post_id ); 
 
@@ -450,7 +450,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		return true;
 	}
 
-	function get_remote_post( $remote_post_id ) {
+	public function get_remote_post( $remote_post_id ) {
 
 		$result = $this->query(
 			'wp.getPost',

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -250,7 +250,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 	 *
 	 * @access private
 	 * @uses $shortcode_tags global variable
-	 * @param string $post_content - post to be syndicated
+	 * @param string $post_content Post to be syndicated.
 	 * @return string $post_content - post content with replaced gallery shortcodes
 	 */
 	private function syndicate_gallery_images( $post_content ) {
@@ -753,7 +753,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 	 * Upload Image for the gallery shortcode
 	 *
 	 * @uses $wp_xmlrpc_server
-	 * @param array $args Contains necessary parameters for XMLRCP call: user, paasword, image data
+	 * @param array $args Contains necessary parameters for XMLRPC call: user, password, image data.
 	 * @return integer $thumbnail_id New ID of the newly uploaded image to the remote site
 	 */
 	public static function xmlrpc_post_gallery_images( $args ) {

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -707,9 +707,9 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		);
 		// update caption and description of the image.
 		$result = $wp_xmlrpc_server->wp_editPost( $args );
+		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf -- TODO: handle attachment update failure.
 		if ( true !== $result ) {
-			// failed to update atatchment post details.
-			// Handle it the way you want it (log it, message it).
+			// Failed to update attachment post details.
 		}
 		// update alt text of the image.
 		update_post_meta( $thumbnail_id, '_wp_attachment_image_alt', $thumbnail_alt_text );

--- a/includes/class-walker-category-dropdown-multiple.php
+++ b/includes/class-walker-category-dropdown-multiple.php
@@ -24,7 +24,7 @@ class Walker_CategoryDropdownMultiple extends Walker {
 	 * @param array  $args              An array of arguments. @see wp_list_categories().
 	 * @param int    $current_object_id ID of the current category.
 	 */
-	function start_el( &$output, $category, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	public function start_el( &$output, $category, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		$pad = str_repeat( '&nbsp;', $depth * 3 );
 
 		$cat_name = apply_filters( 'list_cats', $category->name, $category );

--- a/includes/class-walker-category-dropdown-multiple.php
+++ b/includes/class-walker-category-dropdown-multiple.php
@@ -21,8 +21,8 @@ class Walker_CategoryDropdownMultiple extends Walker {
 	 * @param string $output   Passed by reference. Used to append additional content.
 	 * @param object $category Category data object.
 	 * @param int    $depth    Depth of category in reference to parents. Default 0.
-	 * @param array  $args     An array of arguments. @see wp_list_categories()
-	 * @param int    $id       ID of the current category.
+	 * @param array  $args              An array of arguments. @see wp_list_categories().
+	 * @param int    $current_object_id ID of the current category.
 	 */
 	function start_el( &$output, $category, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		$pad = str_repeat( '&nbsp;', $depth * 3 );

--- a/includes/class-walker-category-dropdown-multiple.php
+++ b/includes/class-walker-category-dropdown-multiple.php
@@ -1,19 +1,22 @@
 <?php
 /**
  * Create HTML list of categories. Allowing a multiple select list
+ *
  * @uses Walker
  */
 class Walker_CategoryDropdownMultiple extends Walker {
 
 	var $tree_type = 'category';
 
-	var $db_fields = array ('parent' => 'parent', 'id' => 'term_id');
+	var $db_fields = array(
+		'parent' => 'parent',
+		'id'     => 'term_id',
+	);
 
 	/**
 	 * Start the element output.
 	 *
 	 * @see Walker::start_el()
-	 *
 	 *
 	 * @param string $output   Passed by reference. Used to append additional content.
 	 * @param object $category Category data object.
@@ -26,15 +29,15 @@ class Walker_CategoryDropdownMultiple extends Walker {
 
 		$cat_name = apply_filters( 'list_cats', $category->name, $category );
 
-		$output .= "\t<option class=\"level-$depth\" value=\"".$category->term_id."\"";
+		$output .= "\t<option class=\"level-$depth\" value=\"" . $category->term_id . '"';
 		if ( isset( $args['selected_array'] ) && in_array( $category->term_id, $args['selected_array'] ) ) {
 			$output .= ' selected="selected"';
 		}
 		$output .= '>';
-		$output .= $pad.$cat_name;
+		$output .= $pad . $cat_name;
 
 		if ( $args['show_count'] ) {
-			$output .= '&nbsp;&nbsp;('. $category->count .')';
+			$output .= '&nbsp;&nbsp;(' . $category->count . ')';
 		}
 		$output .= "</option>\n";
 	}

--- a/includes/class-walker-category-dropdown-multiple.php
+++ b/includes/class-walker-category-dropdown-multiple.php
@@ -1,8 +1,15 @@
 <?php
 /**
- * Create HTML list of categories. Allowing a multiple select list
+ * Walker for multiple-select category dropdowns.
  *
- * @uses Walker
+ * @package Syndication
+ */
+
+/**
+ * Class Walker_CategoryDropdownMultiple
+ *
+ * Creates an HTML list of categories allowing multiple selections.
+ * Used for selecting categories when configuring syndication sites.
  */
 class Walker_CategoryDropdownMultiple extends Walker {
 

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -6,10 +6,13 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	var $enabled_verbosity = false;
 
 	/**
-	 * Pushes all posts of a given type
+	 * Pushes all posts of a given type.
 	 *
 	 * @subcommand push-all-posts
 	 * @synopsis [--post_type=<post-type>] [--paged=<page>]
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments including post_type and paged.
 	 */
 	function push_all_posts( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args(

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -47,7 +47,13 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		}
 	}
 
-	function push_post( $args, $assoc_args ) {
+	/**
+	 * Push a post to syndicated sites.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments including post_id.
+	 */
+	public function push_post( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
@@ -73,7 +79,13 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$server->push_content( $sites );
 	}
 
-	function pull_site( $args, $assoc_args ) {
+	/**
+	 * Pull content from a syndicated site.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments including site_id.
+	 */
+	public function pull_site( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
@@ -94,12 +106,18 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$this->_get_syndication_server()->pull_content( array( $site ) );
 	}
 
-	function pull_sitegroup( $args, $assoc_args ) {
+	/**
+	 * Pull content from all sites in a sitegroup.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments including sitegroup.
+	 */
+	public function pull_sitegroup( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
 				'sitegroup' => '',
-			) 
+			)
 		);
 
 		$sitegroup = sanitize_key( $assoc_args['sitegroup'] );
@@ -118,6 +136,11 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$server->pull_content( $sites );
 	}
 
+	/**
+	 * Enable verbose output for pull operations.
+	 *
+	 * Hooks into syndication filters and actions to output progress information to the CLI.
+	 */
 	private function _make_em_talk_pull() {
 		if ( $this->enabled_verbosity ) {
 			return;
@@ -157,6 +180,11 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		);
 	}
 
+	/**
+	 * Enable verbose output for push operations.
+	 *
+	 * Hooks into syndication filters and actions to output progress information to the CLI.
+	 */
 	private function _make_em_talk_push() {
 		if ( $this->enabled_verbosity ) {
 			return;
@@ -195,10 +223,21 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		);
 	}
 
+	/**
+	 * Get the global syndication server instance.
+	 *
+	 * @return WP_Push_Syndication_Server The syndication server instance.
+	 */
 	private function _get_syndication_server() {
 		return $GLOBALS['push_syndication_server'];
 	}
 
+	/**
+	 * Clear object caches to reduce memory usage during long-running operations.
+	 *
+	 * Resets WP query cache and object cache to prevent memory exhaustion
+	 * when processing large numbers of posts.
+	 */
 	protected function stop_the_insanity() {
 		global $wpdb, $wp_object_cache;
 

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * WP-CLI commands for content syndication.
+ *
+ * @package Syndication
+ */
 
 WP_CLI::add_command( 'syndication', 'Syndication_CLI_Command' );
 
+/**
+ * Class Syndication_CLI_Command
+ *
+ * Provides WP-CLI commands for managing content syndication,
+ * including bulk push operations and syndication status checks.
+ */
 class Syndication_CLI_Command extends WP_CLI_Command {
 	var $enabled_verbosity = false;
 

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -12,23 +12,26 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	 * @synopsis [--post_type=<post-type>] [--paged=<page>]
 	 */
 	function push_all_posts( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'post_type' 	=> 'post',
-			'paged' 		=> 1
-		) );
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'post_type' => 'post',
+				'paged'     => 1,
+			) 
+		);
 
 		$query_args = array(
-			'post_type' 		=> $assoc_args[ 'post_type' ],
-			'posts_per_page' 	=> 150,
-			'paged'				=> $assoc_args[ 'paged' ]
+			'post_type'      => $assoc_args['post_type'],
+			'posts_per_page' => 150,
+			'paged'          => $assoc_args['paged'],
 		);
 
 		$query = new WP_Query( $query_args );
 
-		while( $query->post_count ) {
-			WP_CLI::log( sprintf( 'Processing page %d', $query_args[ 'paged' ] ) );
+		while ( $query->post_count ) {
+			WP_CLI::log( sprintf( 'Processing page %d', $query_args['paged'] ) );
 
-			foreach( $query->posts as $post ) {
+			foreach ( $query->posts as $post ) {
 				WP_CLI::log( sprintf( 'Processing post %d (%s)', $post->ID, $post->post_title ) );
 
 				$this->push_post( array(), array( 'post_id' => $post->ID ) );
@@ -38,19 +41,22 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 
 			sleep( 2 );
 
-			$query_args[ 'paged' ]++;
+			++$query_args['paged'];
 
 			$query = new WP_Query( $query_args );
 		}
 	}
 
 	function push_post( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'post_id' => 0,
-		) );
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'post_id' => 0,
+			) 
+		);
 
-		$post_id = intval( $assoc_args[ 'post_id' ] );
-		$post = get_post( $post_id );
+		$post_id = intval( $assoc_args['post_id'] );
+		$post    = get_post( $post_id );
 		if ( ! $post ) {
 			WP_CLI::error( __( 'Invalid post_id', 'push-syndication' ) );
 		}
@@ -58,7 +64,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$this->_make_em_talk_push();
 
 		$server = $this->_get_syndication_server();
-		$sites = $server->get_sites_by_post_ID( $post_id );
+		$sites  = $server->get_sites_by_post_ID( $post_id );
 
 		if ( empty( $sites ) ) {
 			WP_CLI::error( __( 'Post has no selected sitegroups / sites', 'push-syndication' ) );
@@ -68,15 +74,19 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	}
 
 	function pull_site( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'site_id' => 0,
-		) );
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'site_id' => 0,
+			) 
+		);
 
 		$site_id = intval( $assoc_args['site_id'] );
-		$site = get_post( $site_id );
+		$site    = get_post( $site_id );
 
-		if ( ! $site || 'syn_site' !== $site->post_type )
-			WP_CLI::error( "Please select a valid site." );
+		if ( ! $site || 'syn_site' !== $site->post_type ) {
+			WP_CLI::error( 'Please select a valid site.' );
+		}
 
 		// enable verbosity
 		$this->_make_em_talk_pull();
@@ -85,17 +95,21 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	}
 
 	function pull_sitegroup( $args, $assoc_args ) {
-		$assoc_args = wp_parse_args( $assoc_args, array(
-			'sitegroup' => '',
-		) );
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'sitegroup' => '',
+			) 
+		);
 
 		$sitegroup = sanitize_key( $assoc_args['sitegroup'] );
 
-		if ( empty( $sitegroup ) )
-			WP_CLI::error( "Please specify a valid sitegroup" );
+		if ( empty( $sitegroup ) ) {
+			WP_CLI::error( 'Please specify a valid sitegroup' );
+		}
 
 		$server = $this->_get_syndication_server();
-		$sites = $server->get_sites_by_sitegroup( $sitegroup );
+		$sites  = $server->get_sites_by_sitegroup( $sitegroup );
 
 		// enable verbosity
 		$this->_make_em_talk_pull();
@@ -105,49 +119,80 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	}
 
 	private function _make_em_talk_pull() {
-		if ( $this->enabled_verbosity )
+		if ( $this->enabled_verbosity ) {
 			return;
+		}
 
 		$this->enabled_verbosity = true;
 
 		// output when a post is new or updated
-		add_filter( 'syn_pre_pull_posts', function( $posts, $site, $client ) {
-			WP_CLI::log( sprintf( 'Processing feed %s (%d)', $site->post_title, $site->ID ) );
-			WP_CLI::log( sprintf( '-- found %s posts', count( $posts ) ) );
+		add_filter(
+			'syn_pre_pull_posts',
+			function ( $posts, $site, $client ) {
+				WP_CLI::log( sprintf( 'Processing feed %s (%d)', $site->post_title, $site->ID ) );
+				WP_CLI::log( sprintf( '-- found %s posts', count( $posts ) ) );
 
-			return $posts;
-		}, 10, 3 );
+				return $posts;
+			},
+			10,
+			3 
+		);
 
-		add_action( 'syn_post_pull_new_post', function( $result, $post, $site, $transport_type, $client ) {
-			WP_CLI::log( sprintf( '-- New post #%d (%s)', $result, $post['post_guid'] ) );
-		}, 10, 5 );
+		add_action(
+			'syn_post_pull_new_post',
+			function ( $result, $post, $site, $transport_type, $client ) {
+				WP_CLI::log( sprintf( '-- New post #%d (%s)', $result, $post['post_guid'] ) );
+			},
+			10,
+			5 
+		);
 
-		add_action( 'syn_post_pull_edit_post', function( $result, $post, $site, $transport_type, $client ) {
-			WP_CLI::log( sprintf( '-- Updated post #%d (%s)', $result, $post['post_guid'] ) );
-		}, 10, 5 );
+		add_action(
+			'syn_post_pull_edit_post',
+			function ( $result, $post, $site, $transport_type, $client ) {
+				WP_CLI::log( sprintf( '-- Updated post #%d (%s)', $result, $post['post_guid'] ) );
+			},
+			10,
+			5 
+		);
 	}
 
 	private function _make_em_talk_push() {
-		if ( $this->enabled_verbosity )
+		if ( $this->enabled_verbosity ) {
 			return;
+		}
 
 		$this->enabled_verbosity = true;
 
-		add_filter( 'syn_pre_push_post_sites', function( $sites, $post_id, $slave_states ) {
-			WP_CLI::log( sprintf( "Processing post_id #%d (%s)", $post_id, get_the_title( $post_id ) ) );
-			WP_CLI::log( sprintf( "-- pushing to %s sites and deleting from %s sites", number_format( count( $sites['selected_sites'] ) ), number_format( count( $sites['removed_sites'] ) ) ) );
+		add_filter(
+			'syn_pre_push_post_sites',
+			function ( $sites, $post_id, $slave_states ) {
+				WP_CLI::log( sprintf( 'Processing post_id #%d (%s)', $post_id, get_the_title( $post_id ) ) );
+				WP_CLI::log( sprintf( '-- pushing to %s sites and deleting from %s sites', number_format( count( $sites['selected_sites'] ) ), number_format( count( $sites['removed_sites'] ) ) ) );
 
-			return $sites;
-		}, 10, 3 );
+				return $sites;
+			},
+			10,
+			3 
+		);
 
-		add_action( 'syn_post_push_new_post', function( $result, $post_ID, $site, $transport_type, $client, $info ) {
-			WP_CLI::log( sprintf( '-- Added remote post #%d (%s)', $post_ID, $site->post_title ) );
-		}, 10, 6 );
+		add_action(
+			'syn_post_push_new_post',
+			function ( $result, $post_ID, $site, $transport_type, $client, $info ) {
+				WP_CLI::log( sprintf( '-- Added remote post #%d (%s)', $post_ID, $site->post_title ) );
+			},
+			10,
+			6 
+		);
 
-		add_action( 'syn_post_push_edit_post', function( $result, $post_ID, $site, $transport_type, $client, $info ) {
-			WP_CLI::log( sprintf( '-- Updated remote post #%d (%s)', $post_ID, $site->post_title ) );
-		}, 10, 6 );
-
+		add_action(
+			'syn_post_push_edit_post',
+			function ( $result, $post_ID, $site, $transport_type, $client, $info ) {
+				WP_CLI::log( sprintf( '-- Updated remote post #%d (%s)', $post_ID, $site->post_title ) );
+			},
+			10,
+			6 
+		);
 	}
 
 	private function _get_syndication_server() {
@@ -159,15 +204,17 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 
 		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
 
-		if ( !is_object( $wp_object_cache ) )
+		if ( ! is_object( $wp_object_cache ) ) {
 			return;
+		}
 
-		$wp_object_cache->group_ops = array();
-		$wp_object_cache->stats = array();
+		$wp_object_cache->group_ops      = array();
+		$wp_object_cache->stats          = array();
 		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache = array();
+		$wp_object_cache->cache          = array();
 
-		if ( is_callable( $wp_object_cache, '__remoteset' ) )
+		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 			$wp_object_cache->__remoteset(); // important
+		}
 	}
 }

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -88,7 +88,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( 'Please select a valid site.' );
 		}
 
-		// enable verbosity
+		// Enable verbosity.
 		$this->_make_em_talk_pull();
 
 		$this->_get_syndication_server()->pull_content( array( $site ) );
@@ -111,10 +111,10 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$server = $this->_get_syndication_server();
 		$sites  = $server->get_sites_by_sitegroup( $sitegroup );
 
-		// enable verbosity
+		// Enable verbosity.
 		$this->_make_em_talk_pull();
 
-		// do it, to it
+		// Do it, to it.
 		$server->pull_content( $sites );
 	}
 
@@ -125,7 +125,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 
 		$this->enabled_verbosity = true;
 
-		// output when a post is new or updated
+		// Output when a post is new or updated.
 		add_filter(
 			'syn_pre_pull_posts',
 			function ( $posts, $site, $client ) {
@@ -202,7 +202,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	protected function stop_the_insanity() {
 		global $wpdb, $wp_object_cache;
 
-		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
+		$wpdb->queries = array(); // Or define( 'WP_IMPORTING', true ).
 
 		if ( ! is_object( $wp_object_cache ) ) {
 			return;
@@ -214,7 +214,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 		$wp_object_cache->cache          = array();
 
 		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-			$wp_object_cache->__remoteset(); // important
+			$wp_object_cache->__remoteset(); // Important.
 		}
 	}
 }

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -14,7 +14,7 @@ class Syndication_CLI_Command extends WP_CLI_Command {
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments including post_type and paged.
 	 */
-	function push_all_posts( $args, $assoc_args ) {
+	public function push_all_posts( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * Main syndication server class.
+ *
+ * @package Syndication
+ */
 
 require_once __DIR__ . '/class-syndication-client-factory.php';
 
+/**
+ * Class WP_Push_Syndication_Server
+ *
+ * Core syndication server that handles plugin initialization, admin interfaces,
+ * settings management, and orchestrates content push/pull operations between sites.
+ */
 class WP_Push_Syndication_Server {
 
 	const CUSTOM_USER_AGENT = 'WordPress/Syndication Plugin';

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -247,7 +247,7 @@ class WP_Push_Syndication_Server {
 	public function load_scripts_and_styles( $hook ) {
 		global $typenow;
 		if ( 'syn_site' == $typenow ) {
-			if ( $hook == 'edit.php' ) {
+			if ( 'edit.php' === $hook ) {
 				wp_enqueue_style( 'syn-edit-sites', plugins_url( 'css/sites.css', __FILE__ ), array(), $this->version );
 			} elseif ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
 				wp_enqueue_style( 'syn-edit-site', plugins_url( 'css/edit-site.css', __FILE__ ), array(), $this->version );
@@ -978,7 +978,7 @@ class WP_Push_Syndication_Server {
 					}
 				}
 
-				if ( $info['state'] == 'new' || $info['state'] == 'new-error' ) { // States 'new' and 'new-error'.
+				if ( 'new' === $info['state'] || 'new-error' === $info['state'] ) { // States 'new' and 'new-error'.
 
 					$push_new_shortcircuit = apply_filters( 'syn_pre_push_new_post_shortcircuit', false, $post_ID, $site, $transport_type, $client, $info );
 					if ( true === $push_new_shortcircuit ) {
@@ -1014,7 +1014,7 @@ class WP_Push_Syndication_Server {
 				$info           = $this->get_site_info( $site->ID, $slave_post_states, $client );
 
 				// if the post is not pushed we do not need to delete them.
-				if ( $info['state'] == 'success' || $info['state'] == 'edit-error' || $info['state'] == 'remove-error' ) {
+				if ( 'success' === $info['state'] || 'edit-error' === $info['state'] || 'remove-error' === $info['state'] ) {
 					$result = $client->delete_post( $info['ext_ID'] );
 					if ( is_wp_error( $result ) ) {
 						$slave_post_states['remove-error'][ $site->ID ] = $result;
@@ -1057,7 +1057,7 @@ class WP_Push_Syndication_Server {
 
 				foreach ( $sites as $site ) {
 					$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true );
-					if ( $site_enabled == 'on' ) {
+					if ( 'on' === $site_enabled ) {
 						$data['selected_sites'][] = $site;
 					}
 				}
@@ -1075,7 +1075,7 @@ class WP_Push_Syndication_Server {
 
 				foreach ( $sites as $site ) {
 					$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true );
-					if ( $site_enabled == 'on' ) {
+					if ( 'on' === $site_enabled ) {
 						$data['removed_sites'][] = $site;
 					}
 				}
@@ -1189,7 +1189,7 @@ class WP_Push_Syndication_Server {
 
 		// if slave post deletion is not enabled return.
 		$delete_pushed_posts = ! empty( $this->push_syndicate_settings['delete_pushed_posts'] ) ? $this->push_syndicate_settings['delete_pushed_posts'] : 'off';
-		if ( $delete_pushed_posts != 'on' ) {
+		if ( 'on' !== $delete_pushed_posts ) {
 			return;
 		}
 
@@ -1222,7 +1222,7 @@ class WP_Push_Syndication_Server {
 			$site_enabled = get_post_meta( $site_ID, 'syn_site_enabled', true );
 
 			// check whether the site is enabled.
-			if ( $site_enabled == 'on' ) {
+			if ( 'on' === $site_enabled ) {
 				$transport_type = get_post_meta( $site_ID, 'syn_transport_type', true );
 				$client         = Syndication_Client_Factory::get_client( $transport_type, $site_ID );
 
@@ -1392,7 +1392,7 @@ class WP_Push_Syndication_Server {
 			$site_id = $site->ID;
 
 			$site_enabled = get_post_meta( $site_id, 'syn_site_enabled', true );
-			if ( $site_enabled != 'on' ) {
+			if ( 'on' !== $site_enabled ) {
 				continue;
 			}
 
@@ -1428,7 +1428,7 @@ class WP_Push_Syndication_Server {
 							continue;
 						}
 						// if updation is disabled continue.
-						if ( $this->push_syndicate_settings['update_pulled_posts'] != 'on' ) {
+						if ( 'on' !== $this->push_syndicate_settings['update_pulled_posts'] ) {
 							Syndication_Logger::log_post_info( $site_id, $status = 'skip_update_pulled_posts', $message = sprintf( __( 'skipping post update per update_pulled_posts setting', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 							continue;
 						}

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -14,46 +14,46 @@ class WP_Push_Syndication_Server {
 
 	function __construct() {
 
-		// initialization
+		// initialization.
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-		// custom columns
+		// custom columns.
 		add_filter( 'manage_edit-syn_site_columns', array( $this, 'add_new_columns' ) );
 		add_action( 'manage_syn_site_posts_custom_column', array( $this, 'manage_columns' ), 10, 2 );
 
-		// submenus
+		// submenus.
 		add_action( 'admin_menu', array( $this, 'register_syndicate_settings' ) );
 
-		// defining sites
+		// defining sites.
 		add_action( 'save_post', array( $this, 'save_site_settings' ) );
 
-		// loading necessary styles and scripts
+		// loading necessary styles and scripts.
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts_and_styles' ) );
 
-		// filter admin notices in custom post types
+		// filter admin notices in custom post types.
 		add_filter( 'post_updated_messages', array( $this, 'push_syndicate_admin_messages' ) );
 
-		// syndicating content
+		// syndicating content.
 		add_action( 'add_meta_boxes', array( $this, 'add_post_metaboxes' ) );
-		add_action( 'transition_post_status', array( $this, 'save_syndicate_settings' ) ); // use transition_post_status instead of save_post because the former is fired earlier which causes race conditions when a site group select and publish happen on the same load
+		add_action( 'transition_post_status', array( $this, 'save_syndicate_settings' ) ); // Use transition_post_status instead of save_post because the former is fired earlier which causes race conditions when a site group select and publish happen on the same load.
 		add_action( 'wp_trash_post', array( $this, 'delete_content' ) );
 
-		// adding custom time interval
+		// adding custom time interval.
 		add_filter( 'cron_schedules', array( $this, 'cron_add_pull_time_interval' ) );
 
-		// firing a cron job
+		// firing a cron job.
 		add_action( 'transition_post_status', array( $this, 'pre_schedule_push_content' ), 10, 3 );
 		add_action( 'delete_post', array( $this, 'schedule_delete_content' ) );
 
-		// Handle changes to sites and site groups
+		// Handle changes to sites and site groups.
 		add_action( 'save_post', array( $this, 'handle_site_change' ) );
 		add_action( 'delete_post', array( $this, 'handle_site_change' ) );
 		add_action( 'create_term', array( $this, 'handle_site_group_change' ), 10, 3 );
 		add_action( 'delete_term', array( $this, 'handle_site_group_change' ), 10, 3 );
 
 		// Generic hook for reprocessing all scheduled pull jobs. This allows
-		// for bulk rescheduling of jobs that were scheduled the old way (one job
+		// for bulk rescheduling of jobs that were scheduled the old way (one job.
 		// for many sites).
 		add_action( 'syn_refresh_pull_jobs', array( $this, 'refresh_pull_jobs' ) );
 
@@ -71,7 +71,7 @@ class WP_Push_Syndication_Server {
 			'edit_post'          => $capability,
 			'read_post'          => $capability,
 			'delete_post'        => $capability,
-			'delete_posts'       => $capability, // only added to address notice caused by https://core.trac.wordpress.org/ticket/30991
+			'delete_posts'       => $capability, // Only added to address notice caused by https://core.trac.wordpress.org/ticket/30991.
 			'edit_posts'         => $capability,
 			'edit_others_posts'  => $capability,
 			'publish_posts'      => $capability,
@@ -104,7 +104,7 @@ class WP_Push_Syndication_Server {
 				'publicly_queryable'   => false,
 				'exclude_from_search'  => true,
 				'menu_position'        => 100,
-				// @TODO we need a menu icon here
+				// @TODO we need a menu icon here.
 				'hierarchical'         => false, // @TODO check this
 				'query_var'            => false,
 				'rewrite'              => false,
@@ -210,7 +210,7 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function admin_init() {
-		// @TODO define more parameters
+		// @TODO define more parameters.
 		$name_match = '#class-syndication-(.+)-client\.php$#';
 
 		$full_path = __DIR__ . '/';
@@ -236,11 +236,11 @@ class WP_Push_Syndication_Server {
 		}
 		$this->push_syndicate_transports = apply_filters( 'syn_transports', $this->push_syndicate_transports );
 
-		// register settings
+		// register settings.
 		register_setting( 'push_syndicate_settings', 'push_syndicate_settings', array( $this, 'push_syndicate_settings_validate' ) );
 		register_setting( 'push_syndicate_settings', 'push_syndication_max_pull_attempts', array( $this, 'validate_max_pull_attempts' ) );
 
-		// Maybe run upgrade
+		// Maybe run upgrade.
 		$this->upgrade();
 	}
 
@@ -336,7 +336,7 @@ class WP_Push_Syndication_Server {
 
 	public function display_pull_sitegroups_selection() {
 
-		// get all sitegroups
+		// get all sitegroups.
 		$sitegroups = get_terms(
 			'syn_sitegroup',
 			array(
@@ -346,7 +346,7 @@ class WP_Push_Syndication_Server {
 			) 
 		);
 
-		// if there are no sitegroups defined return
+		// if there are no sitegroups defined return.
 		if ( empty( $sitegroups ) ) {
 			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
@@ -411,7 +411,7 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function display_update_pulled_posts_selection() {
-		// @TODO refractor this
+		// @TODO refractor this.
 		echo '<input type="checkbox" name="push_syndicate_settings[update_pulled_posts]" value="on" ';
 		echo checked( $this->push_syndicate_settings['update_pulled_posts'], 'on' ) . ' />';
 	}
@@ -422,7 +422,7 @@ class WP_Push_Syndication_Server {
 
 	public function display_post_types_selection() {
 
-		// @TODO add more suitable filters
+		// @TODO add more suitable filters.
 		$post_types = get_post_types( array( 'public' => true ) );
 
 		echo '<ul>';
@@ -450,13 +450,13 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function display_delete_pushed_posts_selection() {
-		// @TODO refractor this
+		// @TODO refractor this.
 		echo '<input type="checkbox" name="push_syndicate_settings[delete_pushed_posts]" value="on" ';
 		echo checked( $this->push_syndicate_settings['delete_pushed_posts'], 'on' ) . ' />';
 	}
 
 	public function display_apitoken_description() {
-		// @TODO add client type information
+		// @TODO add client type information.
 		echo '<p>' . esc_html__( 'To syndicate content to WordPress.com you must ', 'push-syndication' ) . '<a href="https://developer.wordpress.com/apps/new/">' . esc_html__( 'create a new application', 'push-syndication' ) . '</a></p>';
 		echo '<p>' . esc_html__( 'Enter the Redirect URI as follows', 'push-syndication' ) . '</p>';
 		echo '<p><b>' . esc_html( menu_page_url( 'push-syndicate-settings', false ) ) . '</p></b>';
@@ -477,7 +477,7 @@ class WP_Push_Syndication_Server {
 
 		echo '<h3>' . esc_html__( 'Authorization ', 'push-syndication' ) . '</h3>';
 
-		// if code is not found return or settings updated return
+		// if code is not found return or settings updated return.
 		if ( empty( $_GET['code'] ) || ! empty( $_GET['settings-updated'] ) ) {
 			echo '<p>' . esc_html__( 'Click the authorize button to generate api token', 'push-syndication' ) . '</p>';
 
@@ -549,7 +549,7 @@ class WP_Push_Syndication_Server {
 		$selected_sitegroups = get_option( 'syn_selected_sitegroups' );
 		$selected_sitegroups = ! empty( $selected_sitegroups ) ? $selected_sitegroups : array();
 
-		// get all sitegroups
+		// get all sitegroups.
 		$sitegroups = get_terms(
 			'syn_sitegroup',
 			array(
@@ -559,7 +559,7 @@ class WP_Push_Syndication_Server {
 			) 
 		);
 
-		// if there are no sitegroups defined return
+		// if there are no sitegroups defined return.
 		if ( empty( $sitegroups ) ) {
 			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
@@ -673,12 +673,12 @@ class WP_Push_Syndication_Server {
 		$transport_type = get_post_meta( $post->ID, 'syn_transport_type', true );
 		$site_enabled   = get_post_meta( $post->ID, 'syn_site_enabled', true );
 
-		// default values
+		// default values.
 		$transport_type = ! empty( $transport_type ) ? $transport_type : 'WP_XMLRPC';
 		$transport_mode = ! empty( $transport_mode ) ? $transport_mode : 'pull';
 		$site_enabled   = ! empty( $site_enabled ) ? $site_enabled : 'off';
 
-		// nonce for verification when saving
+		// nonce for verification when saving.
 		wp_nonce_field( plugin_basename( __FILE__ ), 'site_settings_noncename' );
 
 		$this->display_transports( $transport_type, $transport_mode );
@@ -699,7 +699,7 @@ class WP_Push_Syndication_Server {
 	public function display_transports( $transport_type, $mode ) {
 
 		echo '<p>' . esc_html__( 'Select a transport type', 'push-syndication' ) . '</p>';
-		// TODO: add direction
+		// TODO: add direction.
 		echo '<select name="transport_type" onchange="this.form.submit()">';
 
 		$values  = array();
@@ -715,19 +715,19 @@ class WP_Push_Syndication_Server {
 
 		global $post;
 
-		// autosave verification
+		// autosave verification.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
 
-		// if our nonce isn't there, or we can't verify it return
+		// if our nonce isn't there, or we can't verify it return.
 		if ( ! isset( $_POST['site_settings_noncename'] ) || ! wp_verify_nonce( $_POST['site_settings_noncename'], plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 
-		$transport_type = sanitize_text_field( $_POST['transport_type'] ); // TODO: validate this exists
+		$transport_type = sanitize_text_field( $_POST['transport_type'] ); // TODO: validate this exists.
 
-		// @TODO validate that type and mode are valid
+		// @TODO validate that type and mode are valid.
 		update_post_meta( $post->ID, 'syn_transport_type', $transport_type );
 
 		$site_enabled = sanitize_text_field( $_POST['site_enabled'] );
@@ -769,7 +769,7 @@ class WP_Push_Syndication_Server {
 
 	public function push_syndicate_admin_messages( $messages ) {
 
-		// general error messages
+		// general error messages.
 		$messages['syn_site'][250] = __( 'Transport class not found!', 'push-syndication' );
 		$messages['syn_site'][251] = __( 'Connection Successful!', 'push-syndication' );
 		$messages['syn_site'][252] = __( 'Something went wrong when connecting to the site. Site disabled.', 'push-syndication' );
@@ -782,17 +782,17 @@ class WP_Push_Syndication_Server {
 		$messages['syn_site'][305] = __( 'Transport error. Invalid endpoint', 'push-syndication' );
 		$messages['syn_site'][306] = __( 'Something went wrong when connecting to the site.', 'push-syndication' );
 
-		// WordPress.com REST error messages
+		// WordPress.com REST error messages.
 		$messages['site'][301] = __( 'Invalid URL', 'push-syndication' );
 
-		// RSS error messages
+		// RSS error messages.
 
 		return $messages;
 	}
 
 	public function add_post_metaboxes() {
 
-		// return if no post types supports push syndication
+		// return if no post types supports push syndication.
 		if ( empty( $this->push_syndicate_settings['selected_post_types'] ) ) {
 			return;
 		}
@@ -804,7 +804,7 @@ class WP_Push_Syndication_Server {
 		$selected_post_types = $this->push_syndicate_settings['selected_post_types'];
 		foreach ( $selected_post_types as $selected_post_type ) {
 			add_meta_box( 'syndicatediv', __( ' Syndicate ' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
-			// add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' );
+			// add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' ); // phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- Commented out code.
 		}
 	}
 
@@ -812,10 +812,10 @@ class WP_Push_Syndication_Server {
 
 		global $post;
 
-		// nonce for verification when saving
+		// nonce for verification when saving.
 		wp_nonce_field( plugin_basename( __FILE__ ), 'syndicate_noncename' );
 
-		// get all sitegroups
+		// get all sitegroups.
 		$sitegroups = get_terms(
 			'syn_sitegroup',
 			array(
@@ -825,7 +825,7 @@ class WP_Push_Syndication_Server {
 			) 
 		);
 
-		// if there are no sitegroups defined return
+		// if there are no sitegroups defined return.
 		if ( empty( $sitegroups ) ) {
 			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
@@ -883,12 +883,12 @@ class WP_Push_Syndication_Server {
 
 		global $post;
 
-		// autosave verification
+		// autosave verification.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
 
-		// if our nonce isn't there, or we can't verify it return
+		// if our nonce isn't there, or we can't verify it return.
 		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
@@ -906,17 +906,17 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function add_syndication_status_metabox() {
-		// @TODO retrieve syndication status and display
+		// @TODO retrieve syndication status and display.
 	}
 
 	public function pre_schedule_push_content( $new_status, $old_status, $post ) {
 
-		// autosave verification
+		// autosave verification.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
 
-		// if our nonce isn't there, or we can't verify it return
+		// if our nonce isn't there, or we can't verify it return.
 		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
@@ -942,22 +942,22 @@ class WP_Push_Syndication_Server {
 		);
 	}
 
-	// cron job function to syndicate content
+	// cron job function to syndicate content.
 	public function push_content( $sites ) {
 
-		// if another process running on it return
+		// if another process running on it return.
 		if ( get_transient( 'syn_syndicate_lock' ) == 'locked' ) {
 			return;
 		}
 
-		// set value as locked, valid for 5 mins
+		// set value as locked, valid for 5 mins.
 		set_transient( 'syn_syndicate_lock', 'locked', 60 * 5 );
 
 		/** start of critical section */
 
 		$post_ID = $sites['post_ID'];
 
-		// an array containing states of sites
+		// an array containing states of sites.
 		$slave_post_states = get_post_meta( $post_ID, '_syn_slave_post_states', true );
 		$slave_post_states = ! empty( $slave_post_states ) ? $slave_post_states : array();
 
@@ -978,7 +978,7 @@ class WP_Push_Syndication_Server {
 					}
 				}
 
-				if ( $info['state'] == 'new' || $info['state'] == 'new-error' ) { // states 'new' and 'new-error'
+				if ( $info['state'] == 'new' || $info['state'] == 'new-error' ) { // States 'new' and 'new-error'.
 
 					$push_new_shortcircuit = apply_filters( 'syn_pre_push_new_post_shortcircuit', false, $post_ID, $site, $transport_type, $client, $info );
 					if ( true === $push_new_shortcircuit ) {
@@ -991,7 +991,7 @@ class WP_Push_Syndication_Server {
 					$this->update_slave_post_states( $post_ID, $slave_post_states );
 
 					do_action( 'syn_post_push_new_post', $result, $post_ID, $site, $transport_type, $client, $info );
-				} else { // states 'success', 'edit-error' and 'remove-error'
+				} else { // States 'success', 'edit-error' and 'remove-error'.
 					$push_edit_shortcircuit = apply_filters( 'syn_pre_push_edit_post_shortcircuit', false, $post_ID, $site, $transport_type, $client, $info );
 					if ( true === $push_edit_shortcircuit ) {
 						continue;
@@ -1013,7 +1013,7 @@ class WP_Push_Syndication_Server {
 				$client         = Syndication_Client_Factory::get_client( $transport_type, $site->ID );
 				$info           = $this->get_site_info( $site->ID, $slave_post_states, $client );
 
-				// if the post is not pushed we do not need to delete them
+				// if the post is not pushed we do not need to delete them.
 				if ( $info['state'] == 'success' || $info['state'] == 'edit-error' || $info['state'] == 'remove-error' ) {
 					$result = $client->delete_post( $info['ext_ID'] );
 					if ( is_wp_error( $result ) ) {
@@ -1039,7 +1039,7 @@ class WP_Push_Syndication_Server {
 		$old_sitegroups      = ! empty( $old_sitegroups ) ? $old_sitegroups : array();
 		$removed_sitegroups  = array_diff( $old_sitegroups, $selected_sitegroups );
 
-		// initialization
+		// initialization.
 		$data = array(
 			'post_ID'        => $post_ID,
 			'selected_sites' => array(),
@@ -1049,7 +1049,7 @@ class WP_Push_Syndication_Server {
 		if ( ! empty( $selected_sitegroups ) ) {
 			foreach ( $selected_sitegroups as $selected_sitegroup ) {
 
-				// get all the sites in the sitegroup
+				// get all the sites in the sitegroup.
 				$sites = $this->get_sites_by_sitegroup( $selected_sitegroup );
 				if ( empty( $sites ) ) {
 					continue;
@@ -1067,7 +1067,7 @@ class WP_Push_Syndication_Server {
 		if ( ! empty( $removed_sitegroups ) ) {
 			foreach ( $removed_sitegroups as $removed_sitegroup ) {
 
-				// get all the sites in the sitegroup
+				// get all the sites in the sitegroup.
 				$sites = $this->get_sites_by_sitegroup( $removed_sitegroup );
 				if ( empty( $sites ) ) {
 					continue;
@@ -1087,7 +1087,7 @@ class WP_Push_Syndication_Server {
 		return $data;
 	}
 
-	// return an array of sites as objects based on sitegroup
+	// return an array of sites as objects based on sitegroup.
 	public function get_sites_by_sitegroup( $sitegroup ) {
 
 		// @TODO if sitegroup is deleted?
@@ -1187,7 +1187,7 @@ class WP_Push_Syndication_Server {
 
 	public function pre_schedule_delete_content( $post_id ) {
 
-		// if slave post deletion is not enabled return
+		// if slave post deletion is not enabled return.
 		$delete_pushed_posts = ! empty( $this->push_syndicate_settings['delete_pushed_posts'] ) ? $this->push_syndicate_settings['delete_pushed_posts'] : 'off';
 		if ( $delete_pushed_posts != 'on' ) {
 			return;
@@ -1221,7 +1221,7 @@ class WP_Push_Syndication_Server {
 		foreach ( $slave_posts as $site_ID => $ext_ID ) {
 			$site_enabled = get_post_meta( $site_ID, 'syn_site_enabled', true );
 
-			// check whether the site is enabled
+			// check whether the site is enabled.
 			if ( $site_enabled == 'on' ) {
 				$transport_type = get_post_meta( $site_ID, 'syn_transport_type', true );
 				$client         = Syndication_Client_Factory::get_client( $transport_type, $site_ID );
@@ -1244,19 +1244,19 @@ class WP_Push_Syndication_Server {
 		}
 
 		update_option( 'syn_delete_error_sites', $delete_error_sites );
-		// all post metadata will be automatically deleted including slave_post_states
+		// all post metadata will be automatically deleted including slave_post_states.
 	}
 
-	// get the slave posts as $site_ID => $ext_ID
+	// get the slave posts as $site_ID => $ext_ID.
 	public function get_slave_posts( $post_ID ) {
 
-		// array containing states of sites
+		// array containing states of sites.
 		$slave_post_states = get_post_meta( $post_ID, '_syn_slave_post_states', true );
 		if ( empty( $slave_post_states ) ) {
 			return;
 		}
 
-		// array containing slave posts as $site_ID => $ext_ID
+		// array containing slave posts as $site_ID => $ext_ID.
 		$slave_posts = array();
 
 		foreach ( $slave_post_states as $state ) {
@@ -1270,7 +1270,7 @@ class WP_Push_Syndication_Server {
 		return $slave_posts;
 	}
 
-	// checking user capability
+	// checking user capability.
 	public function current_user_can_syndicate() {
 		$syndicate_cap = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 		return current_user_can( $syndicate_cap );
@@ -1312,8 +1312,8 @@ class WP_Push_Syndication_Server {
 
 	public function schedule_pull_content( $sites ) {
 
-		// to unschedule a cron we need the original arguements passed to schedule the cron
-		// we are saving it as a siteoption
+		// to unschedule a cron we need the original arguements passed to schedule the cron.
+		// we are saving it as a siteoption.
 		$old_pull_sites = get_option( 'syn_old_pull_sites' );
 
 
@@ -1351,7 +1351,7 @@ class WP_Push_Syndication_Server {
 			$sites = array_merge( $sites, $this->get_sites_by_sitegroup( $selected_sitegroup ) );
 		}
 
-		// Order by last update date
+		// Order by last update date.
 		usort( $sites, array( $this, 'sort_sites_by_last_pull_date' ) );
 
 		return $sites;
@@ -1427,7 +1427,7 @@ class WP_Push_Syndication_Server {
 							Syndication_Logger::log_post_info( $site_id, $status = 'skip_pre_pull_edit_post', $message = sprintf( __( 'skipping post per syn_pre_pull_edit_post_shortcircuit', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 							continue;
 						}
-						// if updation is disabled continue
+						// if updation is disabled continue.
 						if ( $this->push_syndicate_settings['update_pulled_posts'] != 'on' ) {
 							Syndication_Logger::log_post_info( $site_id, $status = 'skip_update_pulled_posts', $message = sprintf( __( 'skipping post update per update_pulled_posts setting', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 							continue;
@@ -1574,7 +1574,7 @@ class WP_Push_Syndication_Server {
 			return;
 		}
 
-		// upgrade to 2.1
+		// Upgrade to 2.1.
 		if ( version_compare( $this->version, '2.0', '<=' ) ) {
 			$inserted_posts_by_site = $wpdb->get_col( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'syn_inserted_posts'" );
 			foreach ( $inserted_posts_by_site as $site_id ) {

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -12,7 +12,7 @@ class WP_Push_Syndication_Server {
 
 	private $version;
 
-	function __construct() {
+	public function __construct() {
 
 		// initialization.
 		add_action( 'init', array( $this, 'init' ) );
@@ -366,7 +366,6 @@ class WP_Push_Syndication_Server {
 			</p>
 
 			<?php
-
 		}
 	}
 
@@ -440,7 +439,6 @@ class WP_Push_Syndication_Server {
 			</li>
 
 			<?php
-
 		}
 
 		echo '</ul>';
@@ -580,7 +578,6 @@ class WP_Push_Syndication_Server {
 			</p>
 
 			<?php
-
 		}
 	}
 
@@ -849,7 +846,6 @@ class WP_Push_Syndication_Server {
 				<p> <?php echo esc_html( $sitegroup->description ); ?> </p>
 			</li>
 			<?php
-
 		}
 
 		echo '</ul>';
@@ -935,7 +931,7 @@ class WP_Push_Syndication_Server {
 		do_action( 'syn_schedule_push_content', $post->ID, $sites );
 	}
 
-	function schedule_push_content( $post_id, $sites ) {
+	public function schedule_push_content( $post_id, $sites ) {
 		wp_schedule_single_event(
 			time() - 1,
 			'syn_push_content',
@@ -943,7 +939,11 @@ class WP_Push_Syndication_Server {
 		);
 	}
 
-	// cron job function to syndicate content.
+	/**
+	 * Cron job function to syndicate content.
+	 *
+	 * @param array $sites Array of sites data to syndicate content to.
+	 */
 	public function push_content( $sites ) {
 
 		// if another process running on it return.
@@ -1088,7 +1088,13 @@ class WP_Push_Syndication_Server {
 		return $data;
 	}
 
-	// return an array of sites as objects based on sitegroup.
+	/**
+	 * Return an array of sites as objects based on sitegroup.
+	 *
+	 * @param object $sitegroup The sitegroup term object.
+	 *
+	 * @return array Array of site post objects.
+	 */
 	public function get_sites_by_sitegroup( $sitegroup ) {
 
 		// @TODO if sitegroup is deleted?
@@ -1274,7 +1280,13 @@ class WP_Push_Syndication_Server {
 		// all post metadata will be automatically deleted including slave_post_states.
 	}
 
-	// get the slave posts as $site_ID => $ext_ID.
+	/**
+	 * Get the slave posts as $site_ID => $ext_ID.
+	 *
+	 * @param int $post_ID The post ID to get slave posts for.
+	 *
+	 * @return array|void Array of slave posts or void if none exist.
+	 */
 	public function get_slave_posts( $post_ID ) {
 
 		// array containing states of sites.
@@ -1297,7 +1309,11 @@ class WP_Push_Syndication_Server {
 		return $slave_posts;
 	}
 
-	// checking user capability.
+	/**
+	 * Check if the current user has syndication capability.
+	 *
+	 * @return bool Whether the current user can syndicate.
+	 */
 	public function current_user_can_syndicate() {
 		$syndicate_cap = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 		return current_user_can( $syndicate_cap );
@@ -1514,7 +1530,7 @@ class WP_Push_Syndication_Server {
 		return apply_filters( 'syn_pull_user_agent', self::CUSTOM_USER_AGENT );
 	}
 
-	function find_post_by_guid( $guid, $post, $site ) {
+	public function find_post_by_guid( $guid, $post, $site ) {
 		global $wpdb;
 
 		$post_id = apply_filters( 'syn_pre_find_post_by_guid', false, $guid, $post, $site );

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -1,14 +1,14 @@
 <?php
 
-require_once( dirname( __FILE__ ) . '/class-syndication-client-factory.php' );
+require_once __DIR__ . '/class-syndication-client-factory.php';
 
 class WP_Push_Syndication_Server {
 
 	const CUSTOM_USER_AGENT = 'WordPress/Syndication Plugin';
 
-	public  $push_syndicate_settings;
-	public  $push_syndicate_default_settings;
-	public  $push_syndicate_transports;
+	public $push_syndicate_settings;
+	public $push_syndicate_default_settings;
+	public $push_syndicate_transports;
 
 	private $version;
 
@@ -20,7 +20,7 @@ class WP_Push_Syndication_Server {
 
 		// custom columns
 		add_filter( 'manage_edit-syn_site_columns', array( $this, 'add_new_columns' ) );
-		add_action( 'manage_syn_site_posts_custom_column', array( $this, 'manage_columns' ), 10, 2);
+		add_action( 'manage_syn_site_posts_custom_column', array( $this, 'manage_columns' ), 10, 2 );
 
 		// submenus
 		add_action( 'admin_menu', array( $this, 'register_syndicate_settings' ) );
@@ -68,14 +68,14 @@ class WP_Push_Syndication_Server {
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
 		$post_type_capabilities = array(
-					'edit_post'          => $capability,
-					'read_post'          => $capability,
-					'delete_post'        => $capability,
-					'delete_posts'		 => $capability, // only added to address notice caused by https://core.trac.wordpress.org/ticket/30991
-					'edit_posts'         => $capability,
-					'edit_others_posts'  => $capability,
-					'publish_posts'      => $capability,
-					'read_private_posts' => $capability
+			'edit_post'          => $capability,
+			'read_post'          => $capability,
+			'delete_post'        => $capability,
+			'delete_posts'       => $capability, // only added to address notice caused by https://core.trac.wordpress.org/ticket/30991
+			'edit_posts'         => $capability,
+			'edit_others_posts'  => $capability,
+			'publish_posts'      => $capability,
+			'read_private_posts' => $capability,
 		);
 
 		$taxonomy_capabilities = array(
@@ -85,35 +85,41 @@ class WP_Push_Syndication_Server {
 			'assign_terms' => 'edit_posts',
 		);
 
-		register_post_type( 'syn_site', array(
-			'labels' => array(
-				'name'              => __( 'Sites' ),
-				'singular_name'     => __( 'Site' ),
-				'add_new'           => __( 'Add Site' ),
-				'add_new_item'      => __( 'Add New Site' ),
-				'edit_item'         => __( 'Edit Site' ),
-				'new_item'          => __( 'New Site' ),
-				'view_item'         => __( 'View Site' ),
-				'search_items'      => __( 'Search Sites' ),
-			),
-			'description'           => __( 'Sites in the network' ),
-			'public'                => false,
-			'show_ui'               => true,
-			'publicly_queryable'    => false,
-			'exclude_from_search'   => true,
-			'menu_position'         => 100,
-			// @TODO we need a menu icon here
-			'hierarchical'          => false, // @TODO check this
-			'query_var'             => false,
-			'rewrite'               => false,
-			'supports'              => array( 'title' ),
-			'can_export'            => true,
-			'register_meta_box_cb'  => array( $this, 'site_metaboxes' ),
-			'capabilities'          => $post_type_capabilities,
-		));
+		register_post_type(
+			'syn_site',
+			array(
+				'labels'               => array(
+					'name'          => __( 'Sites' ),
+					'singular_name' => __( 'Site' ),
+					'add_new'       => __( 'Add Site' ),
+					'add_new_item'  => __( 'Add New Site' ),
+					'edit_item'     => __( 'Edit Site' ),
+					'new_item'      => __( 'New Site' ),
+					'view_item'     => __( 'View Site' ),
+					'search_items'  => __( 'Search Sites' ),
+				),
+				'description'          => __( 'Sites in the network' ),
+				'public'               => false,
+				'show_ui'              => true,
+				'publicly_queryable'   => false,
+				'exclude_from_search'  => true,
+				'menu_position'        => 100,
+				// @TODO we need a menu icon here
+				'hierarchical'         => false, // @TODO check this
+				'query_var'            => false,
+				'rewrite'              => false,
+				'supports'             => array( 'title' ),
+				'can_export'           => true,
+				'register_meta_box_cb' => array( $this, 'site_metaboxes' ),
+				'capabilities'         => $post_type_capabilities,
+			)
+		);
 
-		register_taxonomy( 'syn_sitegroup', 'syn_site', array(
-				'labels' => array(
+		register_taxonomy(
+			'syn_sitegroup',
+			'syn_site',
+			array(
+				'labels'            => array(
 					'name'              => __( 'Site Groups' ),
 					'singular_name'     => __( 'Site Group' ),
 					'search_items'      => __( 'Search Site Groups' ),
@@ -127,23 +133,24 @@ class WP_Push_Syndication_Server {
 					'new_item_name'     => __( 'New Site Group Name' ),
 
 				),
-				'public'                => false,
-				'show_ui'               => true,
-				'show_tagcloud'         => false,
-				'show_in_nav_menus'     => false,
-				'hierarchical'          => true,
-				'rewrite'               => false,
-				'capabilities'          => $taxonomy_capabilities,
-		));
+				'public'            => false,
+				'show_ui'           => true,
+				'show_tagcloud'     => false,
+				'show_in_nav_menus' => false,
+				'hierarchical'      => true,
+				'rewrite'           => false,
+				'capabilities'      => $taxonomy_capabilities,
+			)
+		);
 
 		$this->push_syndicate_default_settings = array(
-			'selected_pull_sitegroups'  => array(),
-			'selected_post_types'       => array( 'post' ),
-			'delete_pushed_posts'       => 'off',
-			'pull_time_interval'        => '3600',
-			'update_pulled_posts'       => 'off',
-			'client_id'                 => '',
-			'client_secret'             => ''
+			'selected_pull_sitegroups' => array(),
+			'selected_post_types'      => array( 'post' ),
+			'delete_pushed_posts'      => 'off',
+			'pull_time_interval'       => '3600',
+			'update_pulled_posts'      => 'off',
+			'client_id'                => '',
+			'client_secret'            => '',
 		);
 
 		$this->push_syndicate_settings = wp_parse_args( (array) get_option( 'push_syndicate_settings' ), $this->push_syndicate_default_settings );
@@ -163,13 +170,13 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function add_new_columns( $columns ) {
-		$new_columns = array();
-		$new_columns['cb'] = '<input type="checkbox" />';
-		$new_columns['title'] = _x( 'Site Name', 'column name' );
-		$new_columns['client-type'] = _x( 'Client Type', 'column name' );
+		$new_columns                  = array();
+		$new_columns['cb']            = '<input type="checkbox" />';
+		$new_columns['title']         = _x( 'Site Name', 'column name' );
+		$new_columns['client-type']   = _x( 'Client Type', 'column name' );
 		$new_columns['syn_sitegroup'] = _x( 'Groups', 'column name' );
-		$new_columns['site_status'] = _x( 'Status', 'column name' );
-		$new_columns['date'] = _x('Date', 'column name');
+		$new_columns['site_status']   = _x( 'Status', 'column name' );
+		$new_columns['date']          = _x( 'Date', 'column name' );
 		return $new_columns;
 	}
 
@@ -179,7 +186,7 @@ class WP_Push_Syndication_Server {
 			case 'client-type':
 				$transport_type = get_post_meta( $id, 'syn_transport_type', true );
 				try {
-					$client = Syndication_Client_Factory::get_client( $transport_type, $id );
+					$client      = Syndication_Client_Factory::get_client( $transport_type, $id );
 					$client_data = $client->get_client_data();
 					echo esc_html( sprintf( '%s (%s)', $client_data['name'], array_shift( $client_data['modes'] ) ) );
 				} catch ( Exception $e ) {
@@ -209,17 +216,22 @@ class WP_Push_Syndication_Server {
 		$full_path = __DIR__ . '/';
 		if ( $handle = opendir( $full_path ) ) {
 			while ( false !== ( $entry = readdir( $handle ) ) ) {
-				if ( !preg_match( $name_match, $entry, $matches ) )
+				if ( ! preg_match( $name_match, $entry, $matches ) ) {
 					continue;
-				require_once( $full_path . $entry );
+				}
+				require_once $full_path . $entry;
 				$class_name = 'Syndication_' . strtoupper( str_replace( '-', '_', $matches[1] ) ) . '_Client';
 
-				if ( !class_exists( $class_name ) )
+				if ( ! class_exists( $class_name ) ) {
 					continue;
+				}
 				$client_data = call_user_func( array( $class_name, 'get_client_data' ) );
-				if ( is_array( $client_data ) && !empty( $client_data ) ) {
-					$this->push_syndicate_transports[$client_data['id']] = array( 'name' => $client_data['name'], 'modes' => $client_data['modes'] );
-					}
+				if ( is_array( $client_data ) && ! empty( $client_data ) ) {
+					$this->push_syndicate_transports[ $client_data['id'] ] = array(
+						'name'  => $client_data['name'],
+						'modes' => $client_data['modes'],
+					);
+				}
 			}
 		}
 		$this->push_syndicate_transports = apply_filters( 'syn_transports', $this->push_syndicate_transports );
@@ -235,7 +247,7 @@ class WP_Push_Syndication_Server {
 	public function load_scripts_and_styles( $hook ) {
 		global $typenow;
 		if ( 'syn_site' == $typenow ) {
-			if( $hook == 'edit.php' ) {
+			if ( $hook == 'edit.php' ) {
 				wp_enqueue_style( 'syn-edit-sites', plugins_url( 'css/sites.css', __FILE__ ), array(), $this->version );
 			} elseif ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
 				wp_enqueue_style( 'syn-edit-site', plugins_url( 'css/edit-site.css', __FILE__ ), array(), $this->version );
@@ -245,44 +257,43 @@ class WP_Push_Syndication_Server {
 
 	public function push_syndicate_settings_validate( $raw_settings ) {
 
-		$settings                               = array();
-		$settings['client_id']                  = sanitize_text_field( $raw_settings['client_id'] );
-		$settings['client_secret']              = sanitize_text_field( $raw_settings['client_secret'] );
-		$settings['selected_post_types']        = !empty( $raw_settings['selected_post_types'] ) ? $raw_settings['selected_post_types'] : array() ;
-		$settings['delete_pushed_posts']        = !empty( $raw_settings['delete_pushed_posts'] ) ? $raw_settings['delete_pushed_posts'] : 'off' ;
-		$settings['selected_pull_sitegroups']   = !empty( $raw_settings['selected_pull_sitegroups'] ) ? $raw_settings['selected_pull_sitegroups'] : array() ;
-		$settings['pull_time_interval']         = !empty( $raw_settings['pull_time_interval'] ) ? max( $raw_settings['pull_time_interval'], 300 ) : '3600';
-		$settings['update_pulled_posts']        = !empty( $raw_settings['update_pulled_posts'] ) ? $raw_settings['update_pulled_posts'] : 'off' ;
+		$settings                             = array();
+		$settings['client_id']                = sanitize_text_field( $raw_settings['client_id'] );
+		$settings['client_secret']            = sanitize_text_field( $raw_settings['client_secret'] );
+		$settings['selected_post_types']      = ! empty( $raw_settings['selected_post_types'] ) ? $raw_settings['selected_post_types'] : array();
+		$settings['delete_pushed_posts']      = ! empty( $raw_settings['delete_pushed_posts'] ) ? $raw_settings['delete_pushed_posts'] : 'off';
+		$settings['selected_pull_sitegroups'] = ! empty( $raw_settings['selected_pull_sitegroups'] ) ? $raw_settings['selected_pull_sitegroups'] : array();
+		$settings['pull_time_interval']       = ! empty( $raw_settings['pull_time_interval'] ) ? max( $raw_settings['pull_time_interval'], 300 ) : '3600';
+		$settings['update_pulled_posts']      = ! empty( $raw_settings['update_pulled_posts'] ) ? $raw_settings['update_pulled_posts'] : 'off';
 
 		$this->pre_schedule_pull_content( $settings['selected_pull_sitegroups'] );
 
 		return $settings;
-
 	}
 
 	public function register_syndicate_settings() {
-		add_submenu_page( 'options-general.php', esc_html__( 'Push Syndication Settings', 'push-syndication' ), esc_html__( 'Push Syndication', 'push-syndication' ), apply_filters('syn_syndicate_cap', 'manage_options'), 'push-syndicate-settings', array( $this, 'display_syndicate_settings' ) );
+		add_submenu_page( 'options-general.php', esc_html__( 'Push Syndication Settings', 'push-syndication' ), esc_html__( 'Push Syndication', 'push-syndication' ), apply_filters( 'syn_syndicate_cap', 'manage_options' ), 'push-syndicate-settings', array( $this, 'display_syndicate_settings' ) );
 	}
 
 	public function display_syndicate_settings() {
 
-		add_settings_section( 'push_syndicate_pull_sitegroups', esc_html__( 'Site Groups' , 'push-syndication' ), array( $this, 'display_pull_sitegroups_description' ), 'push_syndicate_pull_sitegroups' );
+		add_settings_section( 'push_syndicate_pull_sitegroups', esc_html__( 'Site Groups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_description' ), 'push_syndicate_pull_sitegroups' );
 		add_settings_field( 'pull_sitegroups_selection', esc_html__( 'select sitegroups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_selection' ), 'push_syndicate_pull_sitegroups', 'push_syndicate_pull_sitegroups' );
 
-		add_settings_section( 'push_syndicate_pull_options', esc_html__( 'Pull Options' , 'push-syndication' ), array( $this, 'display_pull_options_description' ), 'push_syndicate_pull_options' );
+		add_settings_section( 'push_syndicate_pull_options', esc_html__( 'Pull Options', 'push-syndication' ), array( $this, 'display_pull_options_description' ), 'push_syndicate_pull_options' );
 		add_settings_field( 'pull_time_interval', esc_html__( 'Specify time interval in seconds', 'push-syndication' ), array( $this, 'display_time_interval_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 		add_settings_field( 'max_pull_attempts', esc_html__( 'Maximum pull attempts', 'push-syndication' ), array( $this, 'display_max_pull_attempts' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 		add_settings_field( 'update_pulled_posts', esc_html__( 'update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 
-		add_settings_section( 'push_syndicate_post_types', esc_html__( 'Post Types' , 'push-syndication' ), array( $this, 'display_push_post_types_description' ), 'push_syndicate_post_types' );
+		add_settings_section( 'push_syndicate_post_types', esc_html__( 'Post Types', 'push-syndication' ), array( $this, 'display_push_post_types_description' ), 'push_syndicate_post_types' );
 		add_settings_field( 'post_type_selection', esc_html__( 'select post types', 'push-syndication' ), array( $this, 'display_post_types_selection' ), 'push_syndicate_post_types', 'push_syndicate_post_types' );
 
-		add_settings_section( 'delete_pushed_posts', esc_html__(' Delete Pushed Posts ', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_description' ), 'delete_pushed_posts' );
-		add_settings_field( 'delete_post_check', esc_html__(' delete pushed posts ', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_selection' ), 'delete_pushed_posts', 'delete_pushed_posts' );
+		add_settings_section( 'delete_pushed_posts', esc_html__( ' Delete Pushed Posts ', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_description' ), 'delete_pushed_posts' );
+		add_settings_field( 'delete_post_check', esc_html__( ' delete pushed posts ', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_selection' ), 'delete_pushed_posts', 'delete_pushed_posts' );
 
-		add_settings_section( 'api_token', esc_html__(' API Token Configuration ', 'push-syndication' ), array( $this, 'display_apitoken_description' ), 'api_token' );
-		add_settings_field( 'client_id', esc_html__(' Enter your client id ', 'push-syndication' ), array( $this, 'display_client_id' ), 'api_token', 'api_token' );
-		add_settings_field( 'client_secret', esc_html__(' Enter your client secret ', 'push-syndication' ), array( $this, 'display_client_secret' ), 'api_token', 'api_token' );
+		add_settings_section( 'api_token', esc_html__( ' API Token Configuration ', 'push-syndication' ), array( $this, 'display_apitoken_description' ), 'api_token' );
+		add_settings_field( 'client_id', esc_html__( ' Enter your client id ', 'push-syndication' ), array( $this, 'display_client_id' ), 'api_token', 'api_token' );
+		add_settings_field( 'client_secret', esc_html__( ' Enter your client secret ', 'push-syndication' ), array( $this, 'display_client_secret' ), 'api_token', 'api_token' );
 
 		?>
 
@@ -312,12 +323,11 @@ class WP_Push_Syndication_Server {
 
 			</form>
 
-			<?php $this->get_api_token() ?>
+			<?php $this->get_api_token(); ?>
 
 		</div>
 
 		<?php
-
 	}
 
 	public function display_pull_sitegroups_description() {
@@ -327,26 +337,29 @@ class WP_Push_Syndication_Server {
 	public function display_pull_sitegroups_selection() {
 
 		// get all sitegroups
-		$sitegroups = get_terms( 'syn_sitegroup', array(
-			'fields'        => 'all',
-			'hide_empty'    => false,
-			'orderby'       => 'name'
-		) );
+		$sitegroups = get_terms(
+			'syn_sitegroup',
+			array(
+				'fields'     => 'all',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+			) 
+		);
 
 		// if there are no sitegroups defined return
-		if( empty( $sitegroups ) ) {
+		if ( empty( $sitegroups ) ) {
 			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
 			return;
 		}
 
-		foreach( $sitegroups as $sitegroup ) {
+		foreach ( $sitegroups as $sitegroup ) {
 
 			?>
 
 			<p>
 				<label>
-					<input type="checkbox" name="push_syndicate_settings[selected_pull_sitegroups][]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $this->push_syndicate_settings['selected_pull_sitegroups'] ) ?> />
+					<input type="checkbox" name="push_syndicate_settings[selected_pull_sitegroups][]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $this->push_syndicate_settings['selected_pull_sitegroups'] ); ?> />
 					<?php echo esc_html( $sitegroup->name ); ?>
 				</label>
 				<?php echo esc_html( $sitegroup->description ); ?>
@@ -355,10 +368,9 @@ class WP_Push_Syndication_Server {
 			<?php
 
 		}
-
 	}
 
-	public  function display_pull_options_description() {
+	public function display_pull_options_description() {
 		echo esc_html__( 'Configure options for pulling content', 'push-syndication' );
 	}
 
@@ -415,7 +427,7 @@ class WP_Push_Syndication_Server {
 
 		echo '<ul>';
 
-		foreach( $post_types as $post_type  ) {
+		foreach ( $post_types as $post_type ) {
 
 			?>
 
@@ -431,7 +443,6 @@ class WP_Push_Syndication_Server {
 		}
 
 		echo '</ul>';
-
 	}
 
 	public function display_delete_pushed_posts_description() {
@@ -444,9 +455,9 @@ class WP_Push_Syndication_Server {
 		echo checked( $this->push_syndicate_settings['delete_pushed_posts'], 'on' ) . ' />';
 	}
 
-	public function  display_apitoken_description() {
+	public function display_apitoken_description() {
 		// @TODO add client type information
-		echo '<p>' . esc_html__( 'To syndicate content to WordPress.com you must ', 'push-syndication' ). '<a href="https://developer.wordpress.com/apps/new/">' . esc_html__( 'create a new application', 'push-syndication' ) . '</a></p>';
+		echo '<p>' . esc_html__( 'To syndicate content to WordPress.com you must ', 'push-syndication' ) . '<a href="https://developer.wordpress.com/apps/new/">' . esc_html__( 'create a new application', 'push-syndication' ) . '</a></p>';
 		echo '<p>' . esc_html__( 'Enter the Redirect URI as follows', 'push-syndication' ) . '</p>';
 		echo '<p><b>' . esc_html( menu_page_url( 'push-syndicate-settings', false ) ) . '</p></b>';
 	}
@@ -462,13 +473,12 @@ class WP_Push_Syndication_Server {
 	public function get_api_token() {
 
 		$redirect_uri           = menu_page_url( 'push-syndicate-settings', false );
-		$authorization_endpoint = 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $this->push_syndicate_settings['client_id'] . '&redirect_uri=' .  $redirect_uri . '&response_type=code';
+		$authorization_endpoint = 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $this->push_syndicate_settings['client_id'] . '&redirect_uri=' . $redirect_uri . '&response_type=code';
 
 		echo '<h3>' . esc_html__( 'Authorization ', 'push-syndication' ) . '</h3>';
 
 		// if code is not found return or settings updated return
-		if( empty( $_GET['code'] ) || !empty( $_GET[ 'settings-updated' ] ) ) {
-
+		if ( empty( $_GET['code'] ) || ! empty( $_GET['settings-updated'] ) ) {
 			echo '<p>' . esc_html__( 'Click the authorize button to generate api token', 'push-syndication' ) . '</p>';
 
 			?>
@@ -478,24 +488,25 @@ class WP_Push_Syndication_Server {
 			<?php
 
 			return;
-
 		}
 
-		$response = wp_remote_post( 'https://public-api.wordpress.com/oauth2/token', array(
-			'sslverify' => false,
-			'body'      => array (
-				'client_id'     => $this->push_syndicate_settings['client_id'],
-				'redirect_uri'  => $redirect_uri,
-				'client_secret' => $this->push_syndicate_settings['client_secret'],
-				'code'          => $_GET['code'],
-				'grant_type'    => 'authorization_code'
-			),
-		) );
+		$response = wp_remote_post(
+			'https://public-api.wordpress.com/oauth2/token',
+			array(
+				'sslverify' => false,
+				'body'      => array(
+					'client_id'     => $this->push_syndicate_settings['client_id'],
+					'redirect_uri'  => $redirect_uri,
+					'client_secret' => $this->push_syndicate_settings['client_secret'],
+					'code'          => $_GET['code'],
+					'grant_type'    => 'authorization_code',
+				),
+			) 
+		);
 
 		$result = json_decode( $response['body'] );
 
-		if( !empty( $result->error ) ) {
-
+		if ( ! empty( $result->error ) ) {
 			echo '<p>' . esc_html__( 'Error retrieving API token ', 'push-syndication' ) . esc_html( $result->error_description ) . esc_html__( 'Please authorize again', 'push-syndication' ) . '</p>';
 
 			?>
@@ -505,7 +516,6 @@ class WP_Push_Syndication_Server {
 			<?php
 
 			return;
-
 		}
 
 		?>
@@ -529,8 +539,7 @@ class WP_Push_Syndication_Server {
 
 		<?php
 
-		echo '<p>' . esc_html__( 'Enter the above details in relevant fields when registering a ', 'push-syndication' ). '<a href="http://wordpress.com" target="_blank">WordPress.com</a>' . esc_html__( 'site', 'push-syndication' ) . '</p>';
-
+		echo '<p>' . esc_html__( 'Enter the above details in relevant fields when registering a ', 'push-syndication' ) . '<a href="http://wordpress.com" target="_blank">WordPress.com</a>' . esc_html__( 'site', 'push-syndication' ) . '</p>';
 	}
 
 	public function display_sitegroups_selection() {
@@ -538,29 +547,32 @@ class WP_Push_Syndication_Server {
 		echo '<h3>' . esc_html__( 'Select Sitegroups', 'push-syndication' ) . '</h3>';
 
 		$selected_sitegroups = get_option( 'syn_selected_sitegroups' );
-		$selected_sitegroups = !empty( $selected_sitegroups ) ? $selected_sitegroups : array() ;
+		$selected_sitegroups = ! empty( $selected_sitegroups ) ? $selected_sitegroups : array();
 
 		// get all sitegroups
-		$sitegroups = get_terms( 'syn_sitegroup', array(
-			'fields'        => 'all',
-			'hide_empty'    => false,
-			'orderby'       => 'name'
-		) );
+		$sitegroups = get_terms(
+			'syn_sitegroup',
+			array(
+				'fields'     => 'all',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+			) 
+		);
 
 		// if there are no sitegroups defined return
-		if( empty( $sitegroups ) ) {
+		if ( empty( $sitegroups ) ) {
 			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
 			return;
 		}
 
-		foreach( $sitegroups as $sitegroup ) {
+		foreach ( $sitegroups as $sitegroup ) {
 
 			?>
 
 			<p>
 				<label>
-					<input type="checkbox" name="syn_selected_sitegroups[]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $selected_sitegroups ) ?> />
+					<input type="checkbox" name="syn_selected_sitegroups[]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $selected_sitegroups ); ?> />
 					<?php echo esc_html( $sitegroup->name ); ?>
 				</label>
 				<?php echo esc_html( $sitegroup->description ); ?>
@@ -569,13 +581,12 @@ class WP_Push_Syndication_Server {
 			<?php
 
 		}
-
 	}
 
 	public function site_metaboxes() {
-		add_meta_box('sitediv', __(' Site Settings '), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high');
-		remove_meta_box('submitdiv', 'syn_site', 'side');
-		add_meta_box( 'submitdiv', __(' Site Status '), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
+		add_meta_box( 'sitediv', __( ' Site Settings ' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
+		remove_meta_box( 'submitdiv', 'syn_site', 'side' );
+		add_meta_box( 'submitdiv', __( ' Site Status ' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
 	}
 
 	public function add_site_status_metabox( $site ) {
@@ -588,7 +599,7 @@ class WP_Push_Syndication_Server {
 						<label for="post_status"><?php esc_html_e( 'Status:', 'push-syndication' ); ?></label>
 						<span id="post-status-display">
 						<?php
-						switch( $site_enabled ) {
+						switch ( $site_enabled ) {
 							case 'on':
 								esc_html_e( 'Enabled', 'push-syndication' );
 								break;
@@ -613,7 +624,7 @@ class WP_Push_Syndication_Server {
 
 					</div>
 
-					<div id="timestampdiv" class="hide-if-js"><?php touch_time(0, 1, 4); ?></div>
+					<div id="timestampdiv" class="hide-if-js"><?php touch_time( 0, 1, 4 ); ?></div>
 				</div>
 				<div class="clear"></div>
 			</div>
@@ -627,9 +638,21 @@ class WP_Push_Syndication_Server {
 				<div id="publishing-action">
 					<img src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" class="ajax-loading" id="ajax-loading" alt="" />
 					<?php
-					if ( !in_array( $site_enabled, array( 'on', 'off' ) ) || 0 == $site->ID ) { ?>
+					if ( ! in_array( $site_enabled, array( 'on', 'off' ) ) || 0 == $site->ID ) { 
+						?>
 						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Add Site', 'push-syndication' ); ?>" />
-						<?php submit_button( __( 'Add Site', 'push-syndication' ), 'primary', 'enabled', false, array( 'tabindex' => '5', 'accesskey' => 'p' ) ); ?>
+						<?php 
+						submit_button(
+							__( 'Add Site', 'push-syndication' ),
+							'primary',
+							'enabled',
+							false,
+							array(
+								'tabindex'  => '5',
+								'accesskey' => 'p',
+							) 
+						); 
+						?>
 					<?php } else { ?>
 						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Update', 'push-syndication' ); ?>" />
 						<input name="save" type="submit" class="button-primary" id="publish" tabindex="5" accesskey="p" value="<?php esc_attr_e( 'Update', 'push-syndication' ); ?>" />
@@ -647,13 +670,13 @@ class WP_Push_Syndication_Server {
 
 		global $post;
 
-		$transport_type = get_post_meta( $post->ID, 'syn_transport_type', true);
-		$site_enabled   = get_post_meta( $post->ID, 'syn_site_enabled', true);
+		$transport_type = get_post_meta( $post->ID, 'syn_transport_type', true );
+		$site_enabled   = get_post_meta( $post->ID, 'syn_site_enabled', true );
 
 		// default values
-		$transport_type = !empty( $transport_type ) ? $transport_type : 'WP_XMLRPC';
-		$transport_mode = !empty( $transport_mode ) ? $transport_mode : 'pull' ;
-		$site_enabled   = !empty( $site_enabled ) ? $site_enabled : 'off';
+		$transport_type = ! empty( $transport_type ) ? $transport_type : 'WP_XMLRPC';
+		$transport_mode = ! empty( $transport_mode ) ? $transport_mode : 'pull';
+		$site_enabled   = ! empty( $site_enabled ) ? $site_enabled : 'off';
 
 		// nonce for verification when saving
 		wp_nonce_field( plugin_basename( __FILE__ ), 'site_settings_noncename' );
@@ -671,7 +694,6 @@ class WP_Push_Syndication_Server {
 		<div class="clear"></div>
 
 		<?php
-
 	}
 
 	public function display_transports( $transport_type, $mode ) {
@@ -680,14 +702,13 @@ class WP_Push_Syndication_Server {
 		// TODO: add direction
 		echo '<select name="transport_type" onchange="this.form.submit()">';
 
-		$values = array();
+		$values  = array();
 		$max_len = 0;
 		foreach ( $this->push_syndicate_transports as $key => $value ) {
 			$mode = array_shift( $value['modes'] );
-			echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $transport_type, false ) . '>' . sprintf( esc_html__( '%s (%s)', 'push-syndication' ), esc_html( $value['name'] ), esc_html( $mode ) ) . '</option>';
+			echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $transport_type, false ) . '>' . sprintf( esc_html__( '%1$s (%2$s)', 'push-syndication' ), esc_html( $value['name'] ), esc_html( $mode ) ) . '</option>';
 		}
 		echo '</select>';
-
 	}
 
 	public function save_site_settings() {
@@ -695,12 +716,14 @@ class WP_Push_Syndication_Server {
 		global $post;
 
 		// autosave verification
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
+		}
 
 		// if our nonce isn't there, or we can't verify it return
-		if( !isset( $_POST['site_settings_noncename'] ) || !wp_verify_nonce( $_POST['site_settings_noncename'], plugin_basename( __FILE__ ) ) )
+		if ( ! isset( $_POST['site_settings_noncename'] ) || ! wp_verify_nonce( $_POST['site_settings_noncename'], plugin_basename( __FILE__ ) ) ) {
 			return;
+		}
 
 		$transport_type = sanitize_text_field( $_POST['transport_type'] ); // TODO: validate this exists
 
@@ -711,29 +734,37 @@ class WP_Push_Syndication_Server {
 
 		try {
 			$save = Syndication_Client_Factory::save_client_settings( $post->ID, $transport_type );
-			if( !$save )
+			if ( ! $save ) {
 				return;
+			}
 			$client = Syndication_Client_Factory::get_client( $transport_type, $post->ID );
 
-			if ( $client->test_connection()  ) {
-				add_filter('redirect_post_location', function ($location) {
-					return add_query_arg("message", 251, $location);
-				});
+			if ( $client->test_connection() ) {
+				add_filter(
+					'redirect_post_location',
+					function ( $location ) {
+						return add_query_arg( 'message', 251, $location );
+					}
+				);
 			} else {
-				add_filter('redirect_post_location', function ($location) {
-					return add_query_arg("message", 252, $location);
-				});
+				add_filter(
+					'redirect_post_location',
+					function ( $location ) {
+						return add_query_arg( 'message', 252, $location );
+					}
+				);
 				$site_enabled = 'off';
 			}
-
-		} catch( Exception $e ) {
-			add_filter('redirect_post_location', function ($location) {
-				return add_query_arg("message", 250, $location);
-			});
+		} catch ( Exception $e ) {
+			add_filter(
+				'redirect_post_location',
+				function ( $location ) {
+					return add_query_arg( 'message', 250, $location );
+				}
+			);
 		}
 
 		update_post_meta( $post->ID, 'syn_site_enabled', $site_enabled );
-
 	}
 
 	public function push_syndicate_admin_messages( $messages ) {
@@ -757,27 +788,27 @@ class WP_Push_Syndication_Server {
 		// RSS error messages
 
 		return $messages;
-
 	}
 
 	public function add_post_metaboxes() {
 
 		// return if no post types supports push syndication
-		if( empty( $this->push_syndicate_settings['selected_post_types'] ) )
+		if ( empty( $this->push_syndicate_settings['selected_post_types'] ) ) {
 			return;
-
-		if( !$this->current_user_can_syndicate() )
-			return;
-
-		$selected_post_types = $this->push_syndicate_settings[ 'selected_post_types' ];
-		foreach( $selected_post_types as $selected_post_type ) {
-			add_meta_box( 'syndicatediv', __( ' Syndicate ' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
-			//add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' );
 		}
 
+		if ( ! $this->current_user_can_syndicate() ) {
+			return;
+		}
+
+		$selected_post_types = $this->push_syndicate_settings['selected_post_types'];
+		foreach ( $selected_post_types as $selected_post_type ) {
+			add_meta_box( 'syndicatediv', __( ' Syndicate ' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
+			// add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' );
+		}
 	}
 
-	public function add_syndicate_metabox( ) {
+	public function add_syndicate_metabox() {
 
 		global $post;
 
@@ -785,30 +816,33 @@ class WP_Push_Syndication_Server {
 		wp_nonce_field( plugin_basename( __FILE__ ), 'syndicate_noncename' );
 
 		// get all sitegroups
-		$sitegroups = get_terms( 'syn_sitegroup', array(
-			'fields'        => 'all',
-			'hide_empty'    => false,
-			'orderby'       => 'name'
-		) );
+		$sitegroups = get_terms(
+			'syn_sitegroup',
+			array(
+				'fields'     => 'all',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+			) 
+		);
 
 		// if there are no sitegroups defined return
-		if( empty( $sitegroups ) ) {
+		if ( empty( $sitegroups ) ) {
 			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
 			return;
 		}
 
 		$selected_sitegroups = get_post_meta( $post->ID, '_syn_selected_sitegroups', true );
-		$selected_sitegroups = !empty( $selected_sitegroups ) ? $selected_sitegroups : array() ;
+		$selected_sitegroups = ! empty( $selected_sitegroups ) ? $selected_sitegroups : array();
 
 		echo '<ul>';
 
-		foreach( $sitegroups as $sitegroup  ) {
+		foreach ( $sitegroups as $sitegroup ) {
 
 			?>
 			<li>
 				<label>
-					<input type="checkbox" name="selected_sitegroups[]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $selected_sitegroups ) ?> />
+					<input type="checkbox" name="selected_sitegroups[]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $selected_sitegroups ); ?> />
 					<?php echo esc_html( $sitegroup->name ); ?>
 				</label>
 				<p> <?php echo esc_html( $sitegroup->description ); ?> </p>
@@ -835,12 +869,11 @@ class WP_Push_Syndication_Server {
 				);
 			}
 		}
-
 	}
 
 	public function checked_array( $value, $group ) {
-		if( !empty( $group ) ) {
-			if( in_array( $value, $group ) ) {
+		if ( ! empty( $group ) ) {
+			if ( in_array( $value, $group ) ) {
 				echo 'checked="checked"';
 			}
 		}
@@ -851,23 +884,25 @@ class WP_Push_Syndication_Server {
 		global $post;
 
 		// autosave verification
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
+		}
 
 		// if our nonce isn't there, or we can't verify it return
-		if( !isset( $_POST['syndicate_noncename'] ) || !wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) )
+		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
 			return;
+		}
 
-		if ( ! $this->current_user_can_syndicate() )
+		if ( ! $this->current_user_can_syndicate() ) {
 			return;
+		}
 
-		$selected_sitegroups = !empty( $_POST['selected_sitegroups'] ) ? array_map( 'sanitize_key', $_POST['selected_sitegroups'] ) : '' ;
+		$selected_sitegroups = ! empty( $_POST['selected_sitegroups'] ) ? array_map( 'sanitize_key', $_POST['selected_sitegroups'] ) : '';
 		update_post_meta( $post->ID, '_syn_selected_sitegroups', $selected_sitegroups );
 
 		if ( '' === get_post_meta( $post->ID, 'post_uniqueid', true ) ) {
 			update_post_meta( $post->ID, 'post_uniqueid', uniqid() );
 		}
-
 	}
 
 	public function add_syndication_status_metabox() {
@@ -877,15 +912,18 @@ class WP_Push_Syndication_Server {
 	public function pre_schedule_push_content( $new_status, $old_status, $post ) {
 
 		// autosave verification
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
+		}
 
 		// if our nonce isn't there, or we can't verify it return
-		if( !isset( $_POST['syndicate_noncename'] ) || !wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) )
+		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
 			return;
+		}
 
-		if( !$this->current_user_can_syndicate() )
+		if ( ! $this->current_user_can_syndicate() ) {
 			return;
+		}
 
 		$sites = $this->get_sites_by_post_ID( $post->ID );
 
@@ -908,28 +946,27 @@ class WP_Push_Syndication_Server {
 	public function push_content( $sites ) {
 
 		// if another process running on it return
-		if( get_transient( 'syn_syndicate_lock' ) == 'locked' )
+		if ( get_transient( 'syn_syndicate_lock' ) == 'locked' ) {
 			return;
+		}
 
 		// set value as locked, valid for 5 mins
-		set_transient( 'syn_syndicate_lock', 'locked', 60*5 );
+		set_transient( 'syn_syndicate_lock', 'locked', 60 * 5 );
 
-		/** start of critical section **/
+		/** start of critical section */
 
 		$post_ID = $sites['post_ID'];
 
 		// an array containing states of sites
 		$slave_post_states = get_post_meta( $post_ID, '_syn_slave_post_states', true );
-		$slave_post_states = !empty( $slave_post_states ) ? $slave_post_states : array() ;
+		$slave_post_states = ! empty( $slave_post_states ) ? $slave_post_states : array();
 
 		$sites = apply_filters( 'syn_pre_push_post_sites', $sites, $post_ID, $slave_post_states );
 
-		if( !empty( $sites['selected_sites'] ) ) {
-
-			foreach( $sites['selected_sites'] as $site ) {
-
-				$transport_type = get_post_meta( $site->ID, 'syn_transport_type', true);
-				$client         = Syndication_Client_Factory::get_client( $transport_type  ,$site->ID );
+		if ( ! empty( $sites['selected_sites'] ) ) {
+			foreach ( $sites['selected_sites'] as $site ) {
+				$transport_type = get_post_meta( $site->ID, 'syn_transport_type', true );
+				$client         = Syndication_Client_Factory::get_client( $transport_type, $site->ID );
 				$info           = $this->get_site_info( $site->ID, $slave_post_states, $client );
 
 				// Check if post already exists on target to prevent syndication loops.
@@ -941,11 +978,12 @@ class WP_Push_Syndication_Server {
 					}
 				}
 
-				if( $info['state'] == 'new' || $info['state'] == 'new-error' ) { // states 'new' and 'new-error'
+				if ( $info['state'] == 'new' || $info['state'] == 'new-error' ) { // states 'new' and 'new-error'
 
 					$push_new_shortcircuit = apply_filters( 'syn_pre_push_new_post_shortcircuit', false, $post_ID, $site, $transport_type, $client, $info );
-					if ( true === $push_new_shortcircuit )
+					if ( true === $push_new_shortcircuit ) {
 						continue;
+					}
 
 					$result = $client->new_post( $post_ID );
 
@@ -953,11 +991,11 @@ class WP_Push_Syndication_Server {
 					$this->update_slave_post_states( $post_ID, $slave_post_states );
 
 					do_action( 'syn_post_push_new_post', $result, $post_ID, $site, $transport_type, $client, $info );
-
 				} else { // states 'success', 'edit-error' and 'remove-error'
 					$push_edit_shortcircuit = apply_filters( 'syn_pre_push_edit_post_shortcircuit', false, $post_ID, $site, $transport_type, $client, $info );
-					if ( true === $push_edit_shortcircuit )
+					if ( true === $push_edit_shortcircuit ) {
 						continue;
+					}
 
 					$result = $client->edit_post( $post_ID, $info['ext_ID'] );
 
@@ -967,99 +1005,86 @@ class WP_Push_Syndication_Server {
 					do_action( 'syn_post_push_edit_post', $result, $post_ID, $site, $transport_type, $client, $info );
 				}
 			}
-
 		}
 
-		if( !empty( $sites['removed_sites'] ) ) {
-
-			foreach( $sites['removed_sites'] as $site ) {
-
-				$transport_type = get_post_meta( $site->ID, 'syn_transport_type', true);
-				$client         = Syndication_Client_Factory::get_client( $transport_type  ,$site->ID );
+		if ( ! empty( $sites['removed_sites'] ) ) {
+			foreach ( $sites['removed_sites'] as $site ) {
+				$transport_type = get_post_meta( $site->ID, 'syn_transport_type', true );
+				$client         = Syndication_Client_Factory::get_client( $transport_type, $site->ID );
 				$info           = $this->get_site_info( $site->ID, $slave_post_states, $client );
 
 				// if the post is not pushed we do not need to delete them
-				if( $info['state'] == 'success' || $info['state'] == 'edit-error' || $info['state'] == 'remove-error' ) {
-
+				if ( $info['state'] == 'success' || $info['state'] == 'edit-error' || $info['state'] == 'remove-error' ) {
 					$result = $client->delete_post( $info['ext_ID'] );
 					if ( is_wp_error( $result ) ) {
-						$slave_post_states[ 'remove-error' ][ $site->ID ] = $result;
+						$slave_post_states['remove-error'][ $site->ID ] = $result;
 						$this->update_slave_post_states( $post_ID, $slave_post_states );
 					}
-
 				}
-
 			}
-
 		}
 
 
-		/** end of critical section **/
+		/** end of critical section */
 
 		// release the lock.
 		delete_transient( 'syn_syndicate_lock' );
-
 	}
 
 	public function get_sites_by_post_ID( $post_ID ) {
 
-		$selected_sitegroups    = get_post_meta( $post_ID, '_syn_selected_sitegroups', true );
-		$selected_sitegroups    = !empty( $selected_sitegroups ) ? $selected_sitegroups : array() ;
-		$old_sitegroups         = get_post_meta( $post_ID, '_syn_old_sitegroups', true );
-		$old_sitegroups         = !empty( $old_sitegroups ) ? $old_sitegroups : array() ;
-		$removed_sitegroups     = array_diff( $old_sitegroups, $selected_sitegroups );
+		$selected_sitegroups = get_post_meta( $post_ID, '_syn_selected_sitegroups', true );
+		$selected_sitegroups = ! empty( $selected_sitegroups ) ? $selected_sitegroups : array();
+		$old_sitegroups      = get_post_meta( $post_ID, '_syn_old_sitegroups', true );
+		$old_sitegroups      = ! empty( $old_sitegroups ) ? $old_sitegroups : array();
+		$removed_sitegroups  = array_diff( $old_sitegroups, $selected_sitegroups );
 
 		// initialization
 		$data = array(
-			'post_ID'           => $post_ID,
-			'selected_sites'    => array(),
-			'removed_sites'     => array(),
+			'post_ID'        => $post_ID,
+			'selected_sites' => array(),
+			'removed_sites'  => array(),
 		);
 
-		if( !empty( $selected_sitegroups ) ) {
-
-			foreach( $selected_sitegroups as $selected_sitegroup ) {
+		if ( ! empty( $selected_sitegroups ) ) {
+			foreach ( $selected_sitegroups as $selected_sitegroup ) {
 
 				// get all the sites in the sitegroup
 				$sites = $this->get_sites_by_sitegroup( $selected_sitegroup );
-				if( empty( $sites ) )
+				if ( empty( $sites ) ) {
 					continue;
-
-				foreach( $sites as $site ) {
-					$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true);
-					if( $site_enabled == 'on' ) {
-						$data[ 'selected_sites' ][] = $site;
-					}
 				}
 
+				foreach ( $sites as $site ) {
+					$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true );
+					if ( $site_enabled == 'on' ) {
+						$data['selected_sites'][] = $site;
+					}
+				}
 			}
-
 		}
 
-		if( !empty( $removed_sitegroups ) ) {
-
-			foreach( $removed_sitegroups as $removed_sitegroup ) {
+		if ( ! empty( $removed_sitegroups ) ) {
+			foreach ( $removed_sitegroups as $removed_sitegroup ) {
 
 				// get all the sites in the sitegroup
 				$sites = $this->get_sites_by_sitegroup( $removed_sitegroup );
-				if( empty( $sites ) )
+				if ( empty( $sites ) ) {
 					continue;
-
-				foreach( $sites as $site ) {
-					$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true);
-					if( $site_enabled == 'on' ) {
-						$data[ 'removed_sites' ][] = $site;
-					}
 				}
 
+				foreach ( $sites as $site ) {
+					$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true );
+					if ( $site_enabled == 'on' ) {
+						$data['removed_sites'][] = $site;
+					}
+				}
 			}
-
 		}
 
 		update_post_meta( $post_ID, '_syn_old_sitegroups', $selected_sitegroups );
 
 		return $data;
-
 	}
 
 	// return an array of sites as objects based on sitegroup
@@ -1067,20 +1092,21 @@ class WP_Push_Syndication_Server {
 
 		// @TODO if sitegroup is deleted?
 
-		$results = new WP_Query(array(
-			'post_type'         => 'syn_site',
-			'posts_per_page'    => 100,
-			'tax_query'         => array(
-				array(
-					'taxonomy'  => 'syn_sitegroup',
-					'field'     => 'slug',
-					'terms'     => $sitegroup
-				)
+		$results = new WP_Query(
+			array(
+				'post_type'      => 'syn_site',
+				'posts_per_page' => 100,
+				'tax_query'      => array(
+					array(
+						'taxonomy' => 'syn_sitegroup',
+						'field'    => 'slug',
+						'terms'    => $sitegroup,
+					),
+				),
 			)
-		));
+		);
 
-		return (array)$results->posts;
-
+		return (array) $results->posts;
 	}
 
 	/**
@@ -1094,16 +1120,18 @@ class WP_Push_Syndication_Server {
 	 */
 	public function get_site_info( $site_ID, &$slave_post_states, $client ) {
 
-		if( empty( $slave_post_states ) )
+		if ( empty( $slave_post_states ) ) {
 			return array( 'state' => 'new' );
+		}
 
-		foreach( $slave_post_states as $state => $sites  ) {
-			if( isset( $sites[ $site_ID ] ) && is_array( $sites[ $site_ID ] ) && ! empty( $sites[ $site_ID ]['ext_ID'] )   ) {
-				if( $client->is_post_exists( $sites[ $site_ID ]['ext_ID'] ) ) {
+		foreach ( $slave_post_states as $state => $sites ) {
+			if ( isset( $sites[ $site_ID ] ) && is_array( $sites[ $site_ID ] ) && ! empty( $sites[ $site_ID ]['ext_ID'] ) ) {
+				if ( $client->is_post_exists( $sites[ $site_ID ]['ext_ID'] ) ) {
 					$info = array(
-						'state'     => $state,
-						'ext_ID'    => $sites[ $site_ID ]['ext_ID'] );
-					unset( $slave_post_states[ $state ] [$site_ID] );
+						'state'  => $state,
+						'ext_ID' => $sites[ $site_ID ]['ext_ID'],
+					);
+					unset( $slave_post_states[ $state ] [ $site_ID ] );
 					return $info;
 				} else {
 					return array( 'state' => 'new' );
@@ -1112,7 +1140,6 @@ class WP_Push_Syndication_Server {
 		}
 
 		return array( 'state' => 'new' );
-
 	}
 
 	/**
@@ -1124,10 +1151,10 @@ class WP_Push_Syndication_Server {
 	public function validate_result_new_post( $result, &$slave_post_states, $site_ID, $client ) {
 
 		if ( is_wp_error( $result ) ) {
-			$slave_post_states[ 'new-error' ][ $site_ID ] = $result;
+			$slave_post_states['new-error'][ $site_ID ] = $result;
 		} else {
-			$slave_post_states[ 'success' ][ $site_ID ] = array(
-				'ext_ID'        => (int) $result
+			$slave_post_states['success'][ $site_ID ] = array(
+				'ext_ID' => (int) $result,
 			);
 		}
 
@@ -1141,13 +1168,13 @@ class WP_Push_Syndication_Server {
 	 */
 	public function validate_result_edit_post( $result, $ext_ID, &$slave_post_states, $site_ID, $client ) {
 		if ( is_wp_error( $result ) ) {
-			$slave_post_states[ 'edit-error' ][ $site_ID ] = array(
-				'error' => $result,
+			$slave_post_states['edit-error'][ $site_ID ] = array(
+				'error'  => $result,
 				'ext_ID' => (int) $ext_ID,
 			);
 		} else {
-			$slave_post_states[ 'success' ][ $site_ID ] = array(
-				'ext_ID'        => (int) $ext_ID
+			$slave_post_states['success'][ $site_ID ] = array(
+				'ext_ID' => (int) $ext_ID,
 			);
 		}
 
@@ -1161,12 +1188,14 @@ class WP_Push_Syndication_Server {
 	public function pre_schedule_delete_content( $post_id ) {
 
 		// if slave post deletion is not enabled return
-		$delete_pushed_posts =  !empty( $this->push_syndicate_settings[ 'delete_pushed_posts' ] ) ? $this->push_syndicate_settings[ 'delete_pushed_posts' ] : 'off' ;
-		if( $delete_pushed_posts != 'on' )
+		$delete_pushed_posts = ! empty( $this->push_syndicate_settings['delete_pushed_posts'] ) ? $this->push_syndicate_settings['delete_pushed_posts'] : 'off';
+		if ( $delete_pushed_posts != 'on' ) {
 			return;
+		}
 
-		if( !$this->current_user_can_syndicate() )
+		if ( ! $this->current_user_can_syndicate() ) {
 			return;
+		}
 
 		do_action( 'syn_schedule_delete_content', $post_id );
 	}
@@ -1182,44 +1211,40 @@ class WP_Push_Syndication_Server {
 	public function delete_content( $post_ID ) {
 
 		$delete_error_sites = get_option( 'syn_delete_error_sites' );
-		$delete_error_sites = !empty( $delete_error_sites ) ? $delete_error_sites : array() ;
+		$delete_error_sites = ! empty( $delete_error_sites ) ? $delete_error_sites : array();
 		$slave_posts        = $this->get_slave_posts( $post_ID );
 
-		if( empty( $slave_posts ) )
+		if ( empty( $slave_posts ) ) {
 			return;
+		}
 
-		foreach( $slave_posts as $site_ID => $ext_ID ) {
-
-			$site_enabled = get_post_meta( $site_ID, 'syn_site_enabled', true);
+		foreach ( $slave_posts as $site_ID => $ext_ID ) {
+			$site_enabled = get_post_meta( $site_ID, 'syn_site_enabled', true );
 
 			// check whether the site is enabled
-			if( $site_enabled == 'on' ) {
+			if ( $site_enabled == 'on' ) {
+				$transport_type = get_post_meta( $site_ID, 'syn_transport_type', true );
+				$client         = Syndication_Client_Factory::get_client( $transport_type, $site_ID );
 
-				$transport_type = get_post_meta( $site_ID, 'syn_transport_type', true);
-				$client         = Syndication_Client_Factory::get_client( $transport_type , $site_ID );
-
-				if( $client->is_post_exists( $ext_ID ) ) {
+				if ( $client->is_post_exists( $ext_ID ) ) {
 					$push_delete_shortcircuit = apply_filters( 'syn_pre_push_delete_post_shortcircuit', false, $ext_ID, $post_ID, $site_ID, $transport_type, $client );
-					if ( true === $push_delete_shortcircuit )
+					if ( true === $push_delete_shortcircuit ) {
 						continue;
+					}
 
 					$result = $client->delete_post( $ext_ID );
 
 					do_action( 'syn_post_push_delete_post', $result, $ext_ID, $post_ID, $site_ID, $transport_type, $client );
 
-					if( !$result ) {
+					if ( ! $result ) {
 						$delete_error_sites[ $site_ID ] = array( $ext_ID );
 					}
-
 				}
-
 			}
-
 		}
 
 		update_option( 'syn_delete_error_sites', $delete_error_sites );
 		// all post metadata will be automatically deleted including slave_post_states
-
 	}
 
 	// get the slave posts as $site_ID => $ext_ID
@@ -1227,22 +1252,22 @@ class WP_Push_Syndication_Server {
 
 		// array containing states of sites
 		$slave_post_states = get_post_meta( $post_ID, '_syn_slave_post_states', true );
-		if ( empty( $slave_post_states ) )
+		if ( empty( $slave_post_states ) ) {
 			return;
+		}
 
 		// array containing slave posts as $site_ID => $ext_ID
 		$slave_posts = array();
 
-		foreach( $slave_post_states as $state ) {
-			foreach( $state as $site_ID => $info ) {
-				if( ! is_wp_error( $info ) && !empty( $info[ 'ext_ID' ] ) ) {
-					$slave_posts[ $site_ID ] = $info[ 'ext_ID' ];
+		foreach ( $slave_post_states as $state ) {
+			foreach ( $state as $site_ID => $info ) {
+				if ( ! is_wp_error( $info ) && ! empty( $info['ext_ID'] ) ) {
+					$slave_posts[ $site_ID ] = $info['ext_ID'];
 				}
 			}
 		}
 
 		return $slave_posts;
-
 	}
 
 	// checking user capability
@@ -1268,22 +1293,21 @@ class WP_Push_Syndication_Server {
 		);
 
 		return $schedules;
-
 	}
 
 	public function pre_schedule_pull_content( $selected_sitegroups ) {
 
-		if ( ! $this->current_user_can_syndicate() )
+		if ( ! $this->current_user_can_syndicate() ) {
 			return;
+		}
 
 		$sites = array();
-		foreach( $selected_sitegroups as $selected_sitegroup ) {
+		foreach ( $selected_sitegroups as $selected_sitegroup ) {
 			$sites = array_merge( $sites, $this->get_sites_by_sitegroup( $selected_sitegroup ) );
 		}
 
 
 		$this->schedule_pull_content( $sites );
-
 	}
 
 	public function schedule_pull_content( $sites ) {
@@ -1294,7 +1318,7 @@ class WP_Push_Syndication_Server {
 
 
 		// Clear all previously scheduled jobs.
-		if( ! empty( $old_pull_sites ) ) {
+		if ( ! empty( $old_pull_sites ) ) {
 			// Clear any jobs that were scheduled the old way: one job to pull many sites.
 				wp_clear_scheduled_hook( 'syn_pull_content', array( $old_pull_sites ) );
 
@@ -1323,7 +1347,7 @@ class WP_Push_Syndication_Server {
 		$selected_sitegroups = $this->push_syndicate_settings['selected_pull_sitegroups'];
 
 		$sites = array();
-		foreach( $selected_sitegroups as $selected_sitegroup ) {
+		foreach ( $selected_sitegroups as $selected_sitegroup ) {
 			$sites = array_merge( $sites, $this->get_sites_by_sitegroup( $selected_sitegroup ) );
 		}
 
@@ -1337,8 +1361,9 @@ class WP_Push_Syndication_Server {
 		$site_a_pull_date = (int) get_post_meta( $site_a->ID, 'syn_last_pull_time', true );
 		$site_b_pull_date = (int) get_post_meta( $site_b->ID, 'syn_last_pull_time', true );
 
-		if ( $site_a_pull_date == $site_b_pull_date )
+		if ( $site_a_pull_date == $site_b_pull_date ) {
 			return 0;
+		}
 
 		return ( $site_a_pull_date < $site_b_pull_date ) ? -1 : 1;
 	}
@@ -1346,8 +1371,9 @@ class WP_Push_Syndication_Server {
 	public function pull_content( $sites = array() ) {
 		add_filter( 'http_headers_useragent', array( $this, 'syndication_user_agent' ) );
 
-		if ( empty( $sites ) )
+		if ( empty( $sites ) ) {
 			$sites = $this->pull_get_selected_sites();
+		}
 
 		// Treat this process as an import.
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -1362,12 +1388,13 @@ class WP_Push_Syndication_Server {
 		// Keep track of posts that are added or changed.
 		$updated_post_ids = array();
 
-		foreach( $sites as $site ) {
+		foreach ( $sites as $site ) {
 			$site_id = $site->ID;
 
 			$site_enabled = get_post_meta( $site_id, 'syn_site_enabled', true );
-			if( $site_enabled != 'on' )
+			if ( $site_enabled != 'on' ) {
 				continue;
+			}
 
 			$transport_type = get_post_meta( $site_id, 'syn_transport_type', true );
 			$client         = Syndication_Client_Factory::get_client( $transport_type, $site_id );
@@ -1376,14 +1403,13 @@ class WP_Push_Syndication_Server {
 			$post_types_processed = array();
 
 			if ( is_array( $posts ) && count( $posts ) > 0 ) {
-				Syndication_Logger::log_post_info( $site_id, $status = 'start_import', $message = sprintf( __( 'starting import for site id %d with %d posts', 'push-syndication' ), $site_id, count( $posts ) ), $log_time = null, $extra = array() );
+				Syndication_Logger::log_post_info( $site_id, $status = 'start_import', $message = sprintf( __( 'starting import for site id %1$d with %2$d posts', 'push-syndication' ), $site_id, count( $posts ) ), $log_time = null, $extra = array() );
 			} else {
 				Syndication_Logger::log_post_info( $site_id, $status = 'no_posts', $message = sprintf( __( 'no posts for site id %d', 'push-syndication' ), $site_id ), $log_time = null, $extra = array() );
 			}
 
-			if ( is_array( $posts ) && ! empty( $posts) ) {
-				foreach( $posts as $post ) {
-
+			if ( is_array( $posts ) && ! empty( $posts ) ) {
+				foreach ( $posts as $post ) {
 					if ( ! in_array( $post['post_type'], $post_types_processed ) ) {
 						remove_post_type_support( $post['post_type'], 'revisions' );
 						$post_types_processed[] = $post['post_type'];
@@ -1402,7 +1428,7 @@ class WP_Push_Syndication_Server {
 							continue;
 						}
 						// if updation is disabled continue
-						if( $this->push_syndicate_settings['update_pulled_posts'] != 'on' ) {
+						if ( $this->push_syndicate_settings['update_pulled_posts'] != 'on' ) {
 							Syndication_Logger::log_post_info( $site_id, $status = 'skip_update_pulled_posts', $message = sprintf( __( 'skipping post update per update_pulled_posts setting', 'push-syndication' ) ), $log_time = null, $extra = array( 'post' => $post ) );
 							continue;
 						}
@@ -1415,7 +1441,6 @@ class WP_Push_Syndication_Server {
 						do_action( 'syn_post_pull_edit_post', $result, $post, $site, $transport_type, $client );
 
 						$updated_post_ids[] = (int) $result;
-
 					} else {
 						$pull_new_shortcircuit = apply_filters( 'syn_pre_pull_new_post_shortcircuit', false, $post, $site, $transport_type, $client );
 						if ( true === $pull_new_shortcircuit ) {
@@ -1428,7 +1453,7 @@ class WP_Push_Syndication_Server {
 
 						do_action( 'syn_post_pull_new_post', $result, $post, $site, $transport_type, $client );
 
-						if( !is_wp_error( $result ) ) {
+						if ( ! is_wp_error( $result ) ) {
 							update_post_meta( $result, 'syn_post_guid', $post['post_guid'] );
 							update_post_meta( $result, 'syn_source_site_id', $site_id );
 						}
@@ -1442,7 +1467,7 @@ class WP_Push_Syndication_Server {
 				}
 			}
 
-			update_post_meta( $site_id, 'syn_last_pull_time', current_time( 'timestamp', 1 ) );
+			update_post_meta( $site_id, 'syn_last_pull_time', time() );
 		}
 
 		// Resume comment and term counting and cache invalidation.
@@ -1466,14 +1491,16 @@ class WP_Push_Syndication_Server {
 		global $wpdb;
 
 		$post_id = apply_filters( 'syn_pre_find_post_by_guid', false, $guid, $post, $site );
-		if ( false !== $post_id )
+		if ( false !== $post_id ) {
 			return $post_id;
+		}
 
 		// A direct query here is way more efficient than WP_Query, because we don't have to do all the extra processing, filters, and JOIN.
 		$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'syn_post_guid' AND meta_value = %s LIMIT 1", $guid ) );
 
-		if ( $post_id )
+		if ( $post_id ) {
 			return $post_id;
+		}
 
 		return false;
 	}
@@ -1481,7 +1508,7 @@ class WP_Push_Syndication_Server {
 	/**
 	 * Reschedule all scheduled pull jobs.
 	 */
-	public function refresh_pull_jobs()	{
+	public function refresh_pull_jobs() {
 		$sites = $this->pull_get_selected_sites();
 
 		$this->schedule_pull_content( $sites );
@@ -1507,7 +1534,7 @@ class WP_Push_Syndication_Server {
 	 * @param $tt_id
 	 * @param $taxonomy
 	 */
-	public function handle_site_group_change ( $term, $tt_id, $taxonomy ) {
+	public function handle_site_group_change( $term, $tt_id, $taxonomy ) {
 		if ( 'syn_sitegroup' === $taxonomy ) {
 			$this->schedule_deferred_pull_jobs_refresh();
 		}
@@ -1543,8 +1570,9 @@ class WP_Push_Syndication_Server {
 	private function upgrade() {
 		global $wpdb;
 
-		if ( version_compare( $this->version, SYNDICATION_VERSION, '>=' ) )
+		if ( version_compare( $this->version, SYNDICATION_VERSION, '>=' ) ) {
 			return;
+		}
 
 		// upgrade to 2.1
 		if ( version_compare( $this->version, '2.0', '<=' ) ) {
@@ -1563,7 +1591,4 @@ class WP_Push_Syndication_Server {
 
 		update_option( 'syn_version', SYNDICATION_VERSION );
 	}
-
-
-
 }

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -391,8 +391,9 @@ class WP_Push_Syndication_Server {
 	/**
 	 * Validate the push_syndication_max_pull_attempts option.
 	 *
-	 * @param $val
-	 * @return int
+	 * @param mixed $val The option value to validate.
+	 *
+	 * @return int Validated value.
 	 */
 	public function validate_max_pull_attempts( $val ) {
 		/**
@@ -1110,13 +1111,20 @@ class WP_Push_Syndication_Server {
 	}
 
 	/**
-	 * $site_states is an array containing state of the site
-	 * with regard to the post the state. The states are
-	 *  success - the post was pushed successfully.
-	 *  new-error - error when creating the post.
-	 *  edit-error - error when editing the post.
-	 *  remove-error - error when removing the post in a slave site, when the sitegroup is unselected
-	 *  new - if the state is not found or the post is deleted in the slave site.
+	 * Gets the site info relative to a post state.
+	 *
+	 * The states are:
+	 *  - success - the post was pushed successfully.
+	 *  - new-error - error when creating the post.
+	 *  - edit-error - error when editing the post.
+	 *  - remove-error - error when removing the post in a slave site.
+	 *  - new - if the state is not found or the post is deleted in the slave site.
+	 *
+	 * @param int                          $site_ID           The site ID.
+	 * @param array                        $slave_post_states Array of slave post states, passed by reference.
+	 * @param Syndication_Client_Interface $client            The syndication client.
+	 *
+	 * @return array Site info with state and optional ext_ID.
 	 */
 	public function get_site_info( $site_ID, &$slave_post_states, $client ) {
 
@@ -1143,10 +1151,19 @@ class WP_Push_Syndication_Server {
 	}
 
 	/**
-	 * if the result is false state transitions
+	 * Validates result of creating a new post.
+	 *
+	 * State transitions if the result is error:
 	 * new          -> new-error
 	 * new-error    -> new-error
 	 * remove-error -> new-error
+	 *
+	 * @param int|WP_Error                 $result            The result from creating the post.
+	 * @param array                        $slave_post_states Array of slave post states, passed by reference.
+	 * @param int                          $site_ID           The site ID.
+	 * @param Syndication_Client_Interface $client            The syndication client.
+	 *
+	 * @return int|WP_Error The result.
 	 */
 	public function validate_result_new_post( $result, &$slave_post_states, $site_ID, $client ) {
 
@@ -1162,9 +1179,19 @@ class WP_Push_Syndication_Server {
 	}
 
 	/**
-	 * if the result is false state transitions
+	 * Validates result of editing a post.
+	 *
+	 * State transitions if the result is error:
 	 * edit-error   -> edit-error
 	 * success      -> edit-error
+	 *
+	 * @param bool|WP_Error                $result            The result from editing the post.
+	 * @param int                          $ext_ID            The external post ID.
+	 * @param array                        $slave_post_states Array of slave post states, passed by reference.
+	 * @param int                          $site_ID           The site ID.
+	 * @param Syndication_Client_Interface $client            The syndication client.
+	 *
+	 * @return bool|WP_Error The result.
 	 */
 	public function validate_result_edit_post( $result, $ext_ID, &$slave_post_states, $site_ID, $client ) {
 		if ( is_wp_error( $result ) ) {
@@ -1515,10 +1542,11 @@ class WP_Push_Syndication_Server {
 	}
 
 	/**
-	 * Handle save_post and delete_post for syn_site posts. If a syn_site post
-	 * is updated or deleted we should reprocess any scheduled pull jobs.
+	 * Handle save_post and delete_post for syn_site posts.
 	 *
-	 * @param $post_id
+	 * If a syn_site post is updated or deleted we should reprocess any scheduled pull jobs.
+	 *
+	 * @param int $post_id The post ID.
 	 */
 	public function handle_site_change( $post_id ) {
 		if ( 'syn_site' === get_post_type( $post_id ) ) {
@@ -1527,12 +1555,13 @@ class WP_Push_Syndication_Server {
 	}
 
 	/**
-	 * Handle create_term and delete_term for syn_sitegroup terms. If a site
-	 * group is created or deleted we should reprocess any scheduled pull jobs.
+	 * Handle create_term and delete_term for syn_sitegroup terms.
 	 *
-	 * @param $term
-	 * @param $tt_id
-	 * @param $taxonomy
+	 * If a site group is created or deleted we should reprocess any scheduled pull jobs.
+	 *
+	 * @param int    $term     The term ID.
+	 * @param int    $tt_id    The term taxonomy ID.
+	 * @param string $taxonomy The taxonomy slug.
 	 */
 	public function handle_site_group_change( $term, $tt_id, $taxonomy ) {
 		if ( 'syn_sitegroup' === $taxonomy ) {

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -954,7 +954,7 @@ class WP_Push_Syndication_Server {
 		// set value as locked, valid for 5 mins.
 		set_transient( 'syn_syndicate_lock', 'locked', 60 * 5 );
 
-		/** start of critical section */
+		/** Start of critical section. */
 
 		$post_ID = $sites['post_ID'];
 
@@ -1026,7 +1026,7 @@ class WP_Push_Syndication_Server {
 		}
 
 
-		/** end of critical section */
+		/** End of critical section. */
 
 		// release the lock.
 		delete_transient( 'syn_syndicate_lock' );

--- a/includes/interface-syndication-client.php
+++ b/includes/interface-syndication-client.php
@@ -4,6 +4,7 @@ interface Syndication_Client {
 
 	/**
 	 * Return Client Data
+	 *
 	 * @return array array( 'id' => (string) $transport_name, 'modes' => array( 'push', 'pull' ), 'name' => (string) $name );
 	 */
 	public static function get_client_data();
@@ -11,7 +12,7 @@ interface Syndication_Client {
 	/**
 	 * Creates a new post in the slave site.
 	 *
-	 * @param   int  $post_ID  The post ID to push.
+	 * @param   int $post_ID  The post ID to push.
 	 *
 	 * @return  boolean true on success false on failure.
 	 */
@@ -20,8 +21,8 @@ interface Syndication_Client {
 	/**
 	 * Edits an existing post in the slave site.
 	 *
-	 * @param   int  $post_ID  The post ID to push.
-	 * @param   int  $ext_ID   Slave post ID to edit.
+	 * @param   int $post_ID  The post ID to push.
+	 * @param   int $ext_ID   Slave post ID to edit.
 	 *
 	 * @return  boolean true on success false on failure.
 	 */
@@ -30,29 +31,29 @@ interface Syndication_Client {
 	/**
 	 * Deletes an existing post in the slave site.
 	 *
-	 * @param   int  $ext_ID  Slave post ID to delete.
+	 * @param   int $ext_ID  Slave post ID to delete.
 	 *
 	 * @return  boolean true on success false on failure.
 	 */
 	public function delete_post( $ext_ID );
 
-    /**
-     * Retrieves a single post from a slave site.
-     *
-     * @param   int  $ext_ID  Slave post ID to retrieve.
-     *
-     * @return  boolean true on success false on failure.
-     */
-    public function get_post( $ext_ID );
+	/**
+	 * Retrieves a single post from a slave site.
+	 *
+	 * @param   int $ext_ID  Slave post ID to retrieve.
+	 *
+	 * @return  boolean true on success false on failure.
+	 */
+	public function get_post( $ext_ID );
 
-    /**
-     * Retrieves a list of posts from a slave site.
-     *
-     * @param   array   $args  Arguments when retrieving posts.
-     *
-     * @return  boolean true on success false on failure.
-     */
-    public function get_posts( $args = array() );
+	/**
+	 * Retrieves a list of posts from a slave site.
+	 *
+	 * @param   array $args  Arguments when retrieving posts.
+	 *
+	 * @return  boolean true on success false on failure.
+	 */
+	public function get_posts( $args = array() );
 
 	/**
 	 * Test the connection with the slave site.
@@ -64,7 +65,7 @@ interface Syndication_Client {
 	/**
 	 * Checks whether the given post exists in the slave site.
 	 *
-	 * @param   int  $ext_ID  Slave post ID to check.
+	 * @param   int $ext_ID  Slave post ID to check.
 	 *
 	 * @return  boolean  true on success false on failure.
 	 */
@@ -73,17 +74,16 @@ interface Syndication_Client {
 	/**
 	 * Display the client settings for the slave site.
 	 *
-	 * @param   object  $site  The site object to display settings.
+	 * @param   object $site  The site object to display settings.
 	 */
 	public static function display_settings( $site );
 
 	/**
 	 * Save the client settings for the slave site.
 	 *
-	 * @param   int  $site_ID  The site ID to save settings.
+	 * @param   int $site_ID  The site ID to save settings.
 	 *
 	 * @return  boolean  true on success false on failure.
 	 */
 	public static function save_settings( $site_ID );
-
 }

--- a/includes/interface-syndication-client.php
+++ b/includes/interface-syndication-client.php
@@ -1,5 +1,17 @@
 <?php
+/**
+ * Client interface for content syndication.
+ *
+ * @package Syndication
+ */
 
+/**
+ * Interface Syndication_Client
+ *
+ * Defines the contract for syndication transport implementations.
+ * Each client handles pushing and pulling content via a specific protocol
+ * (REST API, XML-RPC, RSS, XML feeds).
+ */
 interface Syndication_Client {
 
 	/**

--- a/includes/interface-syndication-encryptor.php
+++ b/includes/interface-syndication-encryptor.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Encryptor interface for syndication data encryption.
+ *
+ * @package Syndication
+ */
 
 /**
  * Interface Syndication_Encryptor
+ *
+ * Defines the contract for encryption implementations used to secure
+ * sensitive syndication data such as credentials and tokens.
  */
 interface Syndication_Encryptor {
 

--- a/includes/push-syndicate-encryption.php
+++ b/includes/push-syndicate-encryption.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Encryption helper functions for syndication.
+ *
+ * Provides global wrapper functions for encrypting and decrypting
+ * sensitive syndication data using the configured encryptor.
+ *
+ * @package Syndication
+ */
 
 /**
  * Encrypts data.

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -1,5 +1,9 @@
 <?php
 /**
+ * Syndication
+ *
+ * @package Syndication
+ *
  * Plugin Name:  Syndication
  * Plugin URI:   http://wordpress.org/extend/plugins/push-syndication/
  * Description:  Syndicate content to and from your sites

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -40,7 +40,7 @@ new Syndication_Event_Counter();
 require __DIR__ . '/includes/class-syndication-site-failure-monitor.php';
 new Syndication_Site_Failure_Monitor();
 
-// Create the site auto retry functionality
+// Create the site auto retry functionality.
 require __DIR__ . '/includes/class-syndication-site-auto-retry.php';
 new Failed_Syndication_Auto_Retry();
 
@@ -58,5 +58,5 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70100 ) {
 	$syndication_encryption = new Syndication_Encryption( new Syndication_Encryptor_OpenSSL() );
 }
 
-// @TODO: instead of saving this as a global, have it as an attribute of WP_Push_Syndication_Server
+// @TODO: instead of saving this as a global, have it as an attribute of WP_Push_Syndication_Server.
 $GLOBALS['push_syndication_encryption'] = $syndication_encryption;

--- a/push-syndication.php
+++ b/push-syndication.php
@@ -21,13 +21,13 @@ if ( ! defined( 'PUSH_SYNDICATE_KEY' ) ) {
 /**
  * Load syndication logger
  */
-require_once dirname( __FILE__ ) . '/includes/class-syndication-logger.php';
+require_once __DIR__ . '/includes/class-syndication-logger.php';
 Syndication_Logger::init();
 
-require_once dirname( __FILE__ ) . '/includes/class-wp-push-syndication-server.php';
+require_once __DIR__ . '/includes/class-wp-push-syndication-server.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once dirname( __FILE__ ) . '/includes/class-wp-cli.php';
+	require_once __DIR__ . '/includes/class-wp-cli.php';
 }
 
 $GLOBALS['push_syndication_server'] = new WP_Push_Syndication_Server();
@@ -45,10 +45,10 @@ require __DIR__ . '/includes/class-syndication-site-auto-retry.php';
 new Failed_Syndication_Auto_Retry();
 
 // Load encryption classes.
-require_once dirname( __FILE__ ) . '/includes/class-syndication-encryption.php';
-require_once dirname( __FILE__ ) . '/includes/interface-syndication-encryptor.php';
-require_once dirname( __FILE__ ) . '/includes/class-syndication-encryptor-mcrypt.php';
-require_once dirname( __FILE__ ) . '/includes/class-syndication-encryptor-openssl.php';
+require_once __DIR__ . '/includes/class-syndication-encryption.php';
+require_once __DIR__ . '/includes/interface-syndication-encryptor.php';
+require_once __DIR__ . '/includes/class-syndication-encryptor-mcrypt.php';
+require_once __DIR__ . '/includes/class-syndication-encryptor-openssl.php';
 
 // On PHP 7.1 mcrypt is available, but will throw a deprecated error if its used. Therefore, checking for the
 // PHP version, instead of checking for mcrypt is a better approach.


### PR DESCRIPTION
## Summary

Comprehensive PHPCS coding standards fixes across the syndication plugin codebase. This PR addresses multiple categories of violations to improve code quality and maintainability.

### Changes included:

- **Automatic fixes** - Applied `phpcbf` for auto-fixable issues (spacing, alignment)
- **Comment punctuation** - Ensured inline comments end with proper punctuation
- **Function docblocks** - Added missing `@param` and `@return` documentation
- **Yoda conditions** - Applied WordPress-style comparisons (`'value' === $var`)
- **Method visibility** - Added explicit `public`/`private` keywords to all methods
- **Docblock formatting** - Capitalised short descriptions, added full stops to param comments
- **File/class docblocks** - Added `@package Syndication` headers and class descriptions
- **Empty statement handling** - Added `phpcs:ignore` for intentional placeholder blocks

### Not addressed (deferred to 3.0.0):

- Variable naming conventions (breaking change risk)
- Hook naming prefixes (breaking change risk)
- Security validations (requires careful analysis)
- Remaining FileComment.Missing for files with `require_once` (will be resolved with namespace refactor)

## Test plan

- [ ] Run `composer cs` to verify no regressions
- [ ] Verify plugin activates without errors
- [ ] Test basic syndication functionality

---

🤖 Generated with [Claude Code](https://claude.ai/code)