### PR TITLE
Authenticate XML-RPC thumbnail methods before fetching remote URLs

### DIFF
--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -659,11 +659,21 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		$thumbnail_post_data = $args[6];
 		$thumbnail_alt_text  = $args[7];
 
+		// Authenticate before doing anything with the caller-supplied URL, otherwise
+		// an unauthenticated request can make this site fetch an arbitrary URL (SSRF).
+		if ( ! $wp_xmlrpc_server->login( $username, $password ) ) {
+			return $wp_xmlrpc_server->error;
+		}
+
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return new IXR_Error( 401, esc_html__( 'Sorry, you are not allowed to upload files.', 'push-syndication' ) );
+		}
+
 		if ( ! $post_ID ) {
 			return new IXR_Error( 500, esc_html__( 'Please specify a valid post_ID.', 'push-syndication' ) );
 		}
 
-		$thumbnail_raw = wp_remote_retrieve_body( wp_remote_get( $thumbnail_url ) );
+		$thumbnail_raw = wp_remote_retrieve_body( wp_safe_remote_get( $thumbnail_url ) );
 		if ( ! $thumbnail_raw ) {
 			return new IXR_Error( 500, esc_html__( 'Sorry, the image URL provided was incorrect.', 'push-syndication' ) );
 		}
@@ -779,7 +789,17 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		$thumbnail_post_data = $args[4];
 		$thumbnail_alt_text  = $args[5];
 
-		$thumbnail_raw = wp_remote_retrieve_body( wp_remote_get( $thumbnail_url ) );
+		// Authenticate before doing anything with the caller-supplied URL, otherwise
+		// an unauthenticated request can make this site fetch an arbitrary URL (SSRF).
+		if ( ! $wp_xmlrpc_server->login( $username, $password ) ) {
+			return $wp_xmlrpc_server->error;
+		}
+
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return new IXR_Error( 401, esc_html__( 'Sorry, you are not allowed to upload files.', 'push-syndication' ) );
+		}
+
+		$thumbnail_raw = wp_remote_retrieve_body( wp_safe_remote_get( $thumbnail_url ) );
 		if ( ! $thumbnail_raw ) {
 			return new IXR_Error( 500, esc_html__( 'Sorry, the image URL provided was incorrect.', 'push-syndication' ) );
 		}

--- a/tests/Integration/XmlrpcThumbnailAuthTest.php
+++ b/tests/Integration/XmlrpcThumbnailAuthTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests that the custom XML-RPC thumbnail methods authenticate before fetching URLs.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Class XmlrpcThumbnailAuthTest
+ *
+ * Regression guard for the unauthenticated blind SSRF in syndication.addThumbnail
+ * and syndication.postGalleryImage: both fetched the caller-supplied URL before
+ * any authentication or capability check took place.
+ *
+ * @covers Syndication_WP_XMLRPC_Client_Extensions::xmlrpc_add_thumbnail
+ * @covers Syndication_WP_XMLRPC_Client_Extensions::xmlrpc_post_gallery_images
+ */
+class XmlrpcThumbnailAuthTest extends WPIntegrationTestCase {
+
+	/**
+	 * Whether an outbound HTTP request was attempted.
+	 *
+	 * @var bool
+	 */
+	private $http_attempted = false;
+
+	/**
+	 * Set up the XML-RPC server and block (and record) outbound HTTP requests.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once ABSPATH . 'wp-includes/class-wp-xmlrpc-server.php';
+		$GLOBALS['wp_xmlrpc_server'] = new \wp_xmlrpc_server();
+
+		$this->http_attempted = false;
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				$this->http_attempted = true;
+				return new \WP_Error( 'blocked', 'Blocked in tests.' );
+			}
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		unset( $GLOBALS['wp_xmlrpc_server'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Arguments for each method, keyed by method name, with the URL in the right position.
+	 *
+	 * @param string $username Username to pass.
+	 * @param string $password Password to pass.
+	 * @return array<string, array<int, mixed>> Callable name => args.
+	 */
+	private function method_args( string $username, string $password ): array {
+		$url = 'http://169.254.169.254/latest/meta-data/';
+
+		return array(
+			'xmlrpc_add_thumbnail'       => array( 1, $username, $password, 1, $url, '_thumbnail_id', array(), '' ),
+			'xmlrpc_post_gallery_images' => array( 1, $username, $password, $url, array(), '' ),
+		);
+	}
+
+	/**
+	 * An unauthenticated caller gets an error and triggers no outbound request.
+	 */
+	public function test_unauthenticated_call_makes_no_request(): void {
+		foreach ( $this->method_args( 'nobody', 'wrong-password' ) as $method => $args ) {
+			$result = \Syndication_WP_XMLRPC_Client_Extensions::$method( $args );
+
+			$this->assertInstanceOf( \IXR_Error::class, $result, $method . ' should reject unauthenticated callers.' );
+			$this->assertFalse( $this->http_attempted, $method . ' should not fetch the URL before authenticating.' );
+		}
+	}
+
+	/**
+	 * A logged-in user without upload_files gets an error and triggers no outbound request.
+	 */
+	public function test_user_without_upload_files_makes_no_request(): void {
+		$password = 'test-password';
+		wp_set_current_user(
+			self::factory()->user->create(
+				array(
+					'role'      => 'subscriber',
+					'user_login' => 'syndication-subscriber',
+					'user_pass' => $password,
+				)
+			)
+		);
+
+		foreach ( $this->method_args( 'syndication-subscriber', $password ) as $method => $args ) {
+			$result = \Syndication_WP_XMLRPC_Client_Extensions::$method( $args );
+
+			$this->assertInstanceOf( \IXR_Error::class, $result, $method . ' should reject users without upload_files.' );
+			$this->assertFalse( $this->http_attempted, $method . ' should not fetch the URL before the capability check.' );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The `syndication.addThumbnail` and `syndication.postGalleryImage` XML-RPC methods each fetched a caller-supplied URL before performing any authentication, leaving the auth and capability checks to `mw_newMediaObject()` further down the method. Since both methods are registered unconditionally through the `xmlrpc_methods` filter, any unauthenticated visitor could POST to `xmlrpc.php` and make the site issue a GET request to an address of their choosing — internal services, cloud metadata endpoints, or arbitrary ports. The response body was never returned to the caller, so this was blind SSRF, but request-based attacks against internal endpoints still worked and the site became a usable open request proxy.

Both methods now call `$wp_xmlrpc_server->login()` and return `$wp_xmlrpc_server->error` on failure before touching the URL, matching the pattern already used by the sibling `xmlrpc_delete_thumbnail()` method. They also check the `upload_files` capability at the same point: logging in alone would still let any subscriber drive the fetch, because `mw_newMediaObject()` only applies that capability check afterwards. Both guards sit above the fetch rather than in front of the individual call sites, so there is no path left that reaches `wp_remote_get()` without an authorised user behind it.

As defence in depth the fetch now uses `wp_safe_remote_get()`, which blocks loopback and reserved ranges.

**This last part is a behaviour change worth flagging.** The thumbnail URL is built from `wp_get_attachment_image_src()` on the *source* site, so a deployment that syndicates from a host on a private address will find that posts continue to syndicate while thumbnails silently stop. Such sites will need the core `http_request_host_is_external` filter. It is also worth noting that every other outbound call in the plugin — the REST client, the XML feed client, the push-server callback, and the XML-RPC transport itself via `WP_HTTP_IXR_Client` — still uses the unsafe variants, so the thumbnail path is now the only one that restricts private hosts. Making the rest consistent is a larger change and a separate conversation.

Intended for a 2.2.1 release, with the private-host caveat called out in the release notes.

Fixes VIPPLUG-58.

## Related

VIPPLUG-60 covers a separate authorisation gap in `xmlrpc_add_thumbnail()` — it still writes post meta to any `$post_ID` without an `edit_post` check — and is deliberately not addressed here.

## Test plan

`tests/Integration/XmlrpcThumbnailAuthTest.php` covers both methods, asserting that an unauthenticated caller and a logged-in subscriber each receive an `IXR_Error` and that no outbound HTTP request is attempted in either case.

- [ ] Integration suite passes in CI. It has not been run locally: `wp-env start` currently fails to build against an expired Debian `bullseye-security` release file, unrelated to this change.
- [x] Unit suite passes locally (107 tests, 269 assertions).
- [x] `phpcs` is clean on every changed line and on the new test file.