### PR TITLE
Reject XML feeds that declare a doctype

### DIFF
--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -259,7 +259,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		libxml_use_internal_errors( true );
 
 		/** @var SimpleXMLElement $xml */
-		$xml = simplexml_load_string( $feed, null, 0, $namespace, false );
+		$xml = simplexml_load_string( $feed, null, LIBXML_NONET, $namespace, false );
 
 		if ( false === $xml ) {
 			$xml_errors = '';
@@ -986,6 +986,15 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			return new WP_Error( 'syndication-fetch-failure', 'Failed to fetch XML Feed; HTTP code: ' . wp_remote_retrieve_response_code( $request ) );
 		}
 
-		return wp_remote_retrieve_body( $request );
+		$body = wp_remote_retrieve_body( $request );
+
+		// Reject any feed carrying a doctype. No syndication feed needs one, and on
+		// older libxml builds an external entity declaration is resolved at parse
+		// time, turning a MITM'd http:// feed into local file disclosure or SSRF.
+		if ( preg_match( '/<!\s*(DOCTYPE|ENTITY)/i', $body ) ) {
+			return new WP_Error( 'syndication-fetch-failure', 'Refused XML feed: it declares a document type.' );
+		}
+
+		return $body;
 	}
 }

--- a/tests/Integration/XmlClientDoctypeRejectionTest.php
+++ b/tests/Integration/XmlClientDoctypeRejectionTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests that the XML client refuses feeds carrying a document type declaration.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Class XmlClientDoctypeRejectionTest
+ *
+ * Feed bodies are remote and the feed URL field accepts plain http://, so an
+ * on-path attacker can choose the bytes that reach the parser. On libxml builds
+ * that still resolve external entities that means local file disclosure or SSRF,
+ * so fetch_feed() refuses a body declaring a doctype rather than trusting the
+ * library's defaults. Rejecting at the fetch covers test_connection() too, which
+ * means a feed the plugin will refuse to pull reports as broken when it is
+ * configured rather than silently at pull time.
+ *
+ * @covers Syndication_WP_XML_Client
+ */
+class XmlClientDoctypeRejectionTest extends WPIntegrationTestCase {
+
+	/**
+	 * The body returned to the client in place of a real HTTP response.
+	 *
+	 * @var string
+	 */
+	private $feed_body = '';
+
+	/**
+	 * Set up a configured site and intercept the feed fetch.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once dirname( __DIR__, 2 ) . '/includes/class-syndication-wp-xml-client.php';
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'headers'  => array(),
+					'body'     => $this->feed_body,
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			}
+		);
+	}
+
+	/**
+	 * Build a client pointed at an http:// feed with a minimal node config.
+	 *
+	 * @return \Syndication_WP_XML_Client
+	 */
+	private function make_client() {
+		$site_id = self::factory()->post->create( array( 'post_type' => 'syn_site' ) );
+
+		update_post_meta( $site_id, 'syn_feed_url', 'http://example.com/feed.xml' );
+		update_post_meta(
+			$site_id,
+			'syn_node_config',
+			array(
+				'namespace'  => '',
+				'post_root'  => '/rss/channel/item',
+				'enc_parent' => '',
+				'categories' => array(),
+				'nodes'      => array(
+					'title' => array(
+						array(
+							'field'    => 'post_title',
+							'is_item'  => 1,
+							'is_meta'  => 0,
+							'is_tax'   => 0,
+							'is_photo' => 0,
+						),
+					),
+				),
+			)
+		);
+
+		return new \Syndication_WP_XML_Client( $site_id );
+	}
+
+	/**
+	 * Feeds declaring a doctype, external entity or not.
+	 *
+	 * @return array<string, array{0: string}> Test cases keyed by feed shape.
+	 */
+	public function data_doctype_feeds(): array {
+		return array(
+			'external entity'    => array(
+				'<?xml version="1.0"?><!DOCTYPE rss [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+					. '<rss><channel><item><title>&xxe;</title></item></channel></rss>',
+			),
+			'network entity'     => array(
+				'<?xml version="1.0"?><!DOCTYPE rss [<!ENTITY xxe SYSTEM "http://169.254.169.254/">]>'
+					. '<rss><channel><item><title>&xxe;</title></item></channel></rss>',
+			),
+			'whitespace padding' => array(
+				'<?xml version="1.0"?><! DOCTYPE rss SYSTEM "http://example.com/evil.dtd">'
+					. '<rss><channel><item><title>Hello</title></item></channel></rss>',
+			),
+			'harmless doctype'   => array(
+				'<?xml version="1.0"?><!DOCTYPE rss><rss><channel><item><title>Hello</title></item></channel></rss>',
+			),
+		);
+	}
+
+	/**
+	 * A feed with a doctype is never handed to the parser.
+	 *
+	 * @dataProvider data_doctype_feeds
+	 *
+	 * @param string $feed The feed body served to the client.
+	 */
+	public function test_feed_with_a_doctype_is_rejected( string $feed ): void {
+		$this->feed_body = $feed;
+
+		$this->assertSame(
+			array(),
+			$this->make_client()->get_posts(),
+			'A feed declaring a doctype should yield no posts.'
+		);
+	}
+
+	/**
+	 * Rejecting at the fetch means a doctype feed also fails its connection test.
+	 *
+	 * @dataProvider data_doctype_feeds
+	 *
+	 * @param string $feed The feed body served to the client.
+	 */
+	public function test_feed_with_a_doctype_fails_the_connection_test( string $feed ): void {
+		$this->feed_body = $feed;
+
+		$this->assertFalse(
+			$this->make_client()->test_connection(),
+			'A feed declaring a doctype should not report a working connection.'
+		);
+	}
+
+	/**
+	 * A feed without a doctype still parses, so the guard is not just rejecting everything.
+	 */
+	public function test_feed_without_a_doctype_still_parses(): void {
+		$this->feed_body = '<?xml version="1.0"?><rss><channel><item><title>Hello</title></item></channel></rss>';
+
+		$posts = $this->make_client()->get_posts();
+
+		$this->assertCount( 1, $posts );
+		$this->assertSame( 'Hello', $posts[0]['post_title'] );
+		$this->assertTrue( $this->make_client()->test_connection() );
+	}
+}


### PR DESCRIPTION
## Summary

`Syndication_WP_XML_Client::get_posts()` parsed fetched feed bodies with `simplexml_load_string( $feed, null, 0, ... )` — no options set at all. Feed bodies are remote, and the feed URL field accepts plain `http://`, so an on-path attacker gets to choose the bytes that reach the parser even when the configured publisher is trusted.

In practice modern stacks are safe: libxml has defaulted external entity resolution off since 2.9, and this plugin runs on PHP 8.4 in CI. The reason to close it anyway is that the plugin header declares `Requires PHP: 7.4`, and on a 7.4 environment with an older libxml build a crafted external entity becomes local file disclosure or SSRF. Rather than rely on a library default staying where it is, the parse call now passes `LIBXML_NONET`, and `fetch_feed()` refuses any body that declares a doctype.

The refusal sits at the fetch rather than immediately before the parse, which covers both callers of `fetch_feed()`. The practical effect is that `test_connection()` now reports a feed the plugin would refuse to pull as broken at the point it is configured, rather than leaving it to fail silently at pull time. It also means the rejection reuses the existing `WP_Error` handling and its `pull_failure` logging instead of restating it.

One behaviour change worth a reviewer's attention: rejecting all doctypes is slightly broader than rejecting entity declarations. A feed that uses a doctype purely to declare character entities will now be refused rather than parsed. Such feeds are rare and the refusal is logged rather than silent, but it is a real trade and easy to narrow to `<!ENTITY` if any publisher turns out to need it.

The accompanying test drives the real client through an intercepted feed fetch, covering file and network external entities, a whitespace-padded declaration, and a bare doctype — the point being that none of them reach the parser. Every case is asserted through both `get_posts()` and `test_connection()`, so moving the guard back down to the parse would be caught. A clean feed must still parse into a post and report a working connection, so the guard cannot pass by rejecting everything.

Rebased onto `develop` to pick up the `phpcs-changed` job from #214, which this branch now passes.

Fixes VIPPLUG-64.

## Test plan

- [ ] `composer test:integration` passes (51 tests, 5 pre-existing skips for the missing mcrypt extension)
- [ ] `XmlClientDoctypeRejectionTest` fails if the doctype guard is removed
