### PR TITLE
Clean up the plugin's internationalisation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 			"@php ./vendor/bin/phpcbf -q"
 		],
 		"i18n": [
-			"@php wp i18n make-pot . ./languages/push-syndication.pot --domain=push-syndication"
+			"@php wp i18n make-pot . ./languages/push-syndication.pot --domain=push-syndication --slug=syndication"
 		],
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -182,7 +182,7 @@ add_filter( 'syn_message_text_multiple', 'syn_handle_multiple_error_notices', 10
  * @return string The filtered message text.
  */
 function syn_handle_multiple_error_notices( $message, $message_data ) {
-	return __( 'There have been multiple errors. Please validate your syndication logs' );
+	return __( 'There have been multiple errors. Please validate your syndication logs', 'push-syndication' );
 }
 
 add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10, 2 );

--- a/includes/class-syndication-admin-notices.php
+++ b/includes/class-syndication-admin-notices.php
@@ -193,5 +193,6 @@ add_action( 'push_syndication_site_disabled', 'syn_add_site_disabled_notice', 10
  * @param int $count   The number of failed pull attempts.
  */
 function syn_add_site_disabled_notice( $site_id, $count ) {
+	// translators: 1: Site post ID, 2: Number of failed pull attempts.
 	Syndication_Logger_Admin_Notice::add_notice( $message_text = sprintf( __( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ), $message_type = 'Syndication site disabled', $class = 'error', $summarize_multiple = false );
 }

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -297,7 +297,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 				$this->_create_months_dropdown();
 				$this->_create_types_dropdown();
 
-				submit_button( __( 'Filter' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+				submit_button( __( 'Filter', 'push-syndication' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
 			}
 
 			?>

--- a/includes/class-syndication-logger.php
+++ b/includes/class-syndication-logger.php
@@ -232,10 +232,10 @@ class Syndication_Logger {
 			} else {
 				$message = 'fail';
 			}
-			self::log_post_error( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			self::log_post_error( $site->ID, $status = $event, $message, $log_time, $extra );
 		} else {
 			$message = sprintf( '%s,%d', sanitize_text_field( $post['post_guid'] ), intval( $result ) );
-			self::log_post_success( $site->ID, $status = __( esc_attr( $event ), 'push-syndication' ), $message, $log_time, $extra );
+			self::log_post_success( $site->ID, $status = $event, $message, $log_time, $extra );
 		}
 	}
 

--- a/includes/class-syndication-site-auto-retry.php
+++ b/includes/class-syndication-site-auto-retry.php
@@ -105,6 +105,7 @@ class Failed_Syndication_Auto_Retry {
 				// Run in one minute by default.
 				$auto_retry_interval = apply_filters( 'syndication_failure_auto_retry_interval', $time_now + MINUTE_IN_SECONDS );
 
+				// translators: 1: Current retry number, 2: Maximum number of retries, 3: Site URL, 4: Human-readable time until the retry runs.
 				Syndication_Logger::log_post_info( $site->ID, $status = 'start_auto_retry', $message = sprintf( __( 'Connection retry %1$d of %2$d to %3$s in %4$s..', 'push-syndication' ), $site_auto_retry_count + 1, $auto_retry_limit, $site_url, human_time_diff( $time_now, $auto_retry_interval ) ), $log_time, $extra = array() );
 
 				// Schedule a pull retry for one minute in the future.
@@ -138,6 +139,7 @@ class Failed_Syndication_Auto_Retry {
 			// Remove the auto retry if there was one.
 			delete_post_meta( $site->ID, 'syn_failed_auto_retry_attempts' );
 
+			// translators: 1: Number of failed reconnection attempts, 2: Site URL.
 			Syndication_Logger::log_post_error( $site->ID, $status = 'end_auto_retry', $message = sprintf( __( 'Failed %1$d times to reconnect to %2$s', 'push-syndication' ), $site_auto_retry_count, $site_url ), $log_time, $extra = array() );
 		}
 	}

--- a/includes/class-syndication-site-failure-monitor.php
+++ b/includes/class-syndication-site-failure-monitor.php
@@ -47,6 +47,7 @@ class Syndication_Site_Failure_Monitor {
 			do_action( 'push_syndication_reset_event', 'pull_failure', $site_id );
 
 			// Log what happened.
+			// translators: 1: Site post ID, 2: Number of failed pull attempts.
 			Syndication_Logger::log_post_error( $site_id, 'error', sprintf( __( 'Site %1$d disabled after %2$d pull failure(s).', 'push-syndication' ), (int) $site_id, (int) $count ) );
 
 			do_action( 'push_syndication_site_disabled', $site_id, $count );

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -261,11 +261,13 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		$rss_init = $this->init();
 
 		if ( false === $rss_init ) {
+			// translators: %s: Feed URL.
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %s', 'push-syndication' ), $this->feed_url ), $log_time = isset( $site_post->postmeta['is_update'] ) ? $site_post->postmeta['is_update'] : null, $extra = array( 'error' => $this->error() ) );
 
 			// Track the event.
 			do_action( 'push_syndication_event', 'pull_failure', $this->site_ID );
 		} else {
+			// translators: %d: Size of the fetched feed, in bytes.
 			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $this->get_raw_data() ) ), $log_time = null, $extra = array() );
 
 			// Track the event.

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -505,7 +505,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<label for="feed_url"><?php esc_html_e( 'Enter feed URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="feed_url" id="feed_url" size="100" value="<?php esc_attr_e( $feed_url ); ?>" />
+			<input type="text" name="feed_url" id="feed_url" size="100" value="<?php echo esc_attr( $feed_url ); ?>" />
 		</p>
 		<p>
 			<label for="default_post_type"><?php esc_html_e( 'Select post type', 'push-syndication' ); ?></label>
@@ -517,7 +517,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			foreach ( $post_types as $post_type ) {
 				?>
-				<option value="<?php esc_attr_e( $post_type ); ?>" <?php selected( $post_type, $default_post_type ); ?>><?php esc_html_e( $post_type ); ?></option>
+				<option value="<?php echo esc_attr( $post_type ); ?>" <?php selected( $post_type, $default_post_type ); ?>><?php echo esc_html( $post_type ); ?></option>
 			<?php } ?>
 			</select>
 		</p>
@@ -531,7 +531,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			foreach ( $post_statuses as $key => $value ) {
 				?>
-				<option value="<?php esc_attr_e( $key ); ?>" <?php selected( $key, $default_post_status ); ?>><?php esc_html_e( $key ); ?></option>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $default_post_status ); ?>><?php echo esc_html( $key ); ?></option>
 			<?php } ?>
 			</select>
 		</p>
@@ -558,35 +558,35 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			<label for="namespace"><?php esc_html_e( 'Enter XML namespace', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" size="75" name="namespace" id="namespace" value="<?php esc_attr_e( $namespace ); ?>" />
+			<input type="text" size="75" name="namespace" id="namespace" value="<?php echo esc_attr( $namespace ); ?>" />
 		</p>
 
 		<p>
 			<label for="post_root"><?php esc_html_e( 'Enter XPath to post root', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="post_root" id="post_root" value="<?php esc_attr_e( $post_root ); ?>" />
+			<input type="text" name="post_root" id="post_root" value="<?php echo esc_attr( $post_root ); ?>" />
 		</p>
 
 		<p>
 			<label for="id_field"><?php esc_html_e( 'Enter post meta key for unique post identifier', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="id_field" id="id_field" value="<?php esc_attr_e( $id_field ); ?>" />
+			<input type="text" name="id_field" id="id_field" value="<?php echo esc_attr( $id_field ); ?>" />
 		</p>
 
 		<p>
 			<label for="enc_parent"><?php esc_html_e( 'Enter parent element for enclosures', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="enc_parent" id="enc_parent" value="<?php esc_attr_e( $enc_parent ); ?>" />
+			<input type="text" name="enc_parent" id="enc_parent" value="<?php echo esc_attr( $enc_parent ); ?>" />
 		</p>
 
 		<p>
 			<label for="enc_field"><?php esc_html_e( 'Enter meta name for enclosures', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<input type="text" name="enc_field" id="enc_field" value="<?php esc_attr_e( $enc_field ); ?>" />
+			<input type="text" name="enc_field" id="enc_field" value="<?php echo esc_attr( $enc_field ); ?>" />
 		</p>
 
 		<p>

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -117,6 +117,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		if ( parse_url( $url ) ) {
 			$this->feed_url = $url;
 		} else {
+			// translators: %s: Site post ID.
 			$this->error_message = sprintf( __( 'Feed URL not set for this feed: %s', 'push-syndication' ), $this->site_ID );
 		}
 	}
@@ -242,6 +243,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		// TODO: kill feed client if too many failures.
 		$site_post = get_post( $this->site_ID );
 		if ( is_wp_error( $feed ) ) {
+			// translators: 1: Feed URL, 2: Error message.
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Could not reach feed at: %1$s | Error: %2$s', 'push-syndication' ), $this->feed_url, $feed->get_error_message() ), $log_time = null, $extra = array() );
 
 			// Track the event.
@@ -249,6 +251,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 			return array();
 		} else {
+			// translators: %d: Size of the fetched feed, in bytes.
 			Syndication_Logger::log_post_info( $this->site_ID, $status = 'fetch_feed', $message = sprintf( __( 'fetched feed with %d bytes', 'push-syndication' ), strlen( $feed ) ), $log_time = null, $extra = array() );
 
 			// Track the event.
@@ -272,6 +275,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			// Clear libxml error buffer.
 			libxml_clear_errors();
 
+			// translators: 1: Feed URL, 2: List of XML parser errors.
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( __( 'Failed to parse feed at: %1$s \nErrors: %2$s', 'push-syndication' ), $this->feed_url, $xml_errors ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
 
 			// Track the event.
@@ -310,9 +314,11 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		$items         = $xml->xpath( $post_root );
 
 		if ( empty( $items ) ) {
+			// translators: %s: XPath expression used to locate the post root.
 			Syndication_Logger::log_post_error( $this->site_ID, $status = 'error', $message = sprintf( esc_html__( 'No post nodes found using XPath "%s" in feed', 'push-syndication' ), esc_html( $post_root ) ), $log_time = $site_post->postmeta['is_update'], $extra = array() );
 			return array();
 		} else {
+			// translators: %d: Number of items found in the feed.
 			Syndication_Logger::log_post_info( $this->site_ID, $status = 'simplexml_load_string', $message = sprintf( __( 'parsed feed, received %d items', 'push-syndication' ), count( $items ) ), $log_time = null, $extra = array() );
 		}
 
@@ -390,6 +396,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 			++$post_position;
 		}
 
+		// translators: %d: Number of posts prepared for import.
 		Syndication_Logger::log_post_info( $this->site_ID, $status = 'posts_received', $message = sprintf( __( '%d posts were prepared', 'push-syndication' ), count( $posts ) ), $log_time = null, $extra = array() );
 
 		return $posts;
@@ -618,7 +625,12 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 		<h2><?php esc_html_e( 'XPath-to-Data Mapping', 'push-syndication' ); ?></h2>
 
-		<p><?php echo wp_kses( sprintf( __( '<strong>PLEASE NOTE:</strong> %1$s are required. If you want a link to another site, %2$s is required. To include a static string, enclose the string as "%3$s(your_string_here)" &mdash; no quotes.', 'push-syndication' ), 'post_title, post_guid, guid', 'is_permalink', 'string' ), array( 'strong' => array() ) ); ?></p>
+		<p>
+			<?php
+			// translators: 1: Comma-separated list of required field names, 2: The is_permalink field name, 3: The string keyword used to wrap a static value.
+			echo wp_kses( sprintf( __( '<strong>PLEASE NOTE:</strong> %1$s are required. If you want a link to another site, %2$s is required. To include a static string, enclose the string as "%3$s(your_string_here)" &mdash; no quotes.', 'push-syndication' ), 'post_title, post_guid, guid', 'is_permalink', 'string' ), array( 'strong' => array() ) );
+			?>
+		</p>
 
 		<ul class='syn-xml-client-xpath-head syn-xml-client-list-head'>
 			<li class="text">

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -721,7 +721,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		}
 
 		if ( ! $thumbnail_set ) {
-			return new IXR_Error( 403, __( 'Could not attach post thumbnail.' ) );
+			return new IXR_Error( 403, __( 'Could not attach post thumbnail.', 'push-syndication' ) );
 		}
 		
 		$args = array(
@@ -763,7 +763,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_ID ) ) {
-			return new IXR_Error( 401, __( 'Sorry, you are not allowed to post on this site.' ) );
+			return new IXR_Error( 401, __( 'Sorry, you are not allowed to post on this site.', 'push-syndication' ) );
 		}
 
 		if ( '_thumbnail_id' == $meta_key ) {
@@ -773,7 +773,7 @@ class Syndication_WP_XMLRPC_Client_Extensions {
 		}
 
 		if ( ! $result ) {
-			return new IXR_Error( 403, __( 'Could not remove post thumbnail.' ) );
+			return new IXR_Error( 403, __( 'Could not remove post thumbnail.', 'push-syndication' ) );
 		}
 
 		return true;

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -100,16 +100,16 @@ class WP_Push_Syndication_Server {
 			'syn_site',
 			array(
 				'labels'               => array(
-					'name'          => __( 'Sites' ),
-					'singular_name' => __( 'Site' ),
-					'add_new'       => __( 'Add Site' ),
-					'add_new_item'  => __( 'Add New Site' ),
-					'edit_item'     => __( 'Edit Site' ),
-					'new_item'      => __( 'New Site' ),
-					'view_item'     => __( 'View Site' ),
-					'search_items'  => __( 'Search Sites' ),
+					'name'          => __( 'Sites', 'push-syndication' ),
+					'singular_name' => __( 'Site', 'push-syndication' ),
+					'add_new'       => __( 'Add Site', 'push-syndication' ),
+					'add_new_item'  => __( 'Add New Site', 'push-syndication' ),
+					'edit_item'     => __( 'Edit Site', 'push-syndication' ),
+					'new_item'      => __( 'New Site', 'push-syndication' ),
+					'view_item'     => __( 'View Site', 'push-syndication' ),
+					'search_items'  => __( 'Search Sites', 'push-syndication' ),
 				),
-				'description'          => __( 'Sites in the network' ),
+				'description'          => __( 'Sites in the network', 'push-syndication' ),
 				'public'               => false,
 				'show_ui'              => true,
 				'publicly_queryable'   => false,
@@ -131,17 +131,17 @@ class WP_Push_Syndication_Server {
 			'syn_site',
 			array(
 				'labels'            => array(
-					'name'              => __( 'Site Groups' ),
-					'singular_name'     => __( 'Site Group' ),
-					'search_items'      => __( 'Search Site Groups' ),
-					'popular_items'     => __( 'Popular Site Groups' ),
-					'all_items'         => __( 'All Site Groups' ),
-					'parent_item'       => __( 'Parent Site Group' ),
-					'parent_item_colon' => __( 'Parent Site Group' ),
-					'edit_item'         => __( 'Edit Site Group' ),
-					'update_item'       => __( 'Update Site Group' ),
-					'add_new_item'      => __( 'Add New Site Group' ),
-					'new_item_name'     => __( 'New Site Group Name' ),
+					'name'              => __( 'Site Groups', 'push-syndication' ),
+					'singular_name'     => __( 'Site Group', 'push-syndication' ),
+					'search_items'      => __( 'Search Site Groups', 'push-syndication' ),
+					'popular_items'     => __( 'Popular Site Groups', 'push-syndication' ),
+					'all_items'         => __( 'All Site Groups', 'push-syndication' ),
+					'parent_item'       => __( 'Parent Site Group', 'push-syndication' ),
+					'parent_item_colon' => __( 'Parent Site Group', 'push-syndication' ),
+					'edit_item'         => __( 'Edit Site Group', 'push-syndication' ),
+					'update_item'       => __( 'Update Site Group', 'push-syndication' ),
+					'add_new_item'      => __( 'Add New Site Group', 'push-syndication' ),
+					'new_item_name'     => __( 'New Site Group Name', 'push-syndication' ),
 
 				),
 				'public'            => false,
@@ -183,11 +183,11 @@ class WP_Push_Syndication_Server {
 	public function add_new_columns( $columns ) {
 		$new_columns                  = array();
 		$new_columns['cb']            = '<input type="checkbox" />';
-		$new_columns['title']         = _x( 'Site Name', 'column name' );
-		$new_columns['client-type']   = _x( 'Client Type', 'column name' );
-		$new_columns['syn_sitegroup'] = _x( 'Groups', 'column name' );
-		$new_columns['site_status']   = _x( 'Status', 'column name' );
-		$new_columns['date']          = _x( 'Date', 'column name' );
+		$new_columns['title']         = _x( 'Site Name', 'column name', 'push-syndication' );
+		$new_columns['client-type']   = _x( 'Client Type', 'column name', 'push-syndication' );
+		$new_columns['syn_sitegroup'] = _x( 'Groups', 'column name', 'push-syndication' );
+		$new_columns['site_status']   = _x( 'Status', 'column name', 'push-syndication' );
+		$new_columns['date']          = _x( 'Date', 'column name', 'push-syndication' );
 		return $new_columns;
 	}
 
@@ -596,9 +596,9 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function site_metaboxes() {
-		add_meta_box( 'sitediv', __( ' Site Settings ' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
+		add_meta_box( 'sitediv', __( ' Site Settings ', 'push-syndication' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
 		remove_meta_box( 'submitdiv', 'syn_site', 'side' );
-		add_meta_box( 'submitdiv', __( ' Site Status ' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
+		add_meta_box( 'submitdiv', __( ' Site Status ', 'push-syndication' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
 	}
 
 	public function add_site_status_metabox( $site ) {
@@ -829,7 +829,7 @@ class WP_Push_Syndication_Server {
 
 		$selected_post_types = $this->push_syndicate_settings['selected_post_types'];
 		foreach ( $selected_post_types as $selected_post_type ) {
-			add_meta_box( 'syndicatediv', __( ' Syndicate ' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
+			add_meta_box( 'syndicatediv', __( ' Syndicate ', 'push-syndication' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
 			// add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' ); // phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- Commented out code.
 		}
 	}

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -201,6 +201,7 @@ class WP_Push_Syndication_Server {
 					$client_data = $client->get_client_data();
 					echo esc_html( sprintf( '%s (%s)', $client_data['name'], array_shift( $client_data['modes'] ) ) );
 				} catch ( Exception $e ) {
+					// translators: %s: Transport type of the site.
 					printf( esc_html__( 'Unknown (%s)', 'push-syndication' ), esc_html( $transport_type ) );
 				}
 				break;
@@ -719,6 +720,7 @@ class WP_Push_Syndication_Server {
 		$max_len = 0;
 		foreach ( $this->push_syndicate_transports as $key => $value ) {
 			$mode = array_shift( $value['modes'] );
+			// translators: 1: Client name, 2: Client mode.
 			echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $transport_type, false ) . '>' . sprintf( esc_html__( '%1$s (%2$s)', 'push-syndication' ), esc_html( $value['name'] ), esc_html( $mode ) ) . '</option>';
 		}
 		echo '</select>';
@@ -1480,8 +1482,10 @@ class WP_Push_Syndication_Server {
 			$post_types_processed = array();
 
 			if ( is_array( $posts ) && count( $posts ) > 0 ) {
+				// translators: 1: Site post ID, 2: Number of posts in the feed.
 				Syndication_Logger::log_post_info( $site_id, $status = 'start_import', $message = sprintf( __( 'starting import for site id %1$d with %2$d posts', 'push-syndication' ), $site_id, count( $posts ) ), $log_time = null, $extra = array() );
 			} else {
+				// translators: %d: Site post ID.
 				Syndication_Logger::log_post_info( $site_id, $status = 'no_posts', $message = sprintf( __( 'no posts for site id %d', 'push-syndication' ), $site_id ), $log_time = null, $extra = array() );
 			}
 

--- a/languages/push-syndication.pot
+++ b/languages/push-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-04T16:35:15+00:00\n"
+"POT-Creation-Date: 2026-09-12T11:38:11+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: push-syndication\n"
@@ -40,566 +40,729 @@ msgid "http://automattic.com"
 msgstr ""
 
 #. translators: 1: message type, 2: message text, 3: dismiss URL
-#: includes/class-syndication-admin-notices.php:102
+#: includes/class-syndication-admin-notices.php:116
 #, php-format
 msgid "%1$s : %2$s <a href=\"%3$s\">Hide Notice</a>"
 msgstr ""
 
-#: includes/class-syndication-admin-notices.php:126
+#: includes/class-syndication-admin-notices.php:146
 msgid "Invalid security check"
 msgstr ""
 
-#: includes/class-syndication-admin-notices.php:164
-#: includes/class-syndication-site-failure-monitor.php:42
-#, php-format
-msgid "Site %d disabled after %d pull failure(s)."
+#: includes/class-syndication-admin-notices.php:185
+msgid "There have been multiple errors. Please validate your syndication logs"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:23
+#. translators: 1: Site post ID, 2: Number of failed pull attempts.
+#: includes/class-syndication-admin-notices.php:197
+#: includes/class-syndication-site-failure-monitor.php:51
+#, php-format
+msgid "Site %1$d disabled after %2$d pull failure(s)."
+msgstr ""
+
+#: includes/class-syndication-logger-viewer.php:40
 msgid "log"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:24
+#: includes/class-syndication-logger-viewer.php:41
 msgid "logs"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:49
+#: includes/class-syndication-logger-viewer.php:74
 msgid "No log entries found."
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:81
+#: includes/class-syndication-logger-viewer.php:120
 msgid "Object ID"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:82
+#: includes/class-syndication-logger-viewer.php:121
 msgid "Log ID"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:83
+#: includes/class-syndication-logger-viewer.php:122
 msgid "Time"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:84
+#: includes/class-syndication-logger-viewer.php:123
 msgid "Type"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:85
+#: includes/class-syndication-logger-viewer.php:124
 msgid "Status"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:86
+#: includes/class-syndication-logger-viewer.php:125
 msgid "Message"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:209
+#: includes/class-syndication-logger-viewer.php:300
+msgid "Filter"
+msgstr ""
+
+#: includes/class-syndication-logger-viewer.php:315
 msgid "Filter by Log ID"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:211
+#: includes/class-syndication-logger-viewer.php:317
 msgid "All logs"
 msgstr ""
 
-#: includes/class-syndication-logger-viewer.php:298
+#: includes/class-syndication-logger-viewer.php:448
+msgid "Log entries"
+msgstr ""
+
+#: includes/class-syndication-logger-viewer.php:462
 msgid "Syndication Logs"
 msgstr ""
 
-#: includes/class-syndication-logger.php:300
+#: includes/class-syndication-logger.php:356
 msgid "You need to provide a valid post_id or use log_option instead"
 msgstr ""
 
-#: includes/class-syndication-logger.php:305
+#: includes/class-syndication-logger.php:361
 msgid "The post_id provided does not exist."
 msgstr ""
 
-#: includes/class-syndication-site-auto-retry.php:106
+#. translators: 1: Current retry number, 2: Maximum number of retries, 3: Site URL, 4: Human-readable time until the retry runs.
+#: includes/class-syndication-site-auto-retry.php:109
 #, php-format
-msgid "Connection retry %d of %d to %s in %s.."
+msgid "Connection retry %1$d of %2$d to %3$s in %4$s.."
 msgstr ""
 
-#: includes/class-syndication-site-auto-retry.php:140
+#. translators: 1: Number of failed reconnection attempts, 2: Site URL.
+#: includes/class-syndication-site-auto-retry.php:143
 #, php-format
-msgid "Failed %d times to reconnect to %s"
+msgid "Failed %1$d times to reconnect to %2$s"
 msgstr ""
 
-#: includes/class-syndication-wp-rest-client.php:294
+#: includes/class-syndication-wp-rest-client.php:366
 msgid "To generate the following information automatically please visit the "
 msgstr ""
 
-#: includes/class-syndication-wp-rest-client.php:295
+#: includes/class-syndication-wp-rest-client.php:367
 msgid "settings page"
 msgstr ""
 
-#: includes/class-syndication-wp-rest-client.php:298
+#: includes/class-syndication-wp-rest-client.php:370
 msgid "Enter API Token"
 msgstr ""
 
-#: includes/class-syndication-wp-rest-client.php:304
+#: includes/class-syndication-wp-rest-client.php:373
+#: includes/class-syndication-wp-xmlrpc-client.php:589
+#: includes/class-wp-push-syndication-server.php:484
+msgid "Leave blank to keep the saved value"
+msgstr ""
+
+#: includes/class-syndication-wp-rest-client.php:376
 msgid "Enter Blog ID"
 msgstr ""
 
-#: includes/class-syndication-wp-rest-client.php:310
+#: includes/class-syndication-wp-rest-client.php:382
 msgid "Enter a valid Blog URL"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:91
-#: includes/class-syndication-wp-xml-client.php:506
+#: includes/class-syndication-wp-rss-client.php:151
+#: includes/class-syndication-wp-xml-client.php:512
 msgid "Enter feed URL"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:97
-#: includes/class-syndication-wp-xml-client.php:512
+#: includes/class-syndication-wp-rss-client.php:157
+#: includes/class-syndication-wp-xml-client.php:518
 msgid "Select post type"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:115
-#: includes/class-syndication-wp-xml-client.php:526
+#: includes/class-syndication-wp-rss-client.php:175
+#: includes/class-syndication-wp-xml-client.php:532
 msgid "Select post status"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:133
-#: includes/class-syndication-wp-xml-client.php:540
+#: includes/class-syndication-wp-rss-client.php:193
+#: includes/class-syndication-wp-xml-client.php:546
 msgid "Select comment status"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:142
-#: includes/class-syndication-wp-xml-client.php:549
+#: includes/class-syndication-wp-rss-client.php:202
+#: includes/class-syndication-wp-xml-client.php:555
 msgid "Select ping status"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:151
+#: includes/class-syndication-wp-rss-client.php:211
 msgid "Select category status"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:155
+#: includes/class-syndication-wp-rss-client.php:215
 msgid "import categories"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:156
+#: includes/class-syndication-wp-rss-client.php:216
 msgid "ignore categories"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:188
+#. translators: %s: Feed URL.
+#: includes/class-syndication-wp-rss-client.php:265
 #, php-format
 msgid "Failed to parse feed at: %s"
 msgstr ""
 
-#: includes/class-syndication-wp-rss-client.php:193
-#: includes/class-syndication-wp-xml-client.php:248
+#. translators: %d: Size of the fetched feed, in bytes.
+#: includes/class-syndication-wp-rss-client.php:271
+#: includes/class-syndication-wp-xml-client.php:255
 #, php-format
 msgid "fetched feed with %d bytes"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:124
+#. translators: %s: Site post ID.
+#: includes/class-syndication-wp-xml-client.php:121
 #, php-format
 msgid "Feed URL not set for this feed: %s"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:241
+#. translators: 1: Feed URL, 2: Error message.
+#: includes/class-syndication-wp-xml-client.php:247
 #, php-format
-msgid "Could not reach feed at: %s | Error: %s"
+msgid "Could not reach feed at: %1$s | Error: %2$s"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:272
+#. translators: 1: Feed URL, 2: List of XML parser errors.
+#: includes/class-syndication-wp-xml-client.php:279
 #, php-format
-msgid "Failed to parse feed at: %s \\nErrors: %s"
+msgid "Failed to parse feed at: %1$s \\nErrors: %2$s"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:311
+#. translators: %s: XPath expression used to locate the post root.
+#: includes/class-syndication-wp-xml-client.php:318
 #, php-format
 msgid "No post nodes found using XPath \"%s\" in feed"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:314
+#. translators: %d: Number of items found in the feed.
+#: includes/class-syndication-wp-xml-client.php:322
 #, php-format
 msgid "parsed feed, received %d items"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:392
+#. translators: %d: Number of posts prepared for import.
+#: includes/class-syndication-wp-xml-client.php:400
 #, php-format
 msgid "%d posts were prepared"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:544
-#: includes/class-syndication-wp-xml-client.php:553
+#: includes/class-syndication-wp-xml-client.php:550
+#: includes/class-syndication-wp-xml-client.php:559
 msgid "open"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:545
-#: includes/class-syndication-wp-xml-client.php:554
+#: includes/class-syndication-wp-xml-client.php:551
+#: includes/class-syndication-wp-xml-client.php:560
 msgid "closed"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:559
+#: includes/class-syndication-wp-xml-client.php:565
 msgid "Enter XML namespace"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:566
+#: includes/class-syndication-wp-xml-client.php:572
 msgid "Enter XPath to post root"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:573
+#: includes/class-syndication-wp-xml-client.php:579
 msgid "Enter post meta key for unique post identifier"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:580
+#: includes/class-syndication-wp-xml-client.php:586
 msgid "Enter parent element for enclosures"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:587
+#: includes/class-syndication-wp-xml-client.php:593
 msgid "Enter meta name for enclosures"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:596
+#: includes/class-syndication-wp-xml-client.php:602
 msgid "Enclosure is an image file"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:601
+#: includes/class-syndication-wp-xml-client.php:607
 msgid "Select category/categories"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:618
+#: includes/class-syndication-wp-xml-client.php:626
 msgid "XPath-to-Data Mapping"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:620
+#. translators: 1: Comma-separated list of required field names, 2: The is_permalink field name, 3: The string keyword used to wrap a static value.
+#: includes/class-syndication-wp-xml-client.php:631
 #, php-format
-msgid "<strong>PLEASE NOTE:</strong> %s are required. If you want a link to another site, %s is required. To include a static string, enclose the string as \"%s(your_string_here)\" &mdash; no quotes."
+msgid "<strong>PLEASE NOTE:</strong> %1$s are required. If you want a link to another site, %2$s is required. To include a static string, enclose the string as \"%3$s(your_string_here)\" &mdash; no quotes."
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:624
+#: includes/class-syndication-wp-xml-client.php:637
 msgid "XPath Expression"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:627
+#: includes/class-syndication-wp-xml-client.php:640
 msgid "Item"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:630
+#: includes/class-syndication-wp-xml-client.php:643
 msgid "Enc."
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:633
+#: includes/class-syndication-wp-xml-client.php:646
 msgid "Meta"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:636
+#: includes/class-syndication-wp-xml-client.php:649
 msgid "Tax"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:639
+#: includes/class-syndication-wp-xml-client.php:652
 msgid "Field in Post"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:667
-#: includes/class-syndication-wp-xml-client.php:695
+#: includes/class-syndication-wp-xml-client.php:681
+#: includes/class-syndication-wp-xml-client.php:709
 msgid "Delete"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:698
+#: includes/class-syndication-wp-xml-client.php:712
 msgid "Add new"
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:172
+#: includes/class-syndication-wp-xmlrpc-client.php:186
 msgid "Remote post doesn't exist."
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:545
+#: includes/class-syndication-wp-xmlrpc-client.php:574
 msgid "Enter a valid site URL"
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:551
+#: includes/class-syndication-wp-xmlrpc-client.php:580
 msgid "Enter Username"
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:557
+#: includes/class-syndication-wp-xmlrpc-client.php:586
 msgid "Enter Password"
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:637
+#: includes/class-syndication-wp-xmlrpc-client.php:673
+#: includes/class-syndication-wp-xmlrpc-client.php:808
+msgid "Sorry, you are not allowed to upload files."
+msgstr ""
+
+#: includes/class-syndication-wp-xmlrpc-client.php:677
 msgid "Please specify a valid post_ID."
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:641
-#: includes/class-syndication-wp-xmlrpc-client.php:748
+#: includes/class-syndication-wp-xmlrpc-client.php:682
+#: includes/class-syndication-wp-xmlrpc-client.php:813
 msgid "Sorry, the image URL provided was incorrect."
 msgstr ""
 
-#: includes/class-syndication-wp-xmlrpc-client.php:666
-#: includes/class-syndication-wp-xmlrpc-client.php:774
+#: includes/class-syndication-wp-xmlrpc-client.php:709
+msgid "Sorry, you are not allowed to edit this post."
+msgstr ""
+
+#: includes/class-syndication-wp-xmlrpc-client.php:714
+#: includes/class-syndication-wp-xmlrpc-client.php:839
 msgid "Sorry, looks like the image upload failed."
 msgstr ""
 
-#: includes/class-wp-cli.php:55
+#: includes/class-syndication-wp-xmlrpc-client.php:724
+msgid "Could not attach post thumbnail."
+msgstr ""
+
+#: includes/class-syndication-wp-xmlrpc-client.php:766
+msgid "Sorry, you are not allowed to post on this site."
+msgstr ""
+
+#: includes/class-syndication-wp-xmlrpc-client.php:776
+msgid "Could not remove post thumbnail."
+msgstr ""
+
+#: includes/class-wp-cli.php:81
 msgid "Invalid post_id"
 msgstr ""
 
-#: includes/class-wp-cli.php:64
+#: includes/class-wp-cli.php:90
 msgid "Post has no selected sitegroups / sites"
 msgstr ""
 
+#: includes/class-wp-push-syndication-server.php:103
+msgid "Sites"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:104
+msgid "Site"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:105
+#: includes/class-wp-push-syndication-server.php:656
+#: includes/class-wp-push-syndication-server.php:659
+msgid "Add Site"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:106
+msgid "Add New Site"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:107
+msgid "Edit Site"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:108
+msgid "New Site"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:109
+msgid "View Site"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:110
+msgid "Search Sites"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:112
+msgid "Sites in the network"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:134
+#: includes/class-wp-push-syndication-server.php:295
+msgid "Site Groups"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:135
+msgid "Site Group"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:136
+msgid "Search Site Groups"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:137
+msgid "Popular Site Groups"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:138
+msgid "All Site Groups"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:139
+#: includes/class-wp-push-syndication-server.php:140
+msgid "Parent Site Group"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:141
+msgid "Edit Site Group"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:142
+msgid "Update Site Group"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:143
+msgid "Add New Site Group"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:144
+msgid "New Site Group Name"
+msgstr ""
+
 #: includes/class-wp-push-syndication-server.php:186
+msgctxt "column name"
+msgid "Site Name"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:187
+msgctxt "column name"
+msgid "Client Type"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:188
+msgctxt "column name"
+msgid "Groups"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:189
+msgctxt "column name"
+msgid "Status"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:190
+msgctxt "column name"
+msgid "Date"
+msgstr ""
+
+#. translators: %s: Transport type of the site.
+#: includes/class-wp-push-syndication-server.php:205
 #, php-format
 msgid "Unknown (%s)"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:195
+#: includes/class-wp-push-syndication-server.php:214
 msgid "disabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:197
+#: includes/class-wp-push-syndication-server.php:216
 msgid "enabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:264
+#: includes/class-wp-push-syndication-server.php:290
 msgid "Push Syndication Settings"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:264
+#: includes/class-wp-push-syndication-server.php:290
 msgid "Push Syndication"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:269
-msgid "Site Groups"
-msgstr ""
-
-#: includes/class-wp-push-syndication-server.php:270
+#: includes/class-wp-push-syndication-server.php:296
 msgid "select sitegroups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:272
+#: includes/class-wp-push-syndication-server.php:298
 msgid "Pull Options"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:273
+#: includes/class-wp-push-syndication-server.php:299
 msgid "Specify time interval in seconds"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:274
+#: includes/class-wp-push-syndication-server.php:300
 msgid "Maximum pull attempts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:275
+#: includes/class-wp-push-syndication-server.php:301
 msgid "update pulled posts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:277
+#: includes/class-wp-push-syndication-server.php:303
 msgid "Post Types"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:278
+#: includes/class-wp-push-syndication-server.php:304
 msgid "select post types"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:280
+#: includes/class-wp-push-syndication-server.php:306
 msgid " Delete Pushed Posts "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:281
+#: includes/class-wp-push-syndication-server.php:307
 msgid " delete pushed posts "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:283
+#: includes/class-wp-push-syndication-server.php:309
 msgid " API Token Configuration "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:284
+#: includes/class-wp-push-syndication-server.php:310
 msgid " Enter your client id "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:285
+#: includes/class-wp-push-syndication-server.php:311
 msgid " Enter your client secret "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:293
+#: includes/class-wp-push-syndication-server.php:319
 msgid "Push Syndicate Settings"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:324
+#: includes/class-wp-push-syndication-server.php:349
 msgid "Select the sitegroups to pull content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:338
-#: includes/class-wp-push-syndication-server.php:552
-#: includes/class-wp-push-syndication-server.php:796
+#: includes/class-wp-push-syndication-server.php:366
+#: includes/class-wp-push-syndication-server.php:578
+#: includes/class-wp-push-syndication-server.php:858
 msgid "No sitegroups defined yet. You must group your sites into sitegroups to syndicate content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:339
-#: includes/class-wp-push-syndication-server.php:553
-#: includes/class-wp-push-syndication-server.php:797
+#: includes/class-wp-push-syndication-server.php:367
+#: includes/class-wp-push-syndication-server.php:579
+#: includes/class-wp-push-syndication-server.php:859
 msgid "Create new"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:362
+#: includes/class-wp-push-syndication-server.php:388
 msgid "Configure options for pulling content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:375
+#: includes/class-wp-push-syndication-server.php:401
 msgid "Site will be disabled after failure threshold is reached. Set to 0 to disable."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:408
+#: includes/class-wp-push-syndication-server.php:435
 msgid "Select the post types to add support for pushing content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:438
+#: includes/class-wp-push-syndication-server.php:463
 msgid "Tick the box to delete all the pushed posts when the master post is deleted"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:449
+#: includes/class-wp-push-syndication-server.php:474
 msgid "To syndicate content to WordPress.com you must "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:449
+#: includes/class-wp-push-syndication-server.php:474
 msgid "create a new application"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:450
+#: includes/class-wp-push-syndication-server.php:475
 msgid "Enter the Redirect URI as follows"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:467
+#: includes/class-wp-push-syndication-server.php:493
 msgid "Authorization "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:472
+#: includes/class-wp-push-syndication-server.php:497
 msgid "Click the authorize button to generate api token"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:499
+#: includes/class-wp-push-syndication-server.php:524
 msgid "Error retrieving API token "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:499
+#: includes/class-wp-push-syndication-server.php:524
 msgid "Please authorize again"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:532
+#: includes/class-wp-push-syndication-server.php:556
 msgid "Enter the above details in relevant fields when registering a "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:532
+#: includes/class-wp-push-syndication-server.php:556
 msgid "site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:538
+#: includes/class-wp-push-syndication-server.php:561
 msgid "Select Sitegroups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:588
+#: includes/class-wp-push-syndication-server.php:600
+msgid " Site Settings "
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:602
+msgid " Site Status "
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:612
 msgid "Status:"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:593
-#: includes/class-wp-push-syndication-server.php:608
+#: includes/class-wp-push-syndication-server.php:617
+#: includes/class-wp-push-syndication-server.php:632
 msgid "Enabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:597
-#: includes/class-wp-push-syndication-server.php:609
+#: includes/class-wp-push-syndication-server.php:621
+#: includes/class-wp-push-syndication-server.php:633
 msgid "Disabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:603
+#: includes/class-wp-push-syndication-server.php:627
 msgid "Edit"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:611
+#: includes/class-wp-push-syndication-server.php:635
 msgid "OK"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:624
+#: includes/class-wp-push-syndication-server.php:648
 msgid "Move to Trash"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:631
-#: includes/class-wp-push-syndication-server.php:632
-msgid "Add Site"
-msgstr ""
-
-#: includes/class-wp-push-syndication-server.php:634
-#: includes/class-wp-push-syndication-server.php:635
+#: includes/class-wp-push-syndication-server.php:670
+#: includes/class-wp-push-syndication-server.php:671
 msgid "Update"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:679
+#: includes/class-wp-push-syndication-server.php:715
 msgid "Select a transport type"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:687
+#. translators: 1: Client name, 2: Client mode.
+#: includes/class-wp-push-syndication-server.php:724
 #, php-format
-msgid "%s (%s)"
+msgid "%1$s (%2$s)"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:742
+#: includes/class-wp-push-syndication-server.php:801
 msgid "Transport class not found!"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:743
+#: includes/class-wp-push-syndication-server.php:802
 msgid "Connection Successful!"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:744
+#: includes/class-wp-push-syndication-server.php:803
 msgid "Something went wrong when connecting to the site. Site disabled."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:747
+#: includes/class-wp-push-syndication-server.php:806
 msgid "Invalid URL."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:748
+#: includes/class-wp-push-syndication-server.php:807
 msgid "You do not have sufficient capability to perform this action."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:749
+#: includes/class-wp-push-syndication-server.php:808
 msgid "Bad login/pass combination."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:750
+#: includes/class-wp-push-syndication-server.php:809
 msgid "XML-RPC services are disabled on this site."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:751
+#: includes/class-wp-push-syndication-server.php:810
 msgid "Transport error. Invalid endpoint"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:752
+#: includes/class-wp-push-syndication-server.php:811
 msgid "Something went wrong when connecting to the site."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:755
+#: includes/class-wp-push-syndication-server.php:814
 msgid "Invalid URL"
 msgstr ""
 
+#: includes/class-wp-push-syndication-server.php:834
+msgid " Syndicate "
+msgstr ""
+
 #. translators: %s: source site hostname
-#: includes/class-wp-push-syndication-server.php:831
+#: includes/class-wp-push-syndication-server.php:892
 #, php-format
 msgid "Source: %s"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1267
+#: includes/class-wp-push-syndication-server.php:1371
 msgid "Pull Time Interval"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1379
+#. translators: 1: Site post ID, 2: Number of posts in the feed.
+#: includes/class-wp-push-syndication-server.php:1486
 #, php-format
-msgid "starting import for site id %d with %d posts"
+msgid "starting import for site id %1$d with %2$d posts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1381
+#. translators: %d: Site post ID.
+#: includes/class-wp-push-syndication-server.php:1489
 #, php-format
 msgid "no posts for site id %d"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1393
+#: includes/class-wp-push-syndication-server.php:1500
 msgid "skipping post no guid"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1401
-#: includes/class-wp-push-syndication-server.php:1422
+#: includes/class-wp-push-syndication-server.php:1508
+#: includes/class-wp-push-syndication-server.php:1528
 msgid "skipping post per syn_pre_pull_edit_post_shortcircuit"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1406
+#: includes/class-wp-push-syndication-server.php:1513
 msgid "skipping post update per update_pulled_posts setting"
 msgstr ""


### PR DESCRIPTION
## Summary

PHPCS reported 43 `WordPress.WP.I18n.MissingArgDomain` errors across the plugin. Working through them showed they were two unrelated problems wearing the same error code, and fixing them exposed a third in the same area, so this branch clears `WordPress.WP.I18n` entirely and leaves `wp i18n make-pot` running without warnings.

Thirty-three were the straightforward case: post type and taxonomy labels, admin column headings, metabox titles and the XML-RPC error messages all called `__()` or `_x()` with no domain, so they fell through to core's `default` domain. Any translation the plugin shipped for them was ignored, and `make-pot` never saw them at all, since it extracts only the plugin's own domain. Worth flagging for review: a few of these are strings core also defines, such as `Filter`, `Status` and `Sorry, you are not allowed to post on this site.`, so they had been picking up core's translations for free and will now read in English until the POT is translated. That seemed the right trade, as core is free to reword or remove any of its strings and a plugin leaning on another domain has no say when it does, but it is a deliberate choice rather than a mechanical fix.

The other ten were not a text domain problem at all. The XML client's settings form was calling `esc_attr_e( $feed_url )` and `esc_html_e( $post_type )` on runtime values, and those functions translate their first argument before echoing it. The plugin was asking WordPress to look up feed URLs and post type names in the translation table. PHPCS surfaced it as a missing domain, but adding one would have kept the bug; these needed `esc_attr()` and `esc_html()` instead.

The same misuse turned up in `Syndication_Logger`, where `log_post_event()` translated its `$event` argument before storing it as the log status. That one is worse than cosmetic, because the status is persisted, compared for exact equality when filtering log entries, and written into the machine-readable `error_log()` line. On a localised site the stored value became locale-dependent, so changing the site language would silently stop status filters matching historical entries. Nothing translated the value back on display either, as the log viewer just escapes whatever was stored. `$event` is only ever the internal literal `new`, `update` or `delete`, so it is now stored verbatim, matching the plain slugs every other caller already passes.

Rounding it out, the eighteen strings that interpolate values through `sprintf()` now carry translators comments, and `make-pot` has its slug pinned. That last one matters because the command derives the slug from the working directory name and writes it into the POT header, so regenerating from a git worktree previously committed a header pointing at a support forum that does not exist.

## Review notes

The commits are split by concern and are probably easiest read in order. The two `fix:` commits change runtime behaviour; the rest are mechanical.

The logger change corrects new writes only. Any rows written on a localised site before this still hold a translated status. Given `new`, `update` and `delete` were never extractable into the POT until now, I would expect no affected rows anywhere, but I have not inspected live data to confirm that.

Two things I have deliberately left alone: the `$status = $event` pseudo-named-argument assignments, which are the existing idiom throughout the logger and not worth churning here, and the 432 unrelated PHPCS errors elsewhere in the plugin.

## Test plan

- [x] `WordPress.WP.I18n` reports zero errors, down from 73
- [x] `phpcs-changed` clean against `origin/develop` on every touched line
- [x] Full PHPCS down from 452 to 432 errors, with no new ones introduced
- [x] `composer lint` passes and `composer test:unit` is green (107 tests, 269 assertions)
- [x] `composer i18n` regenerates the POT with no warnings, and every placeholder-bearing `msgid` has a translators comment
- [ ] Worth a look at the XPath mapping settings screen and the site settings form, since both had output lines rewritten