### PR TITLE
Harden the syn_log meta read in the log viewer

### DIFF
--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -450,7 +450,15 @@ class Syndication_Logger {
 					 */
 					$all_log_entries = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'syn_log' GROUP BY post_id ORDER BY meta_id DESC LIMIT 0, 100" ); // Cache pass (see note above).
 					foreach ( $all_log_entries as $log_entry ) {
-						$log_entries[ $log_entry->post_id ] = unserialize( $log_entry->meta_value );
+						/*
+						 * Never unserialize the raw column directly. `syn_log` is an unprotected meta key,
+						 * so its contents cannot be assumed to be something this plugin wrote.
+						 * `maybe_unserialize()` applies the same gate as every other meta read, and the
+						 * array check discards anything that did not round-trip as a log array.
+						 */
+						$log_entry_value = maybe_unserialize( $log_entry->meta_value );
+
+						$log_entries[ $log_entry->post_id ] = is_array( $log_entry_value ) ? $log_entry_value : array();
 					}
 				}
 			}

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -118,4 +118,35 @@ class LoggerTest extends WPIntegrationTestCase {
 		$errors = get_post_meta( $site_id, 'syn_log_errors', true );
 		$this->assertEquals( 1, (int) $errors );
 	}
+
+	/**
+	 * Test that a stored value the plugin did not write is not turned into an object.
+	 *
+	 * `syn_log` is an unprotected meta key, so its contents cannot be assumed to be
+	 * well-formed log data. Some values are stored verbatim rather than re-serialized,
+	 * and reading one back must yield an array, never an object graph.
+	 *
+	 * @covers Syndication_Logger::get_messages
+	 */
+	public function test_get_messages_never_returns_an_object_from_stored_meta(): void {
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+			)
+		);
+
+		$inner   = 'x:i:0;a:1:{i:0;s:3:"pwn";};m:a:0:{}';
+		$payload = 'C:11:"ArrayObject":' . strlen( $inner ) . ':{' . $inner . '}';
+
+		add_post_meta( $post_id, 'syn_log', $payload );
+
+		// Confirm the value was stored verbatim rather than re-serialized on the way in.
+		$this->assertSame( $payload, get_post_meta( $post_id, 'syn_log', true ) );
+
+		$log_entries = Syndication_Logger::get_messages();
+
+		$this->assertArrayHasKey( $post_id, $log_entries );
+		$this->assertSame( array(), $log_entries[ $post_id ] );
+	}
 }


### PR DESCRIPTION
## Summary

`Syndication_Logger::get_messages()` has two paths for reading log entries. When it is given an object ID it goes through `get_post_meta()`; when it is not, it falls back to a direct query against `wp_postmeta` and passes the raw `meta_value` column into a bare `unserialize()`. The Syndication → Logs screen always calls it without an object ID, so the raw path is the one that actually runs in practice, and the `get_post_meta()` branch is effectively dead code.

That matters because `syn_log` is an unprotected meta key. Nothing stops a value being written to it outside the plugin, so its contents cannot be assumed to be well-formed log data, and a bare `unserialize()` on that input will happily build whatever structure the stored string describes. Every other meta read in the plugin goes through the `maybe_unserialize()` gate; this one did not.

The fix brings it into line: read through `maybe_unserialize()`, then coerce anything that is not an array to an empty one. The coercion matters as much as the gate, because the caller immediately runs `array_filter()` over the result and a non-array value fatals the log screen outright.

A regression test covers it, using a value that is stored verbatim rather than re-serialized on the way in. It fails against the previous implementation and passes with the change.

Refs VIPPLUG-57. A follow-up (VIPPLUG-67) covers constraining the query itself to the post type the plugin owns, along with renaming the meta key, both of which need more thought than this change did.

## Test plan

- [x] `composer test:integration` — 21 tests, 37 assertions, 5 skipped (pre-existing skips, mcrypt extension absent)
- [x] `composer test:unit` — 107 tests, 269 assertions
- [x] Verified the new test fails without the change
- [x] PHPCS on the touched file: one warning fewer than the `develop` baseline, none added