### PR TITLE
Require edit_post capability in syndication.addThumbnail

### DIFF
--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -690,6 +690,11 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 			return $image;
 		}
 
+		// mw_newMediaObject only requires `upload_files`, so check the caller may edit the target post before writing to it.
+		if ( ! current_user_can( 'edit_post', $post_ID ) ) {
+			return new IXR_Error( 401, esc_html__( 'Sorry, you are not allowed to edit this post.', 'push-syndication' ) );
+		}
+
 		$thumbnail_id = (int) $image['id'];
 		if ( empty( $thumbnail_id ) ) {
 			return new IXR_Error( 500, esc_html__( 'Sorry, looks like the image upload failed.', 'push-syndication' ) );


### PR DESCRIPTION
## Summary

`Syndication_WP_XMLRPC_Client_Extensions::xmlrpc_add_thumbnail()` delegated all of its authentication to `mw_newMediaObject()`, with a comment noting as much. That call only requires the `upload_files` capability, which an Author-level user has, and it says nothing about whether the caller may edit the post the thumbnail is being attached to. Both `$post_ID` and `$meta_key` come straight from the request, so any user who could upload media could set the featured image on, or write an arbitrary attachment ID into an arbitrary meta key on, any post on the site — other users' published content and the plugin's own `syn_site` posts included. Because the handler calls `update_post_meta()` directly, the protected-meta capability checks were bypassed too, putting underscore-prefixed keys in reach.

The sibling `xmlrpc_delete_thumbnail()` handler already performs a `current_user_can( 'edit_post', $post_ID )` check before touching anything, so this was an oversight rather than a deliberate asymmetry. This adds the matching guard to `addThumbnail`, returning `IXR_Error( 401, ... )` when it fails.

The check sits after `mw_newMediaObject()` returns successfully and before any write to `$post_ID`. An unauthorised caller can therefore still leave an orphaned attachment behind, but that is something they could already do by calling `mw_newMediaObject` directly with their `upload_files` capability, so nothing new is granted. Moving the check earlier would require logging in ahead of the media upload, which overlaps with the separate pre-authentication SSRF work in VIPPLUG-58 and is deliberately left out of scope here.

Fixes VIPPLUG-60.

## Test plan

- [ ] As an Author-level user, call `syndication.addThumbnail` against a post owned by another user and confirm a 401 is returned and the post meta is unchanged.
- [ ] As a user who can edit the target post, confirm the thumbnail is still set and the attachment details and alt text are still updated.