### PR TITLE
Verify TLS certificates on WordPress.com API requests

### DIFF
--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -83,7 +83,6 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			array(
 				'timeout'    => $this->timeout,
 				'user-agent' => $this->useragent,
-				'sslverify'  => false,
 				'headers'    => array(
 					'authorization' => 'Bearer ' . $this->access_token,
 				),
@@ -137,7 +136,6 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			array(
 				'timeout'    => $this->timeout,
 				'user-agent' => $this->useragent,
-				'sslverify'  => false,
 				'headers'    => array(
 					'authorization' => 'Bearer ' . $this->access_token,
 					'Content-Type'  => 'application/x-www-form-urlencoded',
@@ -194,7 +192,6 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			array(
 				'timeout'    => $this->timeout,
 				'user-agent' => $this->useragent,
-				'sslverify'  => false,
 				'headers'    => array(
 					'authorization' => 'Bearer ' . $this->access_token,
 					'Content-Type'  => 'application/x-www-form-urlencoded',
@@ -267,7 +264,6 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			array(
 				'timeout'    => $this->timeout,
 				'user-agent' => $this->useragent,
-				'sslverify'  => false,
 				'headers'    => array(
 					'authorization' => 'Bearer ' . $this->access_token,
 				),
@@ -299,7 +295,6 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			array(
 				'timeout'    => $this->timeout,
 				'user-agent' => $this->useragent,
-				'sslverify'  => false,
 				'headers'    => array(
 					'authorization' => 'Bearer ' . $this->access_token,
 				),
@@ -333,7 +328,6 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			array(
 				'timeout'    => $this->timeout,
 				'user-agent' => $this->useragent,
-				'sslverify'  => false,
 				'headers'    => array(
 					'authorization' => 'Bearer ' . $this->access_token,
 				),

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -503,8 +503,7 @@ class WP_Push_Syndication_Server {
 		$response = wp_remote_post(
 			'https://public-api.wordpress.com/oauth2/token',
 			array(
-				'sslverify' => false,
-				'body'      => array(
+				'body' => array(
 					'client_id'     => $this->push_syndicate_settings['client_id'],
 					'redirect_uri'  => $redirect_uri,
 					'client_secret' => $this->push_syndicate_settings['client_secret'],

--- a/tests/Integration/RestClientTlsVerificationTest.php
+++ b/tests/Integration/RestClientTlsVerificationTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests that the REST client never disables TLS certificate verification.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Class RestClientTlsVerificationTest
+ *
+ * Regression guard for credentialed requests to public-api.wordpress.com being
+ * sent with 'sslverify' => false. Every one of these requests carries the OAuth
+ * bearer token, so disabling verification let an on-path attacker impersonate
+ * the API, harvest the token and feed forged responses into the push pipeline.
+ *
+ * These tests assert on the arguments WP_Http has finished assembling, captured
+ * at 'pre_http_request'. That is the effective value on the wire after WP merges
+ * its defaults, so an absent 'sslverify' key correctly reads as true, and the
+ * test fails if anything reintroduces the flag or a filter turns it off.
+ *
+ * @covers Syndication_WP_REST_Client
+ */
+class RestClientTlsVerificationTest extends WPIntegrationTestCase {
+
+	/**
+	 * Arguments captured from each intercepted outbound request.
+	 *
+	 * @var array<int, array{url: string, args: array}>
+	 */
+	private $requests = array();
+
+	/**
+	 * The syndication site post the client reads its credentials from.
+	 *
+	 * @var int
+	 */
+	private $site_id;
+
+	/**
+	 * The client under test.
+	 *
+	 * @var \Syndication_WP_REST_Client
+	 */
+	private $client;
+
+	/**
+	 * Set up the client and intercept outbound HTTP before it leaves WP.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once dirname( __DIR__, 2 ) . '/includes/class-syndication-wp-rest-client.php';
+
+		$this->requests = array();
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) {
+				$this->requests[] = array(
+					'url'  => $url,
+					'args' => $parsed_args,
+				);
+
+				// Short-circuit with a 200 so no request leaves the test runner. The body
+				// carries an ID because new_post() reads $response->ID off a success.
+				return array(
+					'headers'  => array(),
+					'body'     => wp_json_encode( array( 'ID' => 999 ) ),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
+
+		$this->site_id = self::factory()->post->create( array( 'post_type' => 'syn_site' ) );
+		update_post_meta( $this->site_id, 'syn_site_id', '12345' );
+		update_post_meta( $this->site_id, 'syn_site_token', push_syndicate_encrypt( 'test-token' ) );
+
+		$this->client = new \Syndication_WP_REST_Client( $this->site_id );
+	}
+
+	/**
+	 * Every public method that reaches the WordPress.com REST API.
+	 *
+	 * @return array<string, array{0: callable}> Test cases keyed by method name.
+	 */
+	public function data_api_methods(): array {
+		return array(
+			'is_source_site_post' => array(
+				function ( $client, $post_id ) {
+					return $client->is_source_site_post( 'syn_source_url', 'https://example.com/' );
+				},
+			),
+			'new_post'            => array(
+				function ( $client, $post_id ) {
+					return $client->new_post( $post_id );
+				},
+			),
+			'edit_post'           => array(
+				function ( $client, $post_id ) {
+					return $client->edit_post( $post_id, 999 );
+				},
+			),
+			'delete_post'         => array(
+				function ( $client, $post_id ) {
+					return $client->delete_post( 999 );
+				},
+			),
+			'test_connection'     => array(
+				function ( $client, $post_id ) {
+					return $client->test_connection();
+				},
+			),
+			'is_post_exists'      => array(
+				function ( $client, $post_id ) {
+					return $client->is_post_exists( 999 );
+				},
+			),
+		);
+	}
+
+	/**
+	 * Each API method must send its request with certificate verification enabled.
+	 *
+	 * @dataProvider data_api_methods
+	 *
+	 * @param callable $invoke Invokes the method under test.
+	 */
+	public function test_request_verifies_the_certificate( callable $invoke ): void {
+		$post_id = self::factory()->post->create();
+
+		$invoke( $this->client, $post_id );
+
+		$this->assertNotEmpty( $this->requests, 'Expected the method to make an outbound request.' );
+
+		foreach ( $this->requests as $request ) {
+			$this->assertNotFalse(
+				$request['args']['sslverify'],
+				sprintf(
+					'Request to %s was sent with certificate verification disabled, exposing the bearer token to on-path attackers.',
+					$request['url']
+				)
+			);
+		}
+	}
+
+	/**
+	 * The requests carry credentials, which is why verification matters here.
+	 *
+	 * @dataProvider data_api_methods
+	 *
+	 * @param callable $invoke Invokes the method under test.
+	 */
+	public function test_request_is_credentialed_and_uses_https( callable $invoke ): void {
+		$post_id = self::factory()->post->create();
+
+		$invoke( $this->client, $post_id );
+
+		foreach ( $this->requests as $request ) {
+			$this->assertStringStartsWith( 'https://', $request['url'] );
+			$this->assertSame(
+				'Bearer test-token',
+				$request['args']['headers']['authorization'],
+				'Request should carry the OAuth bearer token.'
+			);
+		}
+	}
+
+	/**
+	 * Guard against the interception above silently passing on an unverified default.
+	 *
+	 * If WP ever stopped defaulting sslverify to true, the assertions above would
+	 * still pass while real requests went unverified. This pins the default.
+	 */
+	public function test_wp_defaults_ssl_verification_to_true(): void {
+		wp_remote_get( 'https://public-api.wordpress.com/rest/v1/me/' );
+
+		$this->assertTrue(
+			$this->requests[0]['args']['sslverify'],
+			'WP_Http should default sslverify to true when the argument is omitted.'
+		);
+	}
+}

--- a/tests/Unit/RestClientIsSourceSitePostTest.php
+++ b/tests/Unit/RestClientIsSourceSitePostTest.php
@@ -115,7 +115,6 @@ class RestClientIsSourceSitePostTest extends TestCase {
 					array(
 						'timeout'    => $this->timeout,
 						'user-agent' => $this->useragent,
-						'sslverify'  => false,
 						'headers'    => array(
 							'authorization' => 'Bearer ' . $this->access_token,
 						),


### PR DESCRIPTION
## Summary

Every request the REST client made to `public-api.wordpress.com` was sent with `'sslverify' => false`, and so was the OAuth token exchange in `get_api_token()`. That covers all six client methods plus the one request that posts the `client_id`, `client_secret` and authorisation code. Each of these carries credentials, so an on-path attacker on a compromised network or behind a rogue proxy could present any certificate at all, harvest the bearer token and client secret, and feed forged API responses back into the push pipeline.

The fix is to remove the argument and let the WP HTTP API default of `true` apply.

The obvious question is whether the flag was load-bearing — plenty of plugins carry one because someone once hit a certificate problem and never revisited it. It is not. I checked against the live API from a WordPress install using WordPress's own bundled CA, and all seven endpoints respond normally with verification enabled: the two `GET`s return 200 and 404, `/me/` returns 403 unauthenticated, and the `POST`s return their usual 400s and 404s. The certificate itself verifies cleanly (`Verify return code: 0`, TLS 1.3, Let's Encrypt, SAN `*.wordpress.com`). Nothing about this API needs verification off.

The same check run against `badssl.com` shows what the flag was actually buying: with default arguments WordPress rejects expired, self-signed, wrong-host and untrusted-root certificates, and with `sslverify => false` it accepts a self-signed certificate with a 200. That was the only thing standing between the bearer token and anyone able to intercept the connection.

`tests/Integration/RestClientTlsVerificationTest.php` guards the regression. It drives the real client through all six methods and asserts on the arguments `WP_Http` has finished assembling, captured at `pre_http_request`, which is the pattern already used in `XmlrpcThumbnailAuthTest`. Asserting on the effective value on the wire rather than on the source means an absent `sslverify` correctly reads as `true`, and a filter switching it off fails the test just as a hardcoded `false` would. A further test pins WP's default to `true` so the interception cannot quietly pass on a changed default. Nothing here touches the network, so it will not flake in CI.

One incidental change: the unit test double in `RestClientIsSourceSitePostTest` describes itself as an exact copy of `is_source_site_post()`, so it had to drop the argument too. Worth noting that a test file faithfully mirroring the flag is part of why this sat unnoticed — copying the method wholesale means the test can only ever agree with the code.

This is filed alongside [VIPPLUG-61](https://linear.app/a8c/issue/VIPPLUG-61) on credential encryption, though the two are independent rather than one supporting the other: encryption protects credentials at rest in the database, TLS protects them in transit. The token exchange leak here would have been a problem even with flawless at-rest encryption.

Fixes [VIPPLUG-62](https://linear.app/a8c/issue/VIPPLUG-62/syndication-tls-verification-disabled-sslverify-false-on-credentialed).

## Test plan

- [ ] `composer test:unit` — 107 pass
- [ ] `wp-env run tests-cli --env-cwd=wp-content/plugins/<dir> ./vendor/bin/phpunit --testsuite integration` — 42 pass, 5 skipped (pre-existing, mcrypt unavailable)
- [ ] Reintroduce `'sslverify' => false` in the REST client and confirm all six data sets of `test_request_verifies_the_certificate` fail, naming the offending URL
- [ ] With real WordPress.com credentials configured, confirm a push still syndicates