### PR TITLE
Authorise site settings saves on their own nonce

### DIFF
--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -47,7 +47,7 @@ class WP_Push_Syndication_Server {
 
 		// syndicating content.
 		add_action( 'add_meta_boxes', array( $this, 'add_post_metaboxes' ) );
-		add_action( 'transition_post_status', array( $this, 'save_syndicate_settings' ) ); // Use transition_post_status instead of save_post because the former is fired earlier which causes race conditions when a site group select and publish happen on the same load.
+		add_action( 'transition_post_status', array( $this, 'save_syndicate_settings' ), 10, 3 ); // Use transition_post_status instead of save_post because the former is fired earlier which causes race conditions when a site group select and publish happen on the same load.
 		add_action( 'wp_trash_post', array( $this, 'delete_content' ) );
 
 		// adding custom time interval.
@@ -723,11 +723,10 @@ class WP_Push_Syndication_Server {
 	/**
 	 * Persist the site settings metabox on a syn_site save.
 	 *
+	 * @param int $post_id ID of the post being saved.
 	 * @return void
 	 */
-	public function save_site_settings() {
-
-		global $post;
+	public function save_site_settings( $post_id ) {
 
 		// autosave verification.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
@@ -740,7 +739,7 @@ class WP_Push_Syndication_Server {
 		}
 
 		// Site settings only ever belong to a site, and only to a user who can syndicate.
-		if ( empty( $post->ID ) || 'syn_site' !== get_post_type( $post ) || ! $this->current_user_can_syndicate() ) {
+		if ( 'syn_site' !== get_post_type( $post_id ) || ! $this->current_user_can_syndicate() ) {
 			return;
 		}
 
@@ -751,16 +750,16 @@ class WP_Push_Syndication_Server {
 			return;
 		}
 
-		update_post_meta( $post->ID, 'syn_transport_type', $transport_type );
+		update_post_meta( $post_id, 'syn_transport_type', $transport_type );
 
 		$site_enabled = isset( $_POST['site_enabled'] ) ? sanitize_text_field( wp_unslash( $_POST['site_enabled'] ) ) : 'off';
 
 		try {
-			$save = Syndication_Client_Factory::save_client_settings( $post->ID, $transport_type );
+			$save = Syndication_Client_Factory::save_client_settings( $post_id, $transport_type );
 			if ( ! $save ) {
 				return;
 			}
-			$client = Syndication_Client_Factory::get_client( $transport_type, $post->ID );
+			$client = Syndication_Client_Factory::get_client( $transport_type, $post_id );
 
 			if ( $client->test_connection() ) {
 				add_filter(
@@ -787,7 +786,7 @@ class WP_Push_Syndication_Server {
 			);
 		}
 
-		update_post_meta( $post->ID, 'syn_site_enabled', $site_enabled );
+		update_post_meta( $post_id, 'syn_site_enabled', $site_enabled );
 	}
 
 	public function push_syndicate_admin_messages( $messages ) {
@@ -901,9 +900,15 @@ class WP_Push_Syndication_Server {
 		}
 	}
 
-	public function save_syndicate_settings() {
-
-		global $post;
+	/**
+	 * Persist the syndicate metabox when a post changes status.
+	 *
+	 * @param string   $new_status New post status.
+	 * @param string   $old_status Old post status.
+	 * @param \WP_Post $post       Post being saved.
+	 * @return void
+	 */
+	public function save_syndicate_settings( $new_status, $old_status, $post ) {
 
 		// autosave verification.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
@@ -911,7 +916,7 @@ class WP_Push_Syndication_Server {
 		}
 
 		// if our nonce isn't there, or we can't verify it return.
-		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
+		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['syndicate_noncename'] ) ), plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 
@@ -939,7 +944,7 @@ class WP_Push_Syndication_Server {
 		}
 
 		// if our nonce isn't there, or we can't verify it return.
-		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
+		if ( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['syndicate_noncename'] ) ), plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -686,8 +686,9 @@ class WP_Push_Syndication_Server {
 		$transport_mode = ! empty( $transport_mode ) ? $transport_mode : 'pull';
 		$site_enabled   = ! empty( $site_enabled ) ? $site_enabled : 'off';
 
-		// nonce for verification when saving.
-		wp_nonce_field( plugin_basename( __FILE__ ), 'site_settings_noncename' );
+		// nonce for verification when saving. Distinct from the syndicate metabox nonce so that
+		// a nonce for one save path is not valid for the other.
+		wp_nonce_field( 'syn_save_site_settings', 'site_settings_noncename' );
 
 		$this->display_transports( $transport_type, $transport_mode );
 
@@ -719,6 +720,11 @@ class WP_Push_Syndication_Server {
 		echo '</select>';
 	}
 
+	/**
+	 * Persist the site settings metabox on a syn_site save.
+	 *
+	 * @return void
+	 */
 	public function save_site_settings() {
 
 		global $post;
@@ -729,16 +735,25 @@ class WP_Push_Syndication_Server {
 		}
 
 		// if our nonce isn't there, or we can't verify it return.
-		if ( ! isset( $_POST['site_settings_noncename'] ) || ! wp_verify_nonce( $_POST['site_settings_noncename'], plugin_basename( __FILE__ ) ) ) {
+		if ( ! isset( $_POST['site_settings_noncename'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['site_settings_noncename'] ) ), 'syn_save_site_settings' ) ) {
 			return;
 		}
 
-		$transport_type = sanitize_text_field( $_POST['transport_type'] ); // TODO: validate this exists.
+		// Site settings only ever belong to a site, and only to a user who can syndicate.
+		if ( empty( $post->ID ) || 'syn_site' !== get_post_type( $post ) || ! $this->current_user_can_syndicate() ) {
+			return;
+		}
 
-		// @TODO validate that type and mode are valid.
+		$transport_type = isset( $_POST['transport_type'] ) ? sanitize_text_field( wp_unslash( $_POST['transport_type'] ) ) : '';
+
+		// Only registered transports may be persisted; the value ends up in a class name.
+		if ( ! isset( $this->push_syndicate_transports[ $transport_type ] ) ) {
+			return;
+		}
+
 		update_post_meta( $post->ID, 'syn_transport_type', $transport_type );
 
-		$site_enabled = sanitize_text_field( $_POST['site_enabled'] );
+		$site_enabled = isset( $_POST['site_enabled'] ) ? sanitize_text_field( wp_unslash( $_POST['site_enabled'] ) ) : 'off';
 
 		try {
 			$save = Syndication_Client_Factory::save_client_settings( $post->ID, $transport_type );

--- a/tests/Integration/SaveSiteSettingsAuthTest.php
+++ b/tests/Integration/SaveSiteSettingsAuthTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests that save_site_settings() only ever writes for an authorised site save.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Class SaveSiteSettingsAuthTest
+ *
+ * Regression guard: save_site_settings() is hooked to save_post for every post type
+ * and used to gate only on a nonce whose action was shared with the syndicate metabox,
+ * so anyone able to see that metabox held a nonce valid for this save path.
+ *
+ * @covers WP_Push_Syndication_Server::save_site_settings
+ */
+class SaveSiteSettingsAuthTest extends WPIntegrationTestCase {
+
+	/**
+	 * Set up a site post, a registered transport, and admin-authored POST data.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $push_syndication_server, $post;
+
+		$push_syndication_server->push_syndicate_transports = array(
+			'Mock' => array(
+				'name'  => 'Mock',
+				'modes' => array( 'pull' ),
+			),
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$post = get_post(
+			self::factory()->post->create(
+				array(
+					'post_type'   => 'syn_site',
+					'post_status' => 'publish',
+				)
+			)
+		);
+
+		$_POST = array(
+			'site_settings_noncename' => wp_create_nonce( 'syn_save_site_settings' ),
+			'transport_type'          => 'Mock',
+			'site_enabled'            => 'on',
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		$_POST = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * A valid site save still writes the settings.
+	 */
+	public function test_authorised_site_save_writes_settings(): void {
+		global $push_syndication_server, $post;
+
+		$push_syndication_server->save_site_settings();
+
+		$this->assertSame( 'Mock', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+	}
+
+	/**
+	 * The syndicate metabox nonce is not valid for the site settings save path.
+	 */
+	public function test_syndicate_metabox_nonce_is_rejected(): void {
+		global $push_syndication_server, $post;
+
+		$server_file = ( new \ReflectionClass( $push_syndication_server ) )->getFileName();
+
+		$_POST['site_settings_noncename'] = wp_create_nonce( plugin_basename( $server_file ) );
+
+		$push_syndication_server->save_site_settings();
+
+		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+	}
+
+	/**
+	 * A user without the syndication capability cannot write site settings.
+	 */
+	public function test_user_without_capability_cannot_write(): void {
+		global $push_syndication_server, $post;
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$push_syndication_server->save_site_settings();
+
+		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+	}
+
+	/**
+	 * Saving an ordinary post never writes site settings, even with a valid nonce.
+	 */
+	public function test_other_post_types_are_ignored(): void {
+		global $push_syndication_server, $post;
+
+		$post = get_post( self::factory()->post->create() );
+
+		$push_syndication_server->save_site_settings();
+
+		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+	}
+
+	/**
+	 * An unregistered transport type is never persisted.
+	 */
+	public function test_unregistered_transport_is_rejected(): void {
+		global $push_syndication_server, $post;
+
+		$_POST['transport_type'] = 'Evil';
+
+		$push_syndication_server->save_site_settings();
+
+		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+	}
+}

--- a/tests/Integration/SaveSiteSettingsAuthTest.php
+++ b/tests/Integration/SaveSiteSettingsAuthTest.php
@@ -21,12 +21,19 @@ use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
 class SaveSiteSettingsAuthTest extends WPIntegrationTestCase {
 
 	/**
+	 * ID of the syn_site post under test.
+	 *
+	 * @var int
+	 */
+	private $site_id;
+
+	/**
 	 * Set up a site post, a registered transport, and admin-authored POST data.
 	 */
 	public function set_up(): void {
 		parent::set_up();
 
-		global $push_syndication_server, $post;
+		global $push_syndication_server;
 
 		$push_syndication_server->push_syndicate_transports = array(
 			'Mock' => array(
@@ -37,12 +44,10 @@ class SaveSiteSettingsAuthTest extends WPIntegrationTestCase {
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
-		$post = get_post(
-			self::factory()->post->create(
-				array(
-					'post_type'   => 'syn_site',
-					'post_status' => 'publish',
-				)
+		$this->site_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'syn_site',
+				'post_status' => 'publish',
 			)
 		);
 
@@ -65,64 +70,89 @@ class SaveSiteSettingsAuthTest extends WPIntegrationTestCase {
 	 * A valid site save still writes the settings.
 	 */
 	public function test_authorised_site_save_writes_settings(): void {
-		global $push_syndication_server, $post;
+		global $push_syndication_server;
 
-		$push_syndication_server->save_site_settings();
+		$push_syndication_server->save_site_settings( $this->site_id );
 
-		$this->assertSame( 'Mock', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+		$this->assertSame( 'Mock', get_post_meta( $this->site_id, 'syn_transport_type', true ) );
 	}
 
 	/**
 	 * The syndicate metabox nonce is not valid for the site settings save path.
 	 */
 	public function test_syndicate_metabox_nonce_is_rejected(): void {
-		global $push_syndication_server, $post;
+		global $push_syndication_server;
 
 		$server_file = ( new \ReflectionClass( $push_syndication_server ) )->getFileName();
 
 		$_POST['site_settings_noncename'] = wp_create_nonce( plugin_basename( $server_file ) );
 
-		$push_syndication_server->save_site_settings();
+		$push_syndication_server->save_site_settings( $this->site_id );
 
-		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+		$this->assertSame( '', get_post_meta( $this->site_id, 'syn_transport_type', true ) );
 	}
 
 	/**
 	 * A user without the syndication capability cannot write site settings.
 	 */
 	public function test_user_without_capability_cannot_write(): void {
-		global $push_syndication_server, $post;
+		global $push_syndication_server;
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 
-		$push_syndication_server->save_site_settings();
+		$push_syndication_server->save_site_settings( $this->site_id );
 
-		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+		$this->assertSame( '', get_post_meta( $this->site_id, 'syn_transport_type', true ) );
 	}
 
 	/**
 	 * Saving an ordinary post never writes site settings, even with a valid nonce.
 	 */
 	public function test_other_post_types_are_ignored(): void {
-		global $push_syndication_server, $post;
+		global $push_syndication_server;
 
-		$post = get_post( self::factory()->post->create() );
+		$post_id = self::factory()->post->create();
 
-		$push_syndication_server->save_site_settings();
+		$push_syndication_server->save_site_settings( $post_id );
 
-		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+		$this->assertSame( '', get_post_meta( $post_id, 'syn_transport_type', true ) );
 	}
 
 	/**
 	 * An unregistered transport type is never persisted.
 	 */
 	public function test_unregistered_transport_is_rejected(): void {
-		global $push_syndication_server, $post;
+		global $push_syndication_server;
 
 		$_POST['transport_type'] = 'Evil';
 
-		$push_syndication_server->save_site_settings();
+		$push_syndication_server->save_site_settings( $this->site_id );
 
-		$this->assertSame( '', get_post_meta( $post->ID, 'syn_transport_type', true ) );
+		$this->assertSame( '', get_post_meta( $this->site_id, 'syn_transport_type', true ) );
+	}
+
+	/**
+	 * The save writes to the post it is given, not to whatever global $post holds.
+	 */
+	public function test_save_ignores_the_global_post(): void {
+		global $push_syndication_server, $post;
+
+		// Created with no POST data, or the live save_post hook would write to it too.
+		$posted        = $_POST;
+		$_POST         = array();
+		$other_site_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'syn_site',
+				'post_status' => 'publish',
+			)
+		);
+		$_POST         = $posted;
+
+		$post = get_post( $other_site_id );
+
+		$push_syndication_server->save_site_settings( $this->site_id );
+
+		$this->assertSame( 'Mock', get_post_meta( $this->site_id, 'syn_transport_type', true ) );
+		$this->assertSame( '', get_post_meta( $other_site_id, 'syn_transport_type', true ) );
 	}
 }

--- a/tests/Integration/SaveSyndicateSettingsTest.php
+++ b/tests/Integration/SaveSyndicateSettingsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests that save_syndicate_settings() writes to the post it is handed.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Class SaveSyndicateSettingsTest
+ *
+ * Regression guard: the callback used to ignore the post that transition_post_status
+ * hands it and read global $post instead, which is only the post being saved because
+ * wp-admin/post.php happens to set it before calling edit_post().
+ *
+ * @covers WP_Push_Syndication_Server::save_syndicate_settings
+ */
+class SaveSyndicateSettingsTest extends WPIntegrationTestCase {
+
+	/**
+	 * Set up an administrator.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Populate the POST data the syndicate metabox submits.
+	 *
+	 * Called after the fixtures exist: with this data in place, creating a post fires
+	 * the very hook under test.
+	 *
+	 * @return void
+	 */
+	private function post_syndicate_metabox(): void {
+		global $push_syndication_server;
+
+		$server_file = ( new \ReflectionClass( $push_syndication_server ) )->getFileName();
+
+		$_POST = array(
+			'syndicate_noncename' => wp_create_nonce( plugin_basename( $server_file ) ),
+			'selected_sitegroups' => array( 'test-sitegroup' ),
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		$_POST = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * The transitioning post is the one written to, whatever global $post holds.
+	 *
+	 * Fired through do_action so that the hook's own accepted-args count is exercised:
+	 * registered with fewer than three, this call fails with too few arguments.
+	 */
+	public function test_writes_to_the_transitioning_post(): void {
+		global $post;
+
+		$other_id     = self::factory()->post->create();
+		$post         = get_post( $other_id );
+		$transitioned = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		$this->post_syndicate_metabox();
+
+		do_action( 'transition_post_status', 'publish', 'draft', get_post( $transitioned ) );
+
+		$this->assertSame( array( 'test-sitegroup' ), get_post_meta( $transitioned, '_syn_selected_sitegroups', true ) );
+		$this->assertNotEmpty( get_post_meta( $transitioned, 'post_uniqueid', true ) );
+		$this->assertSame( '', get_post_meta( $other_id, 'post_uniqueid', true ) );
+	}
+}


### PR DESCRIPTION
## Summary

`save_site_settings()` is hooked to `save_post` for every post type and, until this branch, gated on nothing but a nonce. Worse, that nonce's action string was `plugin_basename( __FILE__ )` — the very same string used for `syndicate_noncename` in the syndicate metabox. Those are two different save paths with two different trust requirements sharing one credential, and the syndicate metabox is rendered on ordinary post edit screens to anyone holding the filterable `syn_syndicate_cap`. So on a site that lowers that cap — and the filter exists precisely so that editors can syndicate — any such user was already holding a nonce valid for the site settings save path.

What that bought them: submitting `site_settings_noncename`, `transport_type` and the client settings fields alongside an ordinary post save wrote `syn_transport_type`, `syn_site_enabled` and, through `save_client_settings()`, the feed URL and site credentials onto the post they were editing. It then reached `get_client()` and `test_connection()`, making the server connect to a URL of the attacker's choosing. The `transport_type` value arrived unvalidated from `$_POST` and was interpolated straight into a class name by `Syndication_Client_Factory::get_transport_type_class()`.

The fix is three guards. The site settings metabox gets its own nonce action, `syn_save_site_settings`, so a nonce for one path is no longer a nonce for the other. The save then requires the post to be a `syn_site` and the user to pass `current_user_can_syndicate()`, bringing it into line with `save_syndicate_settings()` and `pre_schedule_push_content()`, which have always checked the capability. Finally, `transport_type` must be a registered key of `$this->push_syndicate_transports` before it is persisted or turned into a class name.

With the default `manage_options` cap this was admin-only, so it is defence in depth rather than a live hole on a stock install.

### The `global $post` problem underneath it

Both `save_site_settings()` and `save_syndicate_settings()` reached for `global $post` to decide which post to write to. That happens to be the post being saved, but only because `wp-admin/post.php:38` assigns the global before the `case 'editpost'` branch calls `edit_post()`. Nothing in either hook's contract promises it, and `save_syndicate_settings()` was discarding the `WP_Post` that `transition_post_status` already hands to its callbacks — while its neighbour `pre_schedule_push_content()`, on the same hook, accepts it correctly.

I fixed the security issue first without touching this, deliberately: guarding on the hook argument while still writing to the global would have opened a fresh mismatch between what is checked and what is written. The second commit then moves both functions onto the hook arguments, which is where the write target should have come from all along.

Each function now has a test that points `global $post` at a different post and asserts the write lands on the given one, so a return to reading the global fails the suite. The syndicate case fires through `do_action` rather than calling the method directly, which additionally catches the hook being registered for too few arguments. Both were confirmed to fail against the previous implementations.

### Two things I found but did not fix

While writing the tests, creating a `syn_site` post through the factory *while a valid nonce sat in `$_POST`* caused the live `save_post` hook to write transport settings to the newly created post. That is not an artefact of PHPUnit: any `wp_insert_post()` call during an admin request carrying these fields gets site settings written to it, given a `syn_site` post type and a user who can syndicate. The nonce requirement keeps it unexploitable and the new post-type guard confines the blast radius to sites, but it is the same missing-context shape that produced this issue. A `wp_is_post_revision()` or explicit action check would close it.

Separately, `save_syndicate_settings()` still has no post-type guard, so it writes `_syn_selected_sitegroups` to any post that transitions status with a syndicate nonce present, including post types never listed in `selected_post_types`. The capability check holds, so this is meta pollution rather than a privilege problem, and it is out of scope here. Both are worth their own tickets if you agree they are real.

Fixes [VIPPLUG-63](https://linear.app/a8c/issue/VIPPLUG-63/syndication-save_site_settings-has-no-capability-check-and-shares-its).

## Test plan

- [ ] `composer test:unit` — 107 pass
- [ ] `wp-env run tests-cli --env-cwd=wp-content/plugins/<dir> ./vendor/bin/phpunit --testsuite integration` — 49 pass, 5 skipped (pre-existing, mcrypt unavailable)
- [ ] Revert `includes/class-wp-push-syndication-server.php` and confirm `test_syndicate_metabox_nonce_is_rejected` and `test_writes_to_the_transitioning_post` both fail
- [ ] As an administrator, add and update a site under Syndication → Sites and confirm the transport settings still save and the connection test still reports success or failure as before
- [ ] With `syn_syndicate_cap` filtered down to `edit_posts`, confirm an editor can still use the syndicate metabox on a post, and that submitting site settings fields with that post save writes no `syn_` meta