### PR TITLE
Enforce coding standards on the lines a pull request changes

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -48,6 +48,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Needed so the PR base commit is present for the changed-line diff below.
+          fetch-depth: 0
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
@@ -71,10 +73,41 @@ jobs:
           xml-file: ./phpunit.xml.dist
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd
 
-      # Check the code-style consistency of the PHP files.
-#      - name: Check PHP code style
-#        continue-on-error: true
-#        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+      # Check the code-style consistency of the lines this pull request changes.
+      #
+      # The plugin carries a backlog of pre-existing violations, none of them
+      # auto-fixable and some only resolvable by renaming public hooks, which is
+      # why the whole-repo PHPCS steps that used to live here sat commented out.
+      # phpcs-changed reports only violations that the change itself introduces,
+      # which holds new work to the standard without requiring the backlog be
+      # cleared first.
+      #
+      # Pinned to ^2.13 deliberately. On this repository 3.0.1 reports nothing
+      # and exits 0 whatever it is given: it batches its PHPCS calls through a
+      # temporary directory and looks results up by the absolute path it wrote,
+      # but PHPCS 3.13 keys its JSON by a path with the leading slash stripped
+      # (and symlinks resolved), so every lookup misses. Reported upstream; lift
+      # the pin once a fixed 3.x is released.
+      - name: Determine changed PHP files
+        id: changed
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- '*.php' > changed-php-files.txt
+          echo "count=$(wc -l < changed-php-files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          cat changed-php-files.txt
 
-#      - name: Show PHPCS results in PR
-#        run: cs2pr ./phpcs-report.xml
+      - name: Check PHP code style on changed lines
+        if: github.event_name == 'pull_request' && steps.changed.outputs.count != '0'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          xargs vendor/bin/phpcs-changed --git --git-base "$BASE_SHA" \
+            --report checkstyle < changed-php-files.txt > phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        if: github.event_name == 'pull_request' && steps.changed.outputs.count != '0'
+        run: cs2pr --graceful-warnings ./phpcs-report.xml

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^9",
+		"sirbrillig/phpcs-changed": "^2.13",
 		"yoast/wp-test-utils": "^1.2"
 	},
 	"config": {


### PR DESCRIPTION
## Summary

Nothing in CI has ever checked code style on this plugin. The two PHPCS steps in `cs-lint.yml` have been commented out for as long as the file has existed, so `composer cs` is a local-only gate and violations merge unnoticed.

Simply uncommenting them does not work. The plugin currently reports 511 errors and 106 warnings across 17 files. None are auto-fixable — `phpcbf` reports "No fixable errors were found" — and the largest groups are not mechanical: 107 non-snake_case variables, 74 missing docblocks, and 62 unprefixed hook names that could only be resolved by renaming public hooks and breaking anyone filtering them. Turning the check on as-is would fail every pull request on day one.

A per-file gate is not workable either. Almost every file already carries violations and the main controller alone has 158, so touching a single line of it would fail the build on debt the author did not create. That is precisely the kind of check that gets switched off again, which is plausibly how it ended up commented out to begin with.

This uses [`sirbrillig/phpcs-changed`](https://github.com/sirbrillig/phpcs-changed) to report only what a change itself introduces. It runs PHPCS over the before and after versions of each changed file and compares the two result sets, which matters: it catches violations a change *induces* on lines it did not itself touch, such as pushing a class's closing brace into an invalid position. An earlier iteration of this PR intersected PHPCS output with the diff's line ranges by hand, and missed exactly that case — the library is the more correct tool, so the hand-rolled script is gone.

Results surface as inline annotations on the diff through `cs2pr`. Warnings annotate without failing the build, so advisory VIP sniffs do not become a reason to switch the check off again.

The checkout step now uses `fetch-depth: 0`, as the comparison needs the base commit present.

## Why the version is pinned to `^2.13`

On this repository, version 3.0.1 reports nothing and exits 0 whatever it is given. For a CI gate, silently passing everything is worse than having no gate.

It batches its PHPCS calls through a temporary directory and looks the results up by the absolute path it wrote there, but PHP_CodeSniffer 3.13 keys its JSON report by a path with the leading slash stripped, and with symlinks resolved. Given `/var/folders/.../new/includes/probe.php`, PHPCS returns `private/var/folders/.../new/includes/probe.php`, so every lookup misses and each file is skipped as having no messages.

Reproduced on macOS and on Linux under `php:8.3-cli`. A from-scratch minimal reproduction did **not** trigger it, so the exact conditions are not fully pinned down — the report upstream says as much rather than overstating the diagnosis. The pin should be lifted once a fixed 3.x is released; the reasoning is recorded in a comment above the step so a future Dependabot bump is not merged blindly.

## Test plan

Verified locally against four cases, with the gate's exact CI command:

- [x] A clean addition to the 158-error main controller passes
- [x] An addition with a missing docblock, a camelCase variable and a missing text domain reports 4 errors on the offending lines
- [x] A docs-only pull request skips the check
- [x] The four merged security commits (`origin/develop~4..origin/develop`), which touch files carrying 43 existing violations, pass

Both paths were then confirmed in real CI on this branch: a temporary commit containing a deliberately violating file turned the check red with seven inline annotations, and was removed again.
