### PR TITLE
Make stored credential fields write-only in the admin

### DIFF
--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -354,9 +354,9 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 	 */
 	public static function display_settings( $site ) {
 
-		$site_token = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_token', true ) );
-		$site_id    = get_post_meta( $site->ID, 'syn_site_id', true );
-		$site_url   = get_post_meta( $site->ID, 'syn_site_url', true );
+		$has_token = '' !== (string) get_post_meta( $site->ID, 'syn_site_token', true );
+		$site_id   = get_post_meta( $site->ID, 'syn_site_id', true );
+		$site_url  = get_post_meta( $site->ID, 'syn_site_url', true );
 
 		// @TODO refresh UI.
 
@@ -370,7 +370,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			<label for=site_token><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" class="widefat" name="site_token" id="site_token" size="100" value="<?php echo esc_attr( $site_token ); ?>" />
+			<input type="password" class="widefat" name="site_token" id="site_token" size="100" autocomplete="off" value="" placeholder="<?php echo $has_token ? esc_attr__( 'Leave blank to keep the saved value', 'push-syndication' ) : ''; ?>" />
 		</p>
 		<p>
 			<label for=site_id><?php echo esc_html__( 'Enter Blog ID', 'push-syndication' ); ?></label>
@@ -402,7 +402,11 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 		// can break OAuth tokens. The token is encrypted before storage anyway.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Token sanitized with wp_strip_all_tags.
 		$token = isset( $_POST['site_token'] ) ? wp_strip_all_tags( wp_unslash( $_POST['site_token'] ) ) : '';
-		update_post_meta( $site_ID, 'syn_site_token', push_syndicate_encrypt( $token ) );
+
+		// The token field is write-only: a blank submission keeps the stored token.
+		if ( '' !== $token ) {
+			update_post_meta( $site_ID, 'syn_site_token', push_syndicate_encrypt( $token ) );
+		}
 		update_post_meta( $site_ID, 'syn_site_id', isset( $_POST['site_id'] ) ? sanitize_text_field( wp_unslash( $_POST['site_id'] ) ) : '' );
 		update_post_meta( $site_ID, 'syn_site_url', isset( $_POST['site_url'] ) ? esc_url_raw( wp_unslash( $_POST['site_url'] ) ) : '' );
 

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -405,6 +405,7 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 
 		// The token field is write-only: a blank submission keeps the stored token.
 		if ( '' !== $token ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- $site_ID is the parameter name set by Syndication_Client.
 			update_post_meta( $site_ID, 'syn_site_token', push_syndicate_encrypt( $token ) );
 		}
 		update_post_meta( $site_ID, 'syn_site_id', isset( $_POST['site_id'] ) ? sanitize_text_field( wp_unslash( $_POST['site_id'] ) ) : '' );

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -566,7 +566,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 		$site_url      = get_post_meta( $site->ID, 'syn_site_url', true );
 		$site_username = get_post_meta( $site->ID, 'syn_site_username', true );
-		$site_password = push_syndicate_decrypt( get_post_meta( $site->ID, 'syn_site_password', true ) );
+		$has_password  = '' !== (string) get_post_meta( $site->ID, 'syn_site_password', true );
 
 		?>
 
@@ -586,7 +586,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			<label><?php echo esc_html__( 'Enter Password', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="password" class="widefat" name="site_password" id="site_password" size="100"  autocomplete="off" value="<?php echo esc_attr( $site_password ); ?>" />
+			<input type="password" class="widefat" name="site_password" id="site_password" size="100"  autocomplete="off" value="" placeholder="<?php echo $has_password ? esc_attr__( 'Leave blank to keep the saved value', 'push-syndication' ) : ''; ?>" />
 		</p>
 
 		<?php
@@ -607,7 +607,10 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 
 		update_post_meta( $site_ID, 'syn_site_url', esc_url_raw( $site_url ) );
 		update_post_meta( $site_ID, 'syn_site_username', $username );
-		update_post_meta( $site_ID, 'syn_site_password', push_syndicate_encrypt( $password ) );
+		// The password field is write-only: a blank submission keeps the stored password.
+		if ( '' !== $password ) {
+			update_post_meta( $site_ID, 'syn_site_password', push_syndicate_encrypt( $password ) );
+		}
 
 		if ( ! filter_var( $site_url, FILTER_VALIDATE_URL ) ) {
 			add_filter(

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -609,6 +609,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		update_post_meta( $site_ID, 'syn_site_username', $username );
 		// The password field is write-only: a blank submission keeps the stored password.
 		if ( '' !== $password ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- $site_ID is the parameter name set by Syndication_Client.
 			update_post_meta( $site_ID, 'syn_site_password', push_syndicate_encrypt( $password ) );
 		}
 

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -270,12 +270,15 @@ class WP_Push_Syndication_Server {
 
 		$settings                             = array();
 		$settings['client_id']                = sanitize_text_field( $raw_settings['client_id'] );
-		$settings['client_secret']            = sanitize_text_field( $raw_settings['client_secret'] );
 		$settings['selected_post_types']      = ! empty( $raw_settings['selected_post_types'] ) ? $raw_settings['selected_post_types'] : array();
 		$settings['delete_pushed_posts']      = ! empty( $raw_settings['delete_pushed_posts'] ) ? $raw_settings['delete_pushed_posts'] : 'off';
 		$settings['selected_pull_sitegroups'] = ! empty( $raw_settings['selected_pull_sitegroups'] ) ? $raw_settings['selected_pull_sitegroups'] : array();
 		$settings['pull_time_interval']       = ! empty( $raw_settings['pull_time_interval'] ) ? max( $raw_settings['pull_time_interval'], 300 ) : '3600';
 		$settings['update_pulled_posts']      = ! empty( $raw_settings['update_pulled_posts'] ) ? $raw_settings['update_pulled_posts'] : 'off';
+
+		// The client secret field is write-only: a blank submission keeps the stored secret.
+		$submitted_secret          = isset( $raw_settings['client_secret'] ) ? sanitize_text_field( $raw_settings['client_secret'] ) : '';
+		$settings['client_secret'] = '' !== $submitted_secret ? $submitted_secret : $this->push_syndicate_settings['client_secret'];
 
 		$this->pre_schedule_pull_content( $settings['selected_pull_sitegroups'] );
 
@@ -477,7 +480,8 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function display_client_secret() {
-		echo '<input type="text" size=100 name="push_syndicate_settings[client_secret]" value="' . esc_attr( $this->push_syndicate_settings['client_secret'] ) . '"/>';
+		$placeholder = empty( $this->push_syndicate_settings['client_secret'] ) ? '' : __( 'Leave blank to keep the saved value', 'push-syndication' );
+		echo '<input type="password" size=100 autocomplete="off" name="push_syndicate_settings[client_secret]" value="" placeholder="' . esc_attr( $placeholder ) . '"/>';
 	}
 
 	public function get_api_token() {

--- a/tests/Integration/WriteOnlyCredentialFieldsTest.php
+++ b/tests/Integration/WriteOnlyCredentialFieldsTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests that stored credentials are never rendered back into admin form fields.
+ *
+ * @package Automattic\Syndication\Tests
+ */
+
+namespace Automattic\Syndication\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Class WriteOnlyCredentialFieldsTest
+ *
+ * Regression guard for VIPPLUG-65: decrypted secrets were printed into the value
+ * attribute of the site edit screen and settings page fields on every load. The
+ * fields are now write-only - blank means "keep what is stored".
+ *
+ * @covers Syndication_WP_XMLRPC_Client::display_settings
+ * @covers Syndication_WP_XMLRPC_Client::save_settings
+ * @covers Syndication_WP_REST_Client::display_settings
+ * @covers Syndication_WP_REST_Client::save_settings
+ * @covers WP_Push_Syndication_Server::push_syndicate_settings_validate
+ */
+class WriteOnlyCredentialFieldsTest extends WPIntegrationTestCase {
+
+	/**
+	 * A site post to hold the credentials.
+	 *
+	 * @var \WP_Post
+	 */
+	private $site;
+
+	/**
+	 * The server settings as they were before a test changed them.
+	 *
+	 * @var array
+	 */
+	private $original_settings;
+
+	/**
+	 * Create the site post used by each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->site              = self::factory()->post->create_and_get( array( 'post_type' => 'syn_site' ) );
+		$this->original_settings = $GLOBALS['push_syndication_server']->push_syndicate_settings;
+	}
+
+	/**
+	 * Clean up superglobals touched by save_settings().
+	 */
+	public function tear_down(): void {
+		unset( $_POST['site_password'], $_POST['site_token'] );
+
+		$GLOBALS['push_syndication_server']->push_syndicate_settings = $this->original_settings;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The XML-RPC password must not appear in the rendered form.
+	 */
+	public function test_xmlrpc_password_is_not_rendered(): void {
+		update_post_meta( $this->site->ID, 'syn_site_password', push_syndicate_encrypt( 'hunter2' ) );
+
+		ob_start();
+		\Syndication_WP_XMLRPC_Client::display_settings( $this->site );
+		$html = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'hunter2', $html );
+	}
+
+	/**
+	 * A blank password submission must leave the stored password untouched.
+	 */
+	public function test_blank_xmlrpc_password_keeps_stored_value(): void {
+		update_post_meta( $this->site->ID, 'syn_site_password', push_syndicate_encrypt( 'hunter2' ) );
+
+		$_POST['site_url']      = 'https://example.com';
+		$_POST['site_password'] = '';
+
+		\Syndication_WP_XMLRPC_Client::save_settings( $this->site->ID );
+
+		$stored = push_syndicate_decrypt( get_post_meta( $this->site->ID, 'syn_site_password', true ) );
+		$this->assertSame( 'hunter2', $stored );
+	}
+
+	/**
+	 * A non-blank password submission must replace the stored password.
+	 */
+	public function test_submitted_xmlrpc_password_is_stored(): void {
+		update_post_meta( $this->site->ID, 'syn_site_password', push_syndicate_encrypt( 'hunter2' ) );
+
+		$_POST['site_url']      = 'https://example.com';
+		$_POST['site_password'] = 'correct-horse';
+
+		\Syndication_WP_XMLRPC_Client::save_settings( $this->site->ID );
+
+		$stored = push_syndicate_decrypt( get_post_meta( $this->site->ID, 'syn_site_password', true ) );
+		$this->assertSame( 'correct-horse', $stored );
+	}
+
+	/**
+	 * The WordPress.com bearer token must not appear in the rendered form.
+	 */
+	public function test_rest_token_is_not_rendered(): void {
+		update_post_meta( $this->site->ID, 'syn_site_token', push_syndicate_encrypt( 'bearer-token-123' ) );
+
+		ob_start();
+		\Syndication_WP_REST_Client::display_settings( $this->site );
+		$html = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'bearer-token-123', $html );
+	}
+
+	/**
+	 * A blank token submission must leave the stored token untouched.
+	 */
+	public function test_blank_rest_token_keeps_stored_value(): void {
+		update_post_meta( $this->site->ID, 'syn_site_token', push_syndicate_encrypt( 'bearer-token-123' ) );
+
+		$_POST['site_token'] = '';
+
+		\Syndication_WP_REST_Client::save_settings( $this->site->ID );
+
+		$stored = push_syndicate_decrypt( get_post_meta( $this->site->ID, 'syn_site_token', true ) );
+		$this->assertSame( 'bearer-token-123', $stored );
+	}
+
+	/**
+	 * A blank client secret submission must leave the stored secret untouched.
+	 */
+	public function test_blank_client_secret_keeps_stored_value(): void {
+		$server                          = $GLOBALS['push_syndication_server'];
+		$server->push_syndicate_settings = array( 'client_secret' => 'stored-secret' );
+
+		$settings = $server->push_syndicate_settings_validate(
+			array(
+				'client_id'     => 'abc',
+				'client_secret' => '',
+			)
+		);
+
+		$this->assertSame( 'stored-secret', $settings['client_secret'] );
+	}
+
+	/**
+	 * A submitted client secret must replace the stored secret.
+	 */
+	public function test_submitted_client_secret_is_stored(): void {
+		$server                          = $GLOBALS['push_syndication_server'];
+		$server->push_syndicate_settings = array( 'client_secret' => 'stored-secret' );
+
+		$settings = $server->push_syndicate_settings_validate(
+			array(
+				'client_id'     => 'abc',
+				'client_secret' => 'new-secret',
+			)
+		);
+
+		$this->assertSame( 'new-secret', $settings['client_secret'] );
+	}
+}


### PR DESCRIPTION
## Summary

Three admin fields read a stored secret back out on every page load and printed it straight into the `value` attribute. The site edit screen decrypted the XML-RPC site password and the WordPress.com bearer token each time it rendered, and the settings page put the OAuth client secret into a plain text input. The token and secret were not even masked, so they sat in the page as readable text.

The consequence is that live credentials were on screen routinely, not just at the moment somebody typed them. That exposes them to shoulder surfing, screen sharing and recordings, browser extensions with DOM access, and browser page caches. It needs admin-level access to reach those screens, so the severity is low, but there is no reason to display a secret that is already stored.

All three fields are now write-only. They render with an empty value and, where something is already saved, a placeholder saying so, and the corresponding save handlers only overwrite the stored secret when a non-empty value is submitted. The token field also moves from `type="text"` to `type="password"` with `autocomplete="off"`, matching the password field alongside it. The practical effect for an admin is that leaving a credential field blank now means "keep what is stored" rather than "wipe it", which is the standard behaviour elsewhere in WordPress.

Two things worth a reviewer's attention. First, the OAuth access token table on the settings page is deliberately unchanged: it renders only on the authorisation callback, where the admin has to copy the value into the site's token field, so masking it would break the flow it exists to serve. Second, making the fields write-only removes any way to clear a stored credential through the UI. That felt speculative to build now, but if decommissioning a site without deleting its post matters, it would need an explicit "remove saved credential" control.

Fixes VIPPLUG-65.

## Test plan

- [ ] On a site with a saved XML-RPC password, open the site edit screen and confirm the password field is empty with the placeholder shown, and that the password does not appear anywhere in the page source.
- [ ] Save that site without touching the password field, then confirm syndication to it still authenticates.
- [ ] Enter a new password, save, and confirm the new value takes effect.
- [ ] Repeat both for a WordPress.com REST site's API token.
- [ ] On Settings → Push Syndication, confirm the client secret field is masked and empty, save the settings form without retyping it, and confirm the OAuth authorisation flow still completes.