### PR TITLE
Escape Syndication log viewer output to fix stored XSS

### DIFF
--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -77,23 +77,20 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	/**
 	 * Render the default column output.
 	 *
+	 * Log entries are read from post meta that may have been written by a
+	 * lower-privileged user, so every value is escaped before output.
+	 * WP_List_Table echoes the return value without escaping it.
+	 *
 	 * @param array  $item        The current log item.
 	 * @param string $column_name The column name being rendered.
-	 * @return string The column value or debug output.
+	 * @return string The escaped column value, or an empty string.
 	 */
 	public function column_default( $item, $column_name ) {
-		switch ( $column_name ) {
-			case 'object_id':
-			case 'log_id':
-			case 'time':
-			case 'msg_type':
-			case 'status':
-			case 'message':
-				return $item[ $column_name ];
-
-			default:
-				return print_r( $item, true );
+		if ( ! isset( $item[ $column_name ] ) || ! is_scalar( $item[ $column_name ] ) ) {
+			return '';
 		}
+
+		return esc_html( (string) $item[ $column_name ] );
 	}
 
 	/**
@@ -138,9 +135,24 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	 * @return int Comparison result.
 	 */
 	public function usort_reorder( $a, $b ) {
-		$orderby = ( ! empty( $_GET['orderby'] ) ) ? esc_attr( $_GET['orderby'] ) : 'time';
-		$order   = ( ! empty( $_GET['order'] ) ) ? esc_attr( $_GET['order'] ) : 'desc';
-		$result  = strcmp( $a[ $orderby ], $b[ $orderby ] );
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only sorting of an admin list table.
+		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : '';
+		$order   = isset( $_GET['order'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( ! array_key_exists( $orderby, $this->get_sortable_columns() ) ) {
+			$orderby = 'time';
+		}
+
+		if ( 'asc' !== $order ) {
+			$order = 'desc';
+		}
+
+		$a_value = isset( $a[ $orderby ] ) && is_scalar( $a[ $orderby ] ) ? (string) $a[ $orderby ] : '';
+		$b_value = isset( $b[ $orderby ] ) && is_scalar( $b[ $orderby ] ) ? (string) $b[ $orderby ] : '';
+
+		$result = strcmp( $a_value, $b_value );
+
 		return ( 'asc' === $order ) ? $result : -$result;
 	}
 
@@ -148,10 +160,16 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	 * Render the log_id column with truncation.
 	 *
 	 * @param array $item The current log item.
-	 * @return string The truncated log ID.
+	 * @return string The escaped, truncated log ID.
 	 */
 	public function column_log_id( $item ) {
-		return sprintf( '%1$s', substr( $item['log_id'], 0, 3 ) . '&hellip;' . substr( $item['log_id'], -3 ) );
+		if ( ! isset( $item['log_id'] ) || ! is_scalar( $item['log_id'] ) ) {
+			return '';
+		}
+
+		$log_id = (string) $item['log_id'];
+
+		return esc_html( substr( $log_id, 0, 3 ) ) . '&hellip;' . esc_html( substr( $log_id, -3 ) );
 	}
 
 	/**
@@ -291,7 +309,8 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	 * Output the log ID filter dropdown.
 	 */
 	private function create_log_id_dropdown() {
-		$requested_log_id = isset( $_REQUEST['log_id'] ) ? esc_attr( $_REQUEST['log_id'] ) : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter on an admin list table.
+		$requested_log_id = isset( $_REQUEST['log_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['log_id'] ) ) : 0;
 		?>
 		<label class="screen-reader-text" for="filter-by-log-id"><?php esc_html_e( 'Filter by Log ID', 'push-syndication' ); ?></label>
 		<select name="log_id" id="filter-by-log-id">
@@ -299,22 +318,22 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 			<?php
 			$log_ids = array();
 			foreach ( $this->prepared_data as $row ) {
-				if ( 0 == $row['log_id'] ) {
+				if ( ! isset( $row['log_id'] ) || ! is_scalar( $row['log_id'] ) || 0 == $row['log_id'] ) {
 					continue;
 				}
 
-				$log_id = esc_attr( $row['log_id'] );
+				$log_id = (string) $row['log_id'];
 				if ( ! isset( $log_ids[ $log_id ] ) ) {
 					$log_ids[ $log_id ] = sprintf(
 						"<option %s value='%s'>%s</option>\n",
 						selected( $requested_log_id, $log_id, false ),
 						esc_attr( $log_id ),
-						esc_attr( $this->column_log_id( $row ) )
+						$this->column_log_id( $row )
 					);
 				}
 			}
 
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each element is escaped with esc_attr() in the loop above
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- values are escaped with esc_attr()/column_log_id() in the loop above.
 			echo implode( "\n", $log_ids );
 			?>
 		</select>

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -98,12 +98,42 @@ class Syndication_Logger {
 	public static function init() {
 		self::instance()->log_id = md5( uniqid() . microtime() );
 
+		add_action( 'init', array( __CLASS__, 'register_log_meta' ) );
+
 		require_once __DIR__ . '/class-syndication-admin-notices.php';
 		new Syndication_Logger_Admin_Notice();
 
 		if ( is_admin() ) {
 			require_once __DIR__ . '/class-syndication-logger-viewer.php';
 			$viewer = new Syndication_Logger_Viewer();
+		}
+	}
+
+	/**
+	 * Register the log meta keys with an auth callback that always denies.
+	 *
+	 * These keys are read back and rendered on the Syndication Logs screen, and
+	 * get_messages() queries them across the whole of postmeta without constraining
+	 * the post type, so their values must not be writable by whoever can edit a post.
+	 *
+	 * map_meta_cap() consults the auth callback for add_post_meta, edit_post_meta and
+	 * delete_post_meta, which keeps the keys out of the Custom Fields panel, the
+	 * add/delete meta AJAX endpoints and XML-RPC set_custom_fields().
+	 *
+	 * This is hardening rather than the fix: update_post_meta() never consults the
+	 * auth callback, so the logger's own writes are unaffected, and so is anything
+	 * else calling it directly. Output escaping in the log viewer remains what
+	 * actually prevents a planted payload from executing.
+	 */
+	public static function register_log_meta() {
+		foreach ( array( 'syn_log', 'syn_log_errors', 'syn_log_errors_overall' ) as $meta_key ) {
+			register_meta(
+				'post',
+				$meta_key,
+				array(
+					'auth_callback' => '__return_false',
+				)
+			);
 		}
 	}
 

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -159,6 +159,14 @@ class LoggerTest extends WPIntegrationTestCase {
 	 * @covers Syndication_Logger::register_log_meta
 	 */
 	public function test_log_meta_keys_are_not_writable_by_capability(): void {
+		/*
+		 * The plugin registers these on `init`, which fires once per PHPUnit run, and
+		 * WP_UnitTestCase_Base::tear_down() calls unregister_all_meta_keys() after every
+		 * test. Register them here rather than relying on a registration an earlier test
+		 * has already torn down.
+		 */
+		Syndication_Logger::register_log_meta();
+
 		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
 

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -149,4 +149,33 @@ class LoggerTest extends WPIntegrationTestCase {
 		$this->assertArrayHasKey( $post_id, $log_entries );
 		$this->assertSame( array(), $log_entries[ $post_id ] );
 	}
+
+	/**
+	 * The log meta keys must not be writable through capability-checked paths.
+	 *
+	 * This is what keeps them out of the Custom Fields panel, the add/delete meta
+	 * AJAX endpoints and XML-RPC set_custom_fields(), all of which gate on these caps.
+	 *
+	 * @covers Syndication_Logger::register_log_meta
+	 */
+	public function test_log_meta_keys_are_not_writable_by_capability(): void {
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->factory()->post->create( array( 'post_type' => 'syn_site' ) );
+
+		foreach ( array( 'syn_log', 'syn_log_errors', 'syn_log_errors_overall' ) as $meta_key ) {
+			$this->assertFalse( current_user_can( 'add_post_meta', $post_id, $meta_key ), $meta_key );
+			$this->assertFalse( current_user_can( 'edit_post_meta', $post_id, $meta_key ), $meta_key );
+			$this->assertFalse( current_user_can( 'delete_post_meta', $post_id, $meta_key ), $meta_key );
+		}
+
+		// An unrelated key is still writable, so the denial is not blanket.
+		$this->assertTrue( current_user_can( 'edit_post_meta', $post_id, 'syn_site_url' ) );
+
+		// The logger writes via update_post_meta(), which does not consult the auth
+		// callback, so normal logging is unaffected.
+		Syndication_Logger::log_post_error( $post_id, 'error', 'still logging' );
+		$this->assertNotEmpty( get_post_meta( $post_id, 'syn_log', true ) );
+	}
 }

--- a/tests/Integration/LoggerViewerTest.php
+++ b/tests/Integration/LoggerViewerTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests for the Syndication_Logger_List_Table output escaping.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+use Syndication_Logger_List_Table;
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-syndication-logger-viewer.php';
+
+/**
+ * Class LoggerViewerTest
+ *
+ * Log entries are read from the unprotected `syn_log` post meta, so their
+ * values must be treated as untrusted when rendered by WP_List_Table.
+ *
+ * @covers Syndication_Logger_List_Table
+ */
+class LoggerViewerTest extends WPIntegrationTestCase {
+
+	/**
+	 * The list table under test.
+	 *
+	 * @var Syndication_Logger_List_Table
+	 */
+	private $table;
+
+	/**
+	 * Set up the list table.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->table = new Syndication_Logger_List_Table();
+	}
+
+	/**
+	 * Clean up request superglobals.
+	 */
+	public function tear_down(): void {
+		unset( $_GET['orderby'], $_GET['order'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Every rendered column value must be escaped.
+	 *
+	 * @covers Syndication_Logger_List_Table::column_default
+	 */
+	public function test_column_default_escapes_values(): void {
+		$item = array( 'message' => '<script>alert(1)</script>' );
+
+		$this->assertSame(
+			'&lt;script&gt;alert(1)&lt;/script&gt;',
+			$this->table->column_default( $item, 'message' )
+		);
+	}
+
+	/**
+	 * Non-scalar or missing values must not leak a var dump of the whole item.
+	 *
+	 * @covers Syndication_Logger_List_Table::column_default
+	 */
+	public function test_column_default_returns_empty_string_for_unusable_values(): void {
+		$item = array( 'status' => array( '<script>alert(1)</script>' ) );
+
+		$this->assertSame( '', $this->table->column_default( $item, 'status' ) );
+		$this->assertSame( '', $this->table->column_default( $item, 'message' ) );
+	}
+
+	/**
+	 * The truncated log ID must be escaped without mangling the ellipsis.
+	 *
+	 * @covers Syndication_Logger_List_Table::column_log_id
+	 */
+	public function test_column_log_id_escapes_and_truncates(): void {
+		$item = array( 'log_id' => '<script>alert(1)</script>' );
+
+		$this->assertSame( '&lt;sc&hellip;pt&gt;', $this->table->column_log_id( $item ) );
+		$this->assertSame( '', $this->table->column_log_id( array( 'log_id' => array() ) ) );
+	}
+
+	/**
+	 * An arbitrary `orderby` must fall back to the default sort column.
+	 *
+	 * @covers Syndication_Logger_List_Table::usort_reorder
+	 */
+	public function test_usort_reorder_ignores_unknown_orderby(): void {
+		$_GET['orderby'] = 'bogus_column';
+		$_GET['order']   = 'asc';
+
+		$a = array( 'time' => '2026-01-01 00:00:00' );
+		$b = array( 'time' => '2026-02-01 00:00:00' );
+
+		// Falls back to 'time', so $a sorts before $b.
+		$this->assertLessThan( 0, $this->table->usort_reorder( $a, $b ) );
+	}
+
+	/**
+	 * A known `orderby` is honoured, and `order` is whitelisted.
+	 *
+	 * @covers Syndication_Logger_List_Table::usort_reorder
+	 */
+	public function test_usort_reorder_honours_known_orderby_and_order(): void {
+		$a = array( 'status' => 'aaa' );
+		$b = array( 'status' => 'bbb' );
+
+		$_GET['orderby'] = 'status';
+		$_GET['order']   = 'asc';
+		$this->assertLessThan( 0, $this->table->usort_reorder( $a, $b ) );
+
+		// Anything that is not 'asc' means descending.
+		$_GET['order'] = 'nonsense';
+		$this->assertGreaterThan( 0, $this->table->usort_reorder( $a, $b ) );
+	}
+}


### PR DESCRIPTION
## Summary

The Syndication Logs list table renders log entries read from the `syn_log` post meta, and it returned every stored value to `WP_List_Table` unescaped. `column_default()` handed back `$item[ $column_name ]` verbatim, and its default branch returned `print_r( $item, true )`; `column_log_id()` was likewise raw. `WP_List_Table` echoes column output without escaping it, so whatever was in that meta ended up in the admin page as markup.

That would be academic if the meta were trustworthy, but it is not. `syn_log` is neither underscore-prefixed nor registered with an `auth_callback`, so it is writable through the core Custom Fields panel by anyone who can edit a post. Worse, the read path in `Syndication_Logger::get_messages()` selects on `meta_key = 'syn_log'` across the whole of postmeta without constraining the post type, so a payload does not even need to live on a `syn_site` post — any post the attacker can edit will do. A plain serialised array with `<script>` in `message`, `status`, `time` or `log_id` is enough; the next administrator to open Syndication → Logs runs it.

The fix escapes at the point every one of those rows passes through. `column_default()` now returns `esc_html()`'d output and drops the `print_r()` fallback, which was leaking a dump of the whole entry into the page for any column not in the switch. `column_log_id()` escapes each truncated half separately so the `&hellip;` between them is not mangled.

Two related bits of hardening came along with it. Because the meta values are attacker-controlled, they need not be scalar, and an array reaching `substr()` or `esc_attr()` is its own small mess — the column callbacks and the log ID dropdown now skip anything non-scalar. And `usort_reorder()` took `$_GET['orderby']` directly as an array key: `esc_attr()` is escaping, not validation, so an arbitrary key produced warnings and broken sorting. Both `orderby` and `order` are now whitelisted, against `get_sortable_columns()` and `asc`/`desc` respectively.

Whilst in the log ID dropdown I also fixed a pre-existing double-escape: the array key was an `esc_attr()`'d log ID, which was then escaped again on output and compared against a singly-escaped request value in `selected()`. The key is now the raw ID, escaped once at the point of output.

Fixes VIPPLUG-59.

## Hardening the write side

The escaping above stops a payload executing, but the second commit closes the route by which it gets planted. `syn_log`, `syn_log_errors` and `syn_log_errors_overall` are now registered with an `auth_callback` that always denies. `map_meta_cap()` consults that callback for `add_post_meta`, `edit_post_meta` and `delete_post_meta` before falling back to `is_protected_meta()`, so the keys vanish from the Custom Fields panel and are refused by the add/delete meta AJAX endpoints and by XML-RPC `set_custom_fields()`. That is the same coverage the `_` prefix would give, but without renaming the keys and orphaning every log entry already stored.

It is deliberately a second commit, because it is hardening with a wider blast radius than the escaping. If it turns out to break a workflow nobody anticipated, it can be reverted without taking the security fix with it.

Worth being clear about what it does not do: `update_post_meta()` never consults the auth callback. The logger's own writes are therefore unaffected, which is the point — but so is anything else calling it directly. Escaping in the viewer remains the thing that actually prevents execution.

## Out of scope

The bare `unserialize()` on the same meta read (`includes/class-syndication-logger.php:453`) is object injection rather than XSS and is tracked separately in VIPPLUG-57. Its suggested fix, `allowed_classes => false`, stops object injection but leaves these values as attacker-controlled strings, so both changes are needed.

## Test plan

`tests/Integration/LoggerViewerTest.php` covers the escaping, the non-scalar guards and the `orderby`/`order` whitelist. `LoggerTest::test_log_meta_keys_are_not_writable_by_capability()` covers the meta registration, including that an unrelated `syn_` key stays writable and that the logger itself still records entries.

I was not able to run the integration suite locally: `wp-env start` fails to build its base image because the `bullseye-security` release file in the upstream WordPress image has expired, so `apt-get update` exits 100. That is unrelated to this branch, and CI should be the judge. I did verify the same assertions against a standalone harness with stubbed WordPress functions, and PHPCS on the changed file drops from 53 findings to 43 with none introduced.

- [ ] CI integration suite passes
- [ ] With a `syn_log` meta entry containing `<script>alert(1)</script>` in `message`, Syndication → Logs renders it as text
- [ ] `?orderby=bogus&order=nonsense` on the logs screen sorts by time descending without warnings
- [ ] `syn_log` no longer appears in, or can be added from, the Custom Fields panel, whilst syndication logging continues to work


