### PR TITLE
Stop unit tests exiting non-zero when a coverage driver is installed

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,8 +23,7 @@
 		</testsuite>
 	</testsuites>
 
-	<coverage cacheDirectory=".phpunit.cache/code-coverage"
-			  processUncoveredFiles="true">
+	<coverage cacheDirectory=".phpunit.cache/code-coverage">
 		<include>
 			<file>push-syndication.php</file>
 			<directory suffix=".php">includes</directory>


### PR DESCRIPTION
## Summary

`composer test:unit` has been reporting a red run for green tests on any machine with Xdebug or PCOV installed. The 107 tests pass, then coverage generation dies with `Undefined constant "ABSPATH"` and the script exits with code 2.

The cause is `processUncoveredFiles="true"` in `phpunit.xml.dist`. It exists so that files never touched by a test still appear in the report at zero per cent, but to do that PHPUnit has to statically include every file under `includes/`. Three of them — the logger viewer, the RSS client and the XML-RPC client — call `require_once ABSPATH . ...` at the top level, and `ABSPATH` does not exist outside WordPress. The unit suite deliberately runs without WordPress, using Brain Monkey, so the include always fails.

CI has been blind to this because `shivammathur/setup-php` runs with `coverage: none`, leaving no driver installed and so no report to generate. The failure only ever appeared locally, which made it easy to mistake for a broken working copy.

Removing the attribute lets the suite finish cleanly. The trade-off is that untested files now drop out of the coverage report rather than reading as zero, which is worth accepting: those three files cannot be loaded without WordPress, so an accurate figure was never reachable from the unit suite in the first place. Integration coverage, which runs inside wp-env with WordPress loaded, is unaffected.

## Test plan

- [ ] With Xdebug or PCOV enabled, `composer test:unit` exits 0 and reports `OK (107 tests, 269 assertions)`
- [ ] Without a coverage driver, behaviour is unchanged