### PR TITLE
Run the full test suite against pull requests into 3.x

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -22,13 +22,14 @@ jobs:
   checkcs:
     name: "Basic CS and QA checks"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     env:
       XMLLINT_INDENT: "	"
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "latest"
           coverage: none
@@ -42,10 +43,10 @@ jobs:
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register XML violations to appear as file diff comments
-        uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
+        uses: korelstar/xmllint-problem-matcher@dd2ad21bd8a2de0187cb621419537f345e7e509c # v1.3.0
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -57,7 +58,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       # Lint PHP.
       - name: Lint PHP against parse errors

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - develop
       - main
+      - 3.x
     paths:
       - '**.php'
       - 'composer.json'
-      - 'composer.lock'
       - 'phpunit.xml.dist'
       - '.wp-env.json'
       - '.github/workflows/integration.yml'
@@ -16,10 +16,10 @@ on:
     branches:
       - develop
       - main
+      - 3.x
     paths:
       - '**.php'
       - 'composer.json'
-      - 'composer.lock'
       - 'phpunit.xml.dist'
       - '.wp-env.json'
       - '.github/workflows/integration.yml'
@@ -37,29 +37,33 @@ jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       matrix:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.4'
-            php: '7.4'
-          # Check latest WP with the latest PHP.
+            php: '8.2'
+          # Check latest WP with the highest supported PHP.
           - wordpress: 'master'
-            php: 'latest'
+            php: '8.5'
       fail-fast: false
 
     env:
       WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
+      # Without this, both legs would run against the phpVersion pinned in
+      # .wp-env.json and the matrix would only vary the PHP used on the host.
+      WP_ENV_PHP_VERSION: ${{ matrix.php }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
@@ -71,10 +75,10 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - develop
-      - trunk
+      - main
+      - 3.x
     paths:
       - '**.php'
       - 'composer.json'
@@ -35,25 +36,25 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.1'
+          # Lowest and highest supported versions. The versions in between are
+          # covered transitively: syntax accepted by both ends works throughout.
           - '8.2'
-          - '8.3'
+          - '8.5'
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
   "plugins": [
     "."
   ],
-  "phpVersion": "7.4",
+  "phpVersion": "8.2",
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,
@@ -13,7 +13,6 @@
   },
   "env": {
     "tests": {
-      "phpVersion": "8.4",
       "core": "WordPress/WordPress#trunk"
     }
   }

--- a/tests/Unit/EventCounterTest.php
+++ b/tests/Unit/EventCounterTest.php
@@ -46,7 +46,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_has_correct_prefix(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->counter, 'test_event', '123' );
 
@@ -58,7 +57,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_is_consistent(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result1 = $method->invoke( $this->counter, 'test_event', '123' );
 		$result2 = $method->invoke( $this->counter, 'test_event', '123' );
@@ -71,7 +69,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_different_slugs(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result1 = $method->invoke( $this->counter, 'event_a', '123' );
 		$result2 = $method->invoke( $this->counter, 'event_b', '123' );
@@ -84,7 +81,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_different_object_ids(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result1 = $method->invoke( $this->counter, 'test_event', '123' );
 		$result2 = $method->invoke( $this->counter, 'test_event', '456' );
@@ -97,7 +93,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_max_length(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		// Test with very long slug and ID.
 		$long_slug = str_repeat( 'very_long_event_slug_', 10 );
@@ -113,7 +108,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_uses_md5(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result   = $method->invoke( $this->counter, 'test', '123' );
 		$expected = 'push_syndication_event_counter_' . md5( 'test123' );
@@ -126,7 +120,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_empty_slug(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result   = $method->invoke( $this->counter, '', '123' );
 		$expected = 'push_syndication_event_counter_' . md5( '123' );
@@ -139,7 +132,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_empty_object_id(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		$result   = $method->invoke( $this->counter, 'test_event', '' );
 		$expected = 'push_syndication_event_counter_' . md5( 'test_event' );
@@ -152,7 +144,6 @@ class EventCounterTest extends TestCase {
 	 */
 	public function test_get_safe_option_name_numeric_id(): void {
 		$method = new ReflectionMethod( \Syndication_Event_Counter::class, '_get_safe_option_name' );
-		$method->setAccessible( true );
 
 		// The method converts to string internally.
 		$result   = $method->invoke( $this->counter, 'pull_failure', 42 );


### PR DESCRIPTION
## Summary

The 3.x rewrite has been assembled without a single integration test run. The integration workflow only fires for pull requests into `develop` and `main`, so every green tick on a 3.x pull request has meant linting and unit tests alone. PR #197 adds 22 CLI integration tests that, as things stand, would never execute in CI. Adding `3.x` to the branch filters closes that gap. The unit workflow already ran for all pull requests, but its push filter named a `trunk` branch that does not exist in this repository, so direct pushes to 3.x went unchecked there too.

The integration matrix also promised more than it delivered. Its two legs were labelled as lowest and latest PHP, yet they differed only in the version installed on the runner: the tests themselves always executed inside wp-env against whatever `.wp-env.json` pinned. Passing `WP_ENV_PHP_VERSION` through makes the advertised pairing real. Those pinned versions now start at the 8.2 that the plugin header has required since the rewrite began, rather than the 7.4 that no file under `includes/Application`, `includes/Domain` or `includes/Infrastructure` can even parse.

On version coverage, testing every minor release between the bounds buys little when syntax accepted at both ends works throughout, so the matrix now runs 8.2 and 8.5 only. Reaching 8.5 needed one code change: `ReflectionMethod::setAccessible()` has had no effect since PHP 8.1 and is deprecated in 8.5, and PHPUnit turns that deprecation into an error, which failed nine `EventCounter` tests. The calls were already redundant at 8.2, so they are simply gone.

The remainder is housekeeping noticed on the way through. Action pins are brought level with `develop`, which Dependabot has been updating while 3.x quietly fell behind by a major version on `actions/checkout`, `actions/setup-node` and `ramsey/composer-install`. Job timeouts are added where they were missing, and a path filter watching the gitignored `composer.lock` is removed, since it could never have triggered anything.

## Notes for reviewers

Two things deliberately left alone:

- The commented-out PHPCS steps in `cs-lint.yml` remain commented out. PR #214 already solves this for `develop` with a changed-lines gate, and duplicating an in-review implementation here would only create divergence. 3.x carries 513 errors and 106 warnings across 18 files, almost all of it in the legacy classes the rewrite has yet to replace, so it needs the same treatment; cherry-picking that commit once #214 lands is the cleaner route.
- Dependabot only reads `.github/dependabot.yml` from the default branch, which is why 3.x drifted in the first place. Keeping it current needs `target-branch: "3.x"` entries added on `develop`, not here.

## Test plan

- [x] `parallel-lint` clean and the unit suite green on PHP 8.2 and 8.5, both verified in Docker
- [x] `actionlint` reports no issues across all three workflows
- [ ] Integration legs pass in CI, which this pull request is itself the first to exercise