### PR TITLE
Fix deprecation notices and label accessibility in the admin UI

### DIFF
--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -459,7 +459,7 @@ class Syndication_Logger_Viewer {
 	 */
 	public function render_list_page() {
 		?>
-		<div class="wrap"><h2><?php esc_html_e( 'Syndication Logs', 'push-syndication' ); ?></h2>
+		<div class="wrap"><h1><?php esc_html_e( 'Syndication Logs', 'push-syndication' ); ?></h1>
 			<?php
 			$this->syndication_logger_table->prepare_items();
 			?>

--- a/includes/class-syndication-logger-viewer.php
+++ b/includes/class-syndication-logger-viewer.php
@@ -347,7 +347,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	protected function _create_months_dropdown() {
 		$requested_month = isset( $_REQUEST['month'] ) ? esc_attr( $_REQUEST['month'] ) : null;
 		?>
-		<label class="screen-reader-text" for="filter-by-month">Filter by month</label>
+		<label class="screen-reader-text" for="filter-by-month"><?php esc_html_e( 'Filter by month', 'push-syndication' ); ?></label>
 		<select name="month" id="filter-by-month">
 			<option value="">All dates</option>
 
@@ -375,7 +375,7 @@ class Syndication_Logger_List_Table extends WP_List_Table {
 	protected function _create_types_dropdown() {
 		$requested_type = isset( $_REQUEST['type'] ) ? esc_attr( $_REQUEST['type'] ) : null;
 		?>
-		<label class="screen-reader-text" for="filter-by-type">Filter by type</label>
+		<label class="screen-reader-text" for="filter-by-type"><?php esc_html_e( 'Filter by type', 'push-syndication' ); ?></label>
 		<select name="type" id="filter-by-type">
 			<option value="">All types</option>
 			<?php 

--- a/includes/class-syndication-wp-rest-client.php
+++ b/includes/class-syndication-wp-rest-client.php
@@ -367,19 +367,19 @@ class Syndication_WP_REST_Client implements Syndication_Client {
 			<a href="<?php echo esc_url( admin_url( 'options-general.php?page=push-syndicate-settings' ) ); ?>" target="_blank"><?php esc_html_e( 'settings page', 'push-syndication' ); ?></a>
 		</p>
 		<p>
-			<label for=site_token><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>
+			<label for="site_token"><?php echo esc_html__( 'Enter API Token', 'push-syndication' ); ?></label>
 		</p>
 		<p>
 			<input type="password" class="widefat" name="site_token" id="site_token" size="100" autocomplete="off" value="" placeholder="<?php echo $has_token ? esc_attr__( 'Leave blank to keep the saved value', 'push-syndication' ) : ''; ?>" />
 		</p>
 		<p>
-			<label for=site_id><?php echo esc_html__( 'Enter Blog ID', 'push-syndication' ); ?></label>
+			<label for="site_id"><?php echo esc_html__( 'Enter Blog ID', 'push-syndication' ); ?></label>
 		</p>
 		<p>
 			<input type="text" class="widefat" name="site_id" id="site_id" size="100" value="<?php echo esc_attr( $site_id ); ?>" />
 		</p>
 		<p>
-			<label for=site_url><?php echo esc_html__( 'Enter a valid Blog URL', 'push-syndication' ); ?></label>
+			<label for="site_url"><?php echo esc_html__( 'Enter a valid Blog URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
 			<input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_attr( $site_url ); ?>" />

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -157,7 +157,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			<label for="default_post_type"><?php echo esc_html__( 'Select post type', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<select name="default_post_type" id="default_post_type" />
+			<select name="default_post_type" id="default_post_type">
 
 			<?php
 
@@ -175,7 +175,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			<label for="default_post_status"><?php echo esc_html__( 'Select post status', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<select name="default_post_status" id="default_post_status" />
+			<select name="default_post_status" id="default_post_status">
 
 			<?php
 
@@ -193,7 +193,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			<label for="default_comment_status"><?php echo esc_html__( 'Select comment status', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<select name="default_comment_status" id="default_comment_status" />
+			<select name="default_comment_status" id="default_comment_status">
 				<option value="open" <?php selected( 'open', $default_comment_status ); ?> ><?php esc_html_e( 'Open', 'push-syndication' ); ?></option>
 				<option value="closed" <?php selected( 'closed', $default_comment_status ); ?> ><?php esc_html_e( 'Closed', 'push-syndication' ); ?></option>
 			</select>
@@ -202,7 +202,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			<label for="default_ping_status"><?php echo esc_html__( 'Select ping status', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<select name="default_ping_status" id="default_ping_status" />
+			<select name="default_ping_status" id="default_ping_status">
 			<option value="open" <?php selected( 'open', $default_ping_status ); ?> ><?php esc_html_e( 'Open', 'push-syndication' ); ?></option>
 			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?> ><?php esc_html_e( 'Closed', 'push-syndication' ); ?></option>
 			</select>
@@ -211,7 +211,7 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 			<label for="default_cat_status"><?php echo esc_html__( 'Select category status', 'push-syndication' ); ?></label>
 		</p>
 		<p>
-			<select name="default_cat_status" id="default_cat_status" />
+			<select name="default_cat_status" id="default_cat_status">
 			<option value="yes" <?php selected( 'yes', $default_cat_status ); ?> ><?php echo esc_html__( 'Import categories', 'push-syndication' ); ?></option>
 			<option value="no" <?php selected( 'no', $default_cat_status ); ?> ><?php echo esc_html__( 'Ignore categories', 'push-syndication' ); ?></option>
 			</select>

--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -194,8 +194,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_comment_status" id="default_comment_status" />
-				<option value="open" <?php selected( 'open', $default_comment_status ); ?> >open</option>
-				<option value="closed" <?php selected( 'closed', $default_comment_status ); ?> >closed</option>
+				<option value="open" <?php selected( 'open', $default_comment_status ); ?> ><?php esc_html_e( 'Open', 'push-syndication' ); ?></option>
+				<option value="closed" <?php selected( 'closed', $default_comment_status ); ?> ><?php esc_html_e( 'Closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 		<p>
@@ -203,8 +203,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_ping_status" id="default_ping_status" />
-			<option value="open" <?php selected( 'open', $default_ping_status ); ?> >open</option>
-			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?> >closed</option>
+			<option value="open" <?php selected( 'open', $default_ping_status ); ?> ><?php esc_html_e( 'Open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?> ><?php esc_html_e( 'Closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 		<p>
@@ -212,8 +212,8 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 		</p>
 		<p>
 			<select name="default_cat_status" id="default_cat_status" />
-			<option value="yes" <?php selected( 'yes', $default_cat_status ); ?> ><?php echo esc_html__( 'import categories', 'push-syndication' ); ?></option>
-			<option value="no" <?php selected( 'no', $default_cat_status ); ?> ><?php echo esc_html__( 'ignore categories', 'push-syndication' ); ?></option>
+			<option value="yes" <?php selected( 'yes', $default_cat_status ); ?> ><?php echo esc_html__( 'Import categories', 'push-syndication' ); ?></option>
+			<option value="no" <?php selected( 'no', $default_cat_status ); ?> ><?php echo esc_html__( 'Ignore categories', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -547,8 +547,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		</p>
 		<p>
 			<select name="default_comment_status" id="default_comment_status">
-			<option value="open" <?php selected( 'open', $default_comment_status ); ?>><?php esc_html_e( 'open', 'push-syndication' ); ?></option>
-			<option value="closed" <?php selected( 'closed', $default_comment_status ); ?>><?php esc_html_e( 'closed', 'push-syndication' ); ?></option>
+			<option value="open" <?php selected( 'open', $default_comment_status ); ?>><?php esc_html_e( 'Open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_comment_status ); ?>><?php esc_html_e( 'Closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 		<p>
@@ -556,8 +556,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 		</p>
 		<p>
 			<select name="default_ping_status" id="default_ping_status">
-			<option value="open" <?php selected( 'open', $default_ping_status ); ?>><?php esc_html_e( 'open', 'push-syndication' ); ?></option>
-			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?>><?php esc_html_e( 'closed', 'push-syndication' ); ?></option>
+			<option value="open" <?php selected( 'open', $default_ping_status ); ?>><?php esc_html_e( 'Open', 'push-syndication' ); ?></option>
+			<option value="closed" <?php selected( 'closed', $default_ping_status ); ?>><?php esc_html_e( 'Closed', 'push-syndication' ); ?></option>
 			</select>
 		</p>
 

--- a/includes/class-syndication-wp-xml-client.php
+++ b/includes/class-syndication-wp-xml-client.php
@@ -617,6 +617,7 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 						'selected_array' => $categories,
 						'walker'         => new Walker_CategoryDropdownMultiple(),
 						'name'           => 'categories[]',
+						'id'             => 'categories',
 					) 
 				);
 				remove_filter( 'wp_dropdown_cats', array( __CLASS__, 'make_multiple_categories_dropdown' ) );
@@ -634,22 +635,22 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 		<ul class='syn-xml-client-xpath-head syn-xml-client-list-head'>
 			<li class="text">
-				<label for="xpath"><?php esc_html_e( 'XPath Expression', 'push-syndication' ); ?></label>
+				<span><?php esc_html_e( 'XPath Expression', 'push-syndication' ); ?></span>
 			</li>
 			<li>
-				<label for="item_node"><?php esc_html_e( 'Item', 'push-syndication' ); ?></label>
+				<span><?php esc_html_e( 'Item', 'push-syndication' ); ?></span>
 			</li>
 			<li>
-				<label for="photo_node"><?php esc_html_e( 'Enc.', 'push-syndication' ); ?></label>
+				<span><?php esc_html_e( 'Enc.', 'push-syndication' ); ?></span>
 			</li>
 			<li>
-				<label for="meta_node"><?php esc_html_e( 'Meta', 'push-syndication' ); ?></label>
+				<span><?php esc_html_e( 'Meta', 'push-syndication' ); ?></span>
 			</li>
 			<li>
-				<label for="tax_node"><?php esc_html_e( 'Tax', 'push-syndication' ); ?></label>
+				<span><?php esc_html_e( 'Tax', 'push-syndication' ); ?></span>
 			</li>
 			<li class="text">
-				<label for="item_field"><?php esc_html_e( 'Field in Post', 'push-syndication' ); ?></label>
+				<span><?php esc_html_e( 'Field in Post', 'push-syndication' ); ?></span>
 			</li>
 		</ul>
 
@@ -661,22 +662,22 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 					?>
 					<ul class='syn-xml-client-xpath-form syn-xml-client-xpath-list syn-xml-client-list' data-row-count="<?php echo (int) $rowcount; ?>">
 					<li class="text">
-						<input type="text" name="node[<?php echo (int) $rowcount; ?>][xpath]" id="node-<?php echo (int) $rowcount; ?>-xpath" value="<?php echo esc_attr( wp_unslash( $key ) ); ?>" />
+						<input type="text" name="node[<?php echo (int) $rowcount; ?>][xpath]" id="node-<?php echo (int) $rowcount; ?>-xpath" aria-label="<?php esc_attr_e( 'XPath expression', 'push-syndication' ); ?>" value="<?php echo esc_attr( wp_unslash( $key ) ); ?>" />
 					</li>
 					<li>
-						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_item]" id="node-<?php echo (int) $rowcount; ?>-is_item" <?php checked( $storage_location['is_item'] ); ?> value="true" />
+						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_item]" id="node-<?php echo (int) $rowcount; ?>-is_item" aria-label="<?php esc_attr_e( 'Item', 'push-syndication' ); ?>" <?php checked( $storage_location['is_item'] ); ?> value="true" />
 					</li>
 					<li>
-						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_photo]" id="node-<?php echo (int) $rowcount; ?>-is_photo" <?php checked( $storage_location['is_photo'] ); ?> value="true" />
+						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_photo]" id="node-<?php echo (int) $rowcount; ?>-is_photo" aria-label="<?php esc_attr_e( 'Enclosure', 'push-syndication' ); ?>" <?php checked( $storage_location['is_photo'] ); ?> value="true" />
 					</li>
 					<li>
-						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_meta]" id="node-<?php echo (int) $rowcount; ?>-is_meta" <?php checked( $storage_location['is_meta'] ); ?> value="true" />
+						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_meta]" id="node-<?php echo (int) $rowcount; ?>-is_meta" aria-label="<?php esc_attr_e( 'Meta', 'push-syndication' ); ?>" <?php checked( $storage_location['is_meta'] ); ?> value="true" />
 					</li>
 					<li>
-						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_tax]" id="node-<?php echo (int) $rowcount; ?>-is_tax" <?php checked( $storage_location['is_tax'] ); ?> value="true" />
+						<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_tax]" id="node-<?php echo (int) $rowcount; ?>-is_tax" aria-label="<?php esc_attr_e( 'Taxonomy', 'push-syndication' ); ?>" <?php checked( $storage_location['is_tax'] ); ?> value="true" />
 					</li>
 					<li class="text">
-						<input type="text" name="node[<?php echo (int) $rowcount; ?>][field]" id="node-<?php echo (int) $rowcount; ?>-field" value="<?php echo esc_attr( stripcslashes( $storage_location['field'] ) ); ?>" />
+						<input type="text" name="node[<?php echo (int) $rowcount; ?>][field]" id="node-<?php echo (int) $rowcount; ?>-field" aria-label="<?php esc_attr_e( 'Field in post', 'push-syndication' ); ?>" value="<?php echo esc_attr( stripcslashes( $storage_location['field'] ) ); ?>" />
 					</li>
 					<a href="#" class="syn-delete syn-pull-xpath-delete"><?php esc_html_e( 'Delete', 'push-syndication' ); ?></a>
 				<?php endforeach; ?>
@@ -689,22 +690,22 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 		<ul class='syn-xml-client-xpath-form syn-xml-xpath-list syn-xml-client-list' data-row-count="<?php echo (int) $rowcount; ?>">
 			<li class="text">
-				<input type="text" name="node[<?php echo (int) $rowcount; ?>][xpath]" id="node-<?php echo (int) $rowcount; ?>-xpath" />
+				<input type="text" name="node[<?php echo (int) $rowcount; ?>][xpath]" id="node-<?php echo (int) $rowcount; ?>-xpath" aria-label="<?php esc_attr_e( 'XPath expression', 'push-syndication' ); ?>" />
 			</li>
 			<li>
-				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_item]" id="node-<?php echo (int) $rowcount; ?>-is_item" />
+				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_item]" id="node-<?php echo (int) $rowcount; ?>-is_item" aria-label="<?php esc_attr_e( 'Item', 'push-syndication' ); ?>" />
 			</li>
 			<li>
-				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_photo]" id="node-<?php echo (int) $rowcount; ?>-is_photo" />
+				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_photo]" id="node-<?php echo (int) $rowcount; ?>-is_photo" aria-label="<?php esc_attr_e( 'Enclosure', 'push-syndication' ); ?>" />
 			</li>
 			<li>
-				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_meta]" id="node-<?php echo (int) $rowcount; ?>-is_meta" />
+				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_meta]" id="node-<?php echo (int) $rowcount; ?>-is_meta" aria-label="<?php esc_attr_e( 'Meta', 'push-syndication' ); ?>" />
 			</li>
 			<li>
-				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_tax]" id="node-<?php echo (int) $rowcount; ?>-is_tax" />
+				<input type="checkbox" name="node[<?php echo (int) $rowcount; ?>][is_tax]" id="node-<?php echo (int) $rowcount; ?>-is_tax" aria-label="<?php esc_attr_e( 'Taxonomy', 'push-syndication' ); ?>" />
 			</li>
 			<li class="text">
-				<input type="text" name="node[<?php echo (int) $rowcount; ?>][field]" id="node-<?php echo (int) $rowcount; ?>-field" />
+				<input type="text" name="node[<?php echo (int) $rowcount; ?>][field]" id="node-<?php echo (int) $rowcount; ?>-field" aria-label="<?php esc_attr_e( 'Field in post', 'push-syndication' ); ?>" />
 			</li>
 			<a href="#" class="syn-delete syn-pull-xpath-delete"><?php esc_html_e( 'Delete', 'push-syndication' ); ?></a>
 		</ul>
@@ -746,6 +747,8 @@ class Syndication_WP_XML_Client implements Syndication_Client {
 
 						name = name.replace( '[' + ( originalRowCount ) + ']', '[' + newRowCount + ']' );
 						$this.attr( 'name', name ); // hack hack hack!!!
+
+						$this.attr( 'id', $this.attr( 'id' ).replace( 'node-' + originalRowCount + '-', 'node-' + newRowCount + '-' ) );
 					} );
 
 					$newForm.insertAfter( $lastForm );

--- a/includes/class-syndication-wp-xmlrpc-client.php
+++ b/includes/class-syndication-wp-xmlrpc-client.php
@@ -571,7 +571,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 		?>
 
 		<p>
-			<label for=site_url><?php echo esc_html__( 'Enter a valid site URL', 'push-syndication' ); ?></label>
+			<label for="site_url"><?php echo esc_html__( 'Enter a valid site URL', 'push-syndication' ); ?></label>
 		</p>
 		<p>
 			<input type="text" class="widefat" name="site_url" id="site_url" size="100" value="<?php echo esc_html( $site_url ); ?>" />
@@ -583,7 +583,7 @@ class Syndication_WP_XMLRPC_Client extends WP_HTTP_IXR_Client implements Syndica
 			<input type="text" class="widefat" name="site_username" id="site_username" size="100" value="<?php echo esc_attr( $site_username ); ?>" />
 		</p>
 		<p>
-			<label><?php echo esc_html__( 'Enter Password', 'push-syndication' ); ?></label>
+			<label for="site_password"><?php echo esc_html__( 'Enter Password', 'push-syndication' ); ?></label>
 		</p>
 		<p>
 			<input type="password" class="widefat" name="site_password" id="site_password" size="100"  autocomplete="off" value="" placeholder="<?php echo $has_password ? esc_attr__( 'Leave blank to keep the saved value', 'push-syndication' ) : ''; ?>" />

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -369,19 +369,19 @@ class WP_Push_Syndication_Server {
 		add_settings_field( 'pull_sitegroups_selection', esc_html__( 'Select sitegroups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_selection' ), 'push_syndicate_pull_sitegroups', 'push_syndicate_pull_sitegroups' );
 
 		add_settings_section( 'push_syndicate_pull_options', esc_html__( 'Pull Options', 'push-syndication' ), array( $this, 'display_pull_options_description' ), 'push_syndicate_pull_options' );
-		add_settings_field( 'pull_time_interval', esc_html__( 'Specify time interval in seconds', 'push-syndication' ), array( $this, 'display_time_interval_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
-		add_settings_field( 'max_pull_attempts', esc_html__( 'Maximum pull attempts', 'push-syndication' ), array( $this, 'display_max_pull_attempts' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
-		add_settings_field( 'update_pulled_posts', esc_html__( 'Update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
+		add_settings_field( 'pull_time_interval', esc_html__( 'Specify time interval in seconds', 'push-syndication' ), array( $this, 'display_time_interval_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options', array( 'label_for' => 'pull_time_interval' ) );
+		add_settings_field( 'max_pull_attempts', esc_html__( 'Maximum pull attempts', 'push-syndication' ), array( $this, 'display_max_pull_attempts' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options', array( 'label_for' => 'push_syndication_max_pull_attempts' ) );
+		add_settings_field( 'update_pulled_posts', esc_html__( 'Update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options', array( 'label_for' => 'update_pulled_posts' ) );
 
 		add_settings_section( 'push_syndicate_post_types', esc_html__( 'Post Types', 'push-syndication' ), array( $this, 'display_push_post_types_description' ), 'push_syndicate_post_types' );
 		add_settings_field( 'post_type_selection', esc_html__( 'Select post types', 'push-syndication' ), array( $this, 'display_post_types_selection' ), 'push_syndicate_post_types', 'push_syndicate_post_types' );
 
 		add_settings_section( 'delete_pushed_posts', esc_html__( 'Delete Pushed Posts', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_description' ), 'delete_pushed_posts' );
-		add_settings_field( 'delete_post_check', esc_html__( 'Delete pushed posts', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_selection' ), 'delete_pushed_posts', 'delete_pushed_posts' );
+		add_settings_field( 'delete_post_check', esc_html__( 'Delete pushed posts', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_selection' ), 'delete_pushed_posts', 'delete_pushed_posts', array( 'label_for' => 'delete_pushed_posts' ) );
 
 		add_settings_section( 'api_token', esc_html__( 'API Token Configuration', 'push-syndication' ), array( $this, 'display_apitoken_description' ), 'api_token' );
-		add_settings_field( 'client_id', esc_html__( 'Enter your client ID', 'push-syndication' ), array( $this, 'display_client_id' ), 'api_token', 'api_token' );
-		add_settings_field( 'client_secret', esc_html__( 'Enter your client secret', 'push-syndication' ), array( $this, 'display_client_secret' ), 'api_token', 'api_token' );
+		add_settings_field( 'client_id', esc_html__( 'Enter your client ID', 'push-syndication' ), array( $this, 'display_client_id' ), 'api_token', 'api_token', array( 'label_for' => 'client_id' ) );
+		add_settings_field( 'client_secret', esc_html__( 'Enter your client secret', 'push-syndication' ), array( $this, 'display_client_secret' ), 'api_token', 'api_token', array( 'label_for' => 'client_secret' ) );
 
 		?>
 
@@ -460,7 +460,7 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function display_time_interval_selection() {
-		echo '<input type="text" size="10" name="push_syndicate_settings[pull_time_interval]" value="' . esc_attr( $this->push_syndicate_settings['pull_time_interval'] ) . '"/>';
+		echo '<input type="text" size="10" id="pull_time_interval" name="push_syndicate_settings[pull_time_interval]" value="' . esc_attr( $this->push_syndicate_settings['pull_time_interval'] ) . '"/>';
 	}
 
 	/**
@@ -468,7 +468,7 @@ class WP_Push_Syndication_Server {
 	 */
 	public function display_max_pull_attempts() {
 		?>
-		<input type="text" size="10" name="push_syndication_max_pull_attempts" value="<?php echo esc_attr( get_option( 'push_syndication_max_pull_attempts', 0 ) ); ?>" />
+		<input type="text" size="10" id="push_syndication_max_pull_attempts" name="push_syndication_max_pull_attempts" value="<?php echo esc_attr( get_option( 'push_syndication_max_pull_attempts', 0 ) ); ?>" />
 		<p><?php echo esc_html__( 'Site will be disabled after failure threshold is reached. Set to 0 to disable.', 'push-syndication' ); ?></p>
 		<?php
 	}
@@ -498,7 +498,7 @@ class WP_Push_Syndication_Server {
 
 	public function display_update_pulled_posts_selection() {
 		// @TODO refractor this.
-		echo '<input type="checkbox" name="push_syndicate_settings[update_pulled_posts]" value="on" ';
+		echo '<input type="checkbox" id="update_pulled_posts" name="push_syndicate_settings[update_pulled_posts]" value="on" ';
 		echo checked( $this->push_syndicate_settings['update_pulled_posts'], 'on' ) . ' />';
 	}
 
@@ -536,7 +536,7 @@ class WP_Push_Syndication_Server {
 
 	public function display_delete_pushed_posts_selection() {
 		// @TODO refractor this.
-		echo '<input type="checkbox" name="push_syndicate_settings[delete_pushed_posts]" value="on" ';
+		echo '<input type="checkbox" id="delete_pushed_posts" name="push_syndicate_settings[delete_pushed_posts]" value="on" ';
 		echo checked( $this->push_syndicate_settings['delete_pushed_posts'], 'on' ) . ' />';
 	}
 
@@ -548,12 +548,12 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function display_client_id() {
-		echo '<input type="text" size=100 name="push_syndicate_settings[client_id]" value="' . esc_attr( $this->push_syndicate_settings['client_id'] ) . '"/>';
+		echo '<input type="text" size="100" id="client_id" name="push_syndicate_settings[client_id]" value="' . esc_attr( $this->push_syndicate_settings['client_id'] ) . '"/>';
 	}
 
 	public function display_client_secret() {
 		$placeholder = empty( $this->push_syndicate_settings['client_secret'] ) ? '' : __( 'Leave blank to keep the saved value', 'push-syndication' );
-		echo '<input type="password" size=100 autocomplete="off" name="push_syndicate_settings[client_secret]" value="" placeholder="' . esc_attr( $placeholder ) . '"/>';
+		echo '<input type="password" size="100" id="client_secret" autocomplete="off" name="push_syndicate_settings[client_secret]" value="" placeholder="' . esc_attr( $placeholder ) . '"/>';
 	}
 
 	public function get_api_token() {
@@ -569,7 +569,7 @@ class WP_Push_Syndication_Server {
 
 			?>
 
-			<input type=button class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value="<?php esc_attr_e( 'Authorize', 'push-syndication' ); ?>">
+			<input type="button" class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value="<?php esc_attr_e( 'Authorize', 'push-syndication' ); ?>">
 
 			<?php
 
@@ -596,7 +596,7 @@ class WP_Push_Syndication_Server {
 
 			?>
 
-			<input type=button class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value="<?php esc_attr_e( 'Authorize', 'push-syndication' ); ?>">
+			<input type="button" class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value="<?php esc_attr_e( 'Authorize', 'push-syndication' ); ?>">
 
 			<?php
 
@@ -783,9 +783,9 @@ class WP_Push_Syndication_Server {
 
 	public function display_transports( $transport_type, $mode ) {
 
-		echo '<p>' . esc_html__( 'Select a transport type', 'push-syndication' ) . '</p>';
+		echo '<p><label for="transport_type">' . esc_html__( 'Select a transport type', 'push-syndication' ) . '</label></p>';
 		// TODO: add direction.
-		echo '<select name="transport_type" onchange="this.form.submit()">';
+		echo '<select name="transport_type" id="transport_type" onchange="this.form.submit()">';
 
 		$values  = array();
 		$max_len = 0;

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -366,22 +366,22 @@ class WP_Push_Syndication_Server {
 	public function display_syndicate_settings() {
 
 		add_settings_section( 'push_syndicate_pull_sitegroups', esc_html__( 'Site Groups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_description' ), 'push_syndicate_pull_sitegroups' );
-		add_settings_field( 'pull_sitegroups_selection', esc_html__( 'select sitegroups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_selection' ), 'push_syndicate_pull_sitegroups', 'push_syndicate_pull_sitegroups' );
+		add_settings_field( 'pull_sitegroups_selection', esc_html__( 'Select sitegroups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_selection' ), 'push_syndicate_pull_sitegroups', 'push_syndicate_pull_sitegroups' );
 
 		add_settings_section( 'push_syndicate_pull_options', esc_html__( 'Pull Options', 'push-syndication' ), array( $this, 'display_pull_options_description' ), 'push_syndicate_pull_options' );
 		add_settings_field( 'pull_time_interval', esc_html__( 'Specify time interval in seconds', 'push-syndication' ), array( $this, 'display_time_interval_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 		add_settings_field( 'max_pull_attempts', esc_html__( 'Maximum pull attempts', 'push-syndication' ), array( $this, 'display_max_pull_attempts' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
-		add_settings_field( 'update_pulled_posts', esc_html__( 'update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
+		add_settings_field( 'update_pulled_posts', esc_html__( 'Update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 
 		add_settings_section( 'push_syndicate_post_types', esc_html__( 'Post Types', 'push-syndication' ), array( $this, 'display_push_post_types_description' ), 'push_syndicate_post_types' );
-		add_settings_field( 'post_type_selection', esc_html__( 'select post types', 'push-syndication' ), array( $this, 'display_post_types_selection' ), 'push_syndicate_post_types', 'push_syndicate_post_types' );
+		add_settings_field( 'post_type_selection', esc_html__( 'Select post types', 'push-syndication' ), array( $this, 'display_post_types_selection' ), 'push_syndicate_post_types', 'push_syndicate_post_types' );
 
-		add_settings_section( 'delete_pushed_posts', esc_html__( ' Delete Pushed Posts ', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_description' ), 'delete_pushed_posts' );
-		add_settings_field( 'delete_post_check', esc_html__( ' delete pushed posts ', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_selection' ), 'delete_pushed_posts', 'delete_pushed_posts' );
+		add_settings_section( 'delete_pushed_posts', esc_html__( 'Delete Pushed Posts', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_description' ), 'delete_pushed_posts' );
+		add_settings_field( 'delete_post_check', esc_html__( 'Delete pushed posts', 'push-syndication' ), array( $this, 'display_delete_pushed_posts_selection' ), 'delete_pushed_posts', 'delete_pushed_posts' );
 
-		add_settings_section( 'api_token', esc_html__( ' API Token Configuration ', 'push-syndication' ), array( $this, 'display_apitoken_description' ), 'api_token' );
-		add_settings_field( 'client_id', esc_html__( ' Enter your client id ', 'push-syndication' ), array( $this, 'display_client_id' ), 'api_token', 'api_token' );
-		add_settings_field( 'client_secret', esc_html__( ' Enter your client secret ', 'push-syndication' ), array( $this, 'display_client_secret' ), 'api_token', 'api_token' );
+		add_settings_section( 'api_token', esc_html__( 'API Token Configuration', 'push-syndication' ), array( $this, 'display_apitoken_description' ), 'api_token' );
+		add_settings_field( 'client_id', esc_html__( 'Enter your client ID', 'push-syndication' ), array( $this, 'display_client_id' ), 'api_token', 'api_token' );
+		add_settings_field( 'client_secret', esc_html__( 'Enter your client secret', 'push-syndication' ), array( $this, 'display_client_secret' ), 'api_token', 'api_token' );
 
 		?>
 
@@ -397,7 +397,7 @@ class WP_Push_Syndication_Server {
 
 				<?php do_settings_sections( 'push_syndicate_pull_options' ); ?>
 
-				<?php submit_button( '  Pull Now ' ); ?>
+				<?php submit_button( __( 'Pull Now', 'push-syndication' ) ); ?>
 
 				<?php do_settings_sections( 'push_syndicate_post_types' ); ?>
 
@@ -561,7 +561,7 @@ class WP_Push_Syndication_Server {
 		$redirect_uri           = menu_page_url( 'push-syndicate-settings', false );
 		$authorization_endpoint = 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $this->push_syndicate_settings['client_id'] . '&redirect_uri=' . $redirect_uri . '&response_type=code';
 
-		echo '<h3>' . esc_html__( 'Authorization ', 'push-syndication' ) . '</h3>';
+		echo '<h3>' . esc_html__( 'Authorization', 'push-syndication' ) . '</h3>';
 
 		// if code is not found return or settings updated return.
 		if ( empty( $_GET['code'] ) || ! empty( $_GET['settings-updated'] ) ) {
@@ -569,7 +569,7 @@ class WP_Push_Syndication_Server {
 
 			?>
 
-			<input type=button class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value=" Authorize  ">
+			<input type=button class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value="<?php esc_attr_e( 'Authorize', 'push-syndication' ); ?>">
 
 			<?php
 
@@ -596,7 +596,7 @@ class WP_Push_Syndication_Server {
 
 			?>
 
-			<input type=button class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value=" Authorize  ">
+			<input type=button class="button-primary" onClick="parent.location='<?php echo esc_url( $authorization_endpoint ); ?>'" value="<?php esc_attr_e( 'Authorize', 'push-syndication' ); ?>">
 
 			<?php
 
@@ -668,9 +668,9 @@ class WP_Push_Syndication_Server {
 	}
 
 	public function site_metaboxes() {
-		add_meta_box( 'sitediv', __( ' Site Settings ', 'push-syndication' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
+		add_meta_box( 'sitediv', __( 'Site Settings', 'push-syndication' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
 		remove_meta_box( 'submitdiv', 'syn_site', 'side' );
-		add_meta_box( 'submitdiv', __( ' Site Status ', 'push-syndication' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
+		add_meta_box( 'submitdiv', __( 'Site Status', 'push-syndication' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
 	}
 
 	public function add_site_status_metabox( $site ) {
@@ -902,7 +902,7 @@ class WP_Push_Syndication_Server {
 
 		$selected_post_types = $this->push_syndicate_settings['selected_post_types'];
 		foreach ( $selected_post_types as $selected_post_type ) {
-			add_meta_box( 'syndicatediv', __( ' Syndicate ', 'push-syndication' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
+			add_meta_box( 'syndicatediv', __( 'Syndicate', 'push-syndication' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
 			// add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' ); // phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- Commented out code.
 		}
 	}

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -385,9 +385,9 @@ class WP_Push_Syndication_Server {
 
 		?>
 
-		<div class="wrap" xmlns="http://www.w3.org/1999/html">
+		<div class="wrap">
 
-			<h2><?php esc_html_e( 'Push Syndicate Settings', 'push-syndication' ); ?></h2>
+			<h1><?php esc_html_e( 'Push Syndicate Settings', 'push-syndication' ); ?></h1>
 
 			<form action="options.php" method="post">
 

--- a/includes/class-wp-push-syndication-server.php
+++ b/includes/class-wp-push-syndication-server.php
@@ -387,8 +387,6 @@ class WP_Push_Syndication_Server {
 
 		<div class="wrap" xmlns="http://www.w3.org/1999/html">
 
-			<?php screen_icon(); // @TODO custom screen icon ?>
-
 			<h2><?php esc_html_e( 'Push Syndicate Settings', 'push-syndication' ); ?></h2>
 
 			<form action="options.php" method="post">

--- a/languages/push-syndication.pot
+++ b/languages/push-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-09-12T11:38:11+00:00\n"
+"POT-Creation-Date: 2026-09-12T12:49:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: push-syndication\n"
@@ -108,6 +108,14 @@ msgstr ""
 msgid "All logs"
 msgstr ""
 
+#: includes/class-syndication-logger-viewer.php:350
+msgid "Filter by month"
+msgstr ""
+
+#: includes/class-syndication-logger-viewer.php:378
+msgid "Filter by type"
+msgstr ""
+
 #: includes/class-syndication-logger-viewer.php:448
 msgid "Log entries"
 msgstr ""
@@ -150,7 +158,7 @@ msgstr ""
 
 #: includes/class-syndication-wp-rest-client.php:373
 #: includes/class-syndication-wp-xmlrpc-client.php:589
-#: includes/class-wp-push-syndication-server.php:484
+#: includes/class-wp-push-syndication-server.php:555
 msgid "Leave blank to keep the saved value"
 msgstr ""
 
@@ -182,6 +190,20 @@ msgstr ""
 msgid "Select comment status"
 msgstr ""
 
+#: includes/class-syndication-wp-rss-client.php:197
+#: includes/class-syndication-wp-rss-client.php:206
+#: includes/class-syndication-wp-xml-client.php:550
+#: includes/class-syndication-wp-xml-client.php:559
+msgid "Open"
+msgstr ""
+
+#: includes/class-syndication-wp-rss-client.php:198
+#: includes/class-syndication-wp-rss-client.php:207
+#: includes/class-syndication-wp-xml-client.php:551
+#: includes/class-syndication-wp-xml-client.php:560
+msgid "Closed"
+msgstr ""
+
 #: includes/class-syndication-wp-rss-client.php:202
 #: includes/class-syndication-wp-xml-client.php:555
 msgid "Select ping status"
@@ -192,11 +214,11 @@ msgid "Select category status"
 msgstr ""
 
 #: includes/class-syndication-wp-rss-client.php:215
-msgid "import categories"
+msgid "Import categories"
 msgstr ""
 
 #: includes/class-syndication-wp-rss-client.php:216
-msgid "ignore categories"
+msgid "Ignore categories"
 msgstr ""
 
 #. translators: %s: Feed URL.
@@ -248,16 +270,6 @@ msgstr ""
 msgid "%d posts were prepared"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:550
-#: includes/class-syndication-wp-xml-client.php:559
-msgid "open"
-msgstr ""
-
-#: includes/class-syndication-wp-xml-client.php:551
-#: includes/class-syndication-wp-xml-client.php:560
-msgid "closed"
-msgstr ""
-
 #: includes/class-syndication-wp-xml-client.php:565
 msgid "Enter XML namespace"
 msgstr ""
@@ -286,46 +298,70 @@ msgstr ""
 msgid "Select category/categories"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:626
+#: includes/class-syndication-wp-xml-client.php:627
 msgid "XPath-to-Data Mapping"
 msgstr ""
 
 #. translators: 1: Comma-separated list of required field names, 2: The is_permalink field name, 3: The string keyword used to wrap a static value.
-#: includes/class-syndication-wp-xml-client.php:631
+#: includes/class-syndication-wp-xml-client.php:632
 #, php-format
 msgid "<strong>PLEASE NOTE:</strong> %1$s are required. If you want a link to another site, %2$s is required. To include a static string, enclose the string as \"%3$s(your_string_here)\" &mdash; no quotes."
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:637
+#: includes/class-syndication-wp-xml-client.php:638
 msgid "XPath Expression"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:640
+#: includes/class-syndication-wp-xml-client.php:641
+#: includes/class-syndication-wp-xml-client.php:668
+#: includes/class-syndication-wp-xml-client.php:696
 msgid "Item"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:643
+#: includes/class-syndication-wp-xml-client.php:644
 msgid "Enc."
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:646
+#: includes/class-syndication-wp-xml-client.php:647
+#: includes/class-syndication-wp-xml-client.php:674
+#: includes/class-syndication-wp-xml-client.php:702
 msgid "Meta"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:649
+#: includes/class-syndication-wp-xml-client.php:650
 msgid "Tax"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:652
+#: includes/class-syndication-wp-xml-client.php:653
 msgid "Field in Post"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:681
-#: includes/class-syndication-wp-xml-client.php:709
+#: includes/class-syndication-wp-xml-client.php:665
+#: includes/class-syndication-wp-xml-client.php:693
+msgid "XPath expression"
+msgstr ""
+
+#: includes/class-syndication-wp-xml-client.php:671
+#: includes/class-syndication-wp-xml-client.php:699
+msgid "Enclosure"
+msgstr ""
+
+#: includes/class-syndication-wp-xml-client.php:677
+#: includes/class-syndication-wp-xml-client.php:705
+msgid "Taxonomy"
+msgstr ""
+
+#: includes/class-syndication-wp-xml-client.php:680
+#: includes/class-syndication-wp-xml-client.php:708
+msgid "Field in post"
+msgstr ""
+
+#: includes/class-syndication-wp-xml-client.php:682
+#: includes/class-syndication-wp-xml-client.php:710
 msgid "Delete"
 msgstr ""
 
-#: includes/class-syndication-wp-xml-client.php:712
+#: includes/class-syndication-wp-xml-client.php:713
 msgid "Add new"
 msgstr ""
 
@@ -388,381 +424,390 @@ msgstr ""
 msgid "Post has no selected sitegroups / sites"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:103
+#: includes/class-wp-push-syndication-server.php:109
 msgid "Sites"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:104
+#: includes/class-wp-push-syndication-server.php:110
 msgid "Site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:105
-#: includes/class-wp-push-syndication-server.php:656
-#: includes/class-wp-push-syndication-server.php:659
+#: includes/class-wp-push-syndication-server.php:111
+#: includes/class-wp-push-syndication-server.php:727
+#: includes/class-wp-push-syndication-server.php:730
 msgid "Add Site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:106
+#: includes/class-wp-push-syndication-server.php:112
 msgid "Add New Site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:107
+#: includes/class-wp-push-syndication-server.php:113
 msgid "Edit Site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:108
+#: includes/class-wp-push-syndication-server.php:114
 msgid "New Site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:109
+#: includes/class-wp-push-syndication-server.php:115
 msgid "View Site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:110
+#: includes/class-wp-push-syndication-server.php:116
 msgid "Search Sites"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:112
+#: includes/class-wp-push-syndication-server.php:118
 msgid "Sites in the network"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:134
-#: includes/class-wp-push-syndication-server.php:295
+#: includes/class-wp-push-syndication-server.php:140
+#: includes/class-wp-push-syndication-server.php:368
 msgid "Site Groups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:135
+#: includes/class-wp-push-syndication-server.php:141
 msgid "Site Group"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:136
+#: includes/class-wp-push-syndication-server.php:142
 msgid "Search Site Groups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:137
+#: includes/class-wp-push-syndication-server.php:143
 msgid "Popular Site Groups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:138
+#: includes/class-wp-push-syndication-server.php:144
 msgid "All Site Groups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:139
-#: includes/class-wp-push-syndication-server.php:140
+#: includes/class-wp-push-syndication-server.php:145
+#: includes/class-wp-push-syndication-server.php:146
 msgid "Parent Site Group"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:141
+#: includes/class-wp-push-syndication-server.php:147
 msgid "Edit Site Group"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:142
+#: includes/class-wp-push-syndication-server.php:148
 msgid "Update Site Group"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:143
+#: includes/class-wp-push-syndication-server.php:149
 msgid "Add New Site Group"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:144
+#: includes/class-wp-push-syndication-server.php:150
 msgid "New Site Group Name"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:186
+#: includes/class-wp-push-syndication-server.php:192
 msgctxt "column name"
 msgid "Site Name"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:187
+#: includes/class-wp-push-syndication-server.php:193
 msgctxt "column name"
 msgid "Client Type"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:188
+#: includes/class-wp-push-syndication-server.php:194
 msgctxt "column name"
 msgid "Groups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:189
+#: includes/class-wp-push-syndication-server.php:195
 msgctxt "column name"
 msgid "Status"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:190
+#: includes/class-wp-push-syndication-server.php:196
 msgctxt "column name"
 msgid "Date"
 msgstr ""
 
 #. translators: %s: Transport type of the site.
-#: includes/class-wp-push-syndication-server.php:205
+#: includes/class-wp-push-syndication-server.php:211
 #, php-format
 msgid "Unknown (%s)"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:214
+#: includes/class-wp-push-syndication-server.php:220
 msgid "disabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:216
+#: includes/class-wp-push-syndication-server.php:222
 msgid "enabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:290
+#: includes/class-wp-push-syndication-server.php:363
 msgid "Push Syndication Settings"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:290
+#: includes/class-wp-push-syndication-server.php:363
 msgid "Push Syndication"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:296
-msgid "select sitegroups"
+#: includes/class-wp-push-syndication-server.php:369
+msgid "Select sitegroups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:298
+#: includes/class-wp-push-syndication-server.php:371
 msgid "Pull Options"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:299
+#: includes/class-wp-push-syndication-server.php:372
 msgid "Specify time interval in seconds"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:300
+#: includes/class-wp-push-syndication-server.php:373
 msgid "Maximum pull attempts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:301
-msgid "update pulled posts"
+#: includes/class-wp-push-syndication-server.php:374
+msgid "Update pulled posts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:303
+#: includes/class-wp-push-syndication-server.php:376
 msgid "Post Types"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:304
-msgid "select post types"
+#: includes/class-wp-push-syndication-server.php:377
+msgid "Select post types"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:306
-msgid " Delete Pushed Posts "
+#: includes/class-wp-push-syndication-server.php:379
+msgid "Delete Pushed Posts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:307
-msgid " delete pushed posts "
+#: includes/class-wp-push-syndication-server.php:380
+msgid "Delete pushed posts"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:309
-msgid " API Token Configuration "
+#: includes/class-wp-push-syndication-server.php:382
+msgid "API Token Configuration"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:310
-msgid " Enter your client id "
+#: includes/class-wp-push-syndication-server.php:383
+msgid "Enter your client ID"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:311
-msgid " Enter your client secret "
+#: includes/class-wp-push-syndication-server.php:384
+msgid "Enter your client secret"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:319
+#: includes/class-wp-push-syndication-server.php:390
 msgid "Push Syndicate Settings"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:349
+#: includes/class-wp-push-syndication-server.php:400
+msgid "Pull Now"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:420
 msgid "Select the sitegroups to pull content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:366
-#: includes/class-wp-push-syndication-server.php:578
-#: includes/class-wp-push-syndication-server.php:858
+#: includes/class-wp-push-syndication-server.php:437
+#: includes/class-wp-push-syndication-server.php:649
+#: includes/class-wp-push-syndication-server.php:929
 msgid "No sitegroups defined yet. You must group your sites into sitegroups to syndicate content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:367
-#: includes/class-wp-push-syndication-server.php:579
-#: includes/class-wp-push-syndication-server.php:859
+#: includes/class-wp-push-syndication-server.php:438
+#: includes/class-wp-push-syndication-server.php:650
+#: includes/class-wp-push-syndication-server.php:930
 msgid "Create new"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:388
+#: includes/class-wp-push-syndication-server.php:459
 msgid "Configure options for pulling content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:401
+#: includes/class-wp-push-syndication-server.php:472
 msgid "Site will be disabled after failure threshold is reached. Set to 0 to disable."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:435
+#: includes/class-wp-push-syndication-server.php:506
 msgid "Select the post types to add support for pushing content"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:463
+#: includes/class-wp-push-syndication-server.php:534
 msgid "Tick the box to delete all the pushed posts when the master post is deleted"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:474
+#: includes/class-wp-push-syndication-server.php:545
 msgid "To syndicate content to WordPress.com you must "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:474
+#: includes/class-wp-push-syndication-server.php:545
 msgid "create a new application"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:475
+#: includes/class-wp-push-syndication-server.php:546
 msgid "Enter the Redirect URI as follows"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:493
-msgid "Authorization "
+#: includes/class-wp-push-syndication-server.php:564
+msgid "Authorization"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:497
+#: includes/class-wp-push-syndication-server.php:568
 msgid "Click the authorize button to generate api token"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:524
+#: includes/class-wp-push-syndication-server.php:572
+#: includes/class-wp-push-syndication-server.php:599
+msgid "Authorize"
+msgstr ""
+
+#: includes/class-wp-push-syndication-server.php:595
 msgid "Error retrieving API token "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:524
+#: includes/class-wp-push-syndication-server.php:595
 msgid "Please authorize again"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:556
+#: includes/class-wp-push-syndication-server.php:627
 msgid "Enter the above details in relevant fields when registering a "
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:556
+#: includes/class-wp-push-syndication-server.php:627
 msgid "site"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:561
+#: includes/class-wp-push-syndication-server.php:632
 msgid "Select Sitegroups"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:600
-msgid " Site Settings "
+#: includes/class-wp-push-syndication-server.php:671
+msgid "Site Settings"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:602
-msgid " Site Status "
+#: includes/class-wp-push-syndication-server.php:673
+msgid "Site Status"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:612
+#: includes/class-wp-push-syndication-server.php:683
 msgid "Status:"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:617
-#: includes/class-wp-push-syndication-server.php:632
+#: includes/class-wp-push-syndication-server.php:688
+#: includes/class-wp-push-syndication-server.php:703
 msgid "Enabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:621
-#: includes/class-wp-push-syndication-server.php:633
+#: includes/class-wp-push-syndication-server.php:692
+#: includes/class-wp-push-syndication-server.php:704
 msgid "Disabled"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:627
+#: includes/class-wp-push-syndication-server.php:698
 msgid "Edit"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:635
+#: includes/class-wp-push-syndication-server.php:706
 msgid "OK"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:648
+#: includes/class-wp-push-syndication-server.php:719
 msgid "Move to Trash"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:670
-#: includes/class-wp-push-syndication-server.php:671
+#: includes/class-wp-push-syndication-server.php:741
+#: includes/class-wp-push-syndication-server.php:742
 msgid "Update"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:715
+#: includes/class-wp-push-syndication-server.php:786
 msgid "Select a transport type"
 msgstr ""
 
 #. translators: 1: Client name, 2: Client mode.
-#: includes/class-wp-push-syndication-server.php:724
+#: includes/class-wp-push-syndication-server.php:795
 #, php-format
 msgid "%1$s (%2$s)"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:801
+#: includes/class-wp-push-syndication-server.php:872
 msgid "Transport class not found!"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:802
+#: includes/class-wp-push-syndication-server.php:873
 msgid "Connection Successful!"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:803
+#: includes/class-wp-push-syndication-server.php:874
 msgid "Something went wrong when connecting to the site. Site disabled."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:806
+#: includes/class-wp-push-syndication-server.php:877
 msgid "Invalid URL."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:807
+#: includes/class-wp-push-syndication-server.php:878
 msgid "You do not have sufficient capability to perform this action."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:808
+#: includes/class-wp-push-syndication-server.php:879
 msgid "Bad login/pass combination."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:809
+#: includes/class-wp-push-syndication-server.php:880
 msgid "XML-RPC services are disabled on this site."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:810
+#: includes/class-wp-push-syndication-server.php:881
 msgid "Transport error. Invalid endpoint"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:811
+#: includes/class-wp-push-syndication-server.php:882
 msgid "Something went wrong when connecting to the site."
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:814
+#: includes/class-wp-push-syndication-server.php:885
 msgid "Invalid URL"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:834
-msgid " Syndicate "
+#: includes/class-wp-push-syndication-server.php:905
+msgid "Syndicate"
 msgstr ""
 
 #. translators: %s: source site hostname
-#: includes/class-wp-push-syndication-server.php:892
+#: includes/class-wp-push-syndication-server.php:963
 #, php-format
 msgid "Source: %s"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1371
+#: includes/class-wp-push-syndication-server.php:1442
 msgid "Pull Time Interval"
 msgstr ""
 
 #. translators: 1: Site post ID, 2: Number of posts in the feed.
-#: includes/class-wp-push-syndication-server.php:1486
+#: includes/class-wp-push-syndication-server.php:1557
 #, php-format
 msgid "starting import for site id %1$d with %2$d posts"
 msgstr ""
 
 #. translators: %d: Site post ID.
-#: includes/class-wp-push-syndication-server.php:1489
+#: includes/class-wp-push-syndication-server.php:1560
 #, php-format
 msgid "no posts for site id %d"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1500
+#: includes/class-wp-push-syndication-server.php:1571
 msgid "skipping post no guid"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1508
-#: includes/class-wp-push-syndication-server.php:1528
+#: includes/class-wp-push-syndication-server.php:1579
+#: includes/class-wp-push-syndication-server.php:1599
 msgid "skipping post per syn_pre_pull_edit_post_shortcircuit"
 msgstr ""
 
-#: includes/class-wp-push-syndication-server.php:1513
+#: includes/class-wp-push-syndication-server.php:1584
 msgid "skipping post update per update_pulled_posts setting"
 msgstr ""


### PR DESCRIPTION
## Summary

The settings page has been emitting two deprecation notices on every load: `screen_icon()`, and the `get_screen_icon()` it calls internally. WordPress removed admin screen icons in 3.8 and offers no replacement, so the call and its long-standing `@TODO` are simply gone.

Looking at the surrounding markup made it clear the notices were the visible symptom of an admin UI that had not been revisited in some time, so this branch also addresses what sits around them.

Neither admin screen had an `h1`. Both opened at `h2`, which leaves screen reader users navigating by heading level with no anchor for the page title and starts the document outline a level too deep; core has used `h1` for admin page titles since 4.3.

Label text was an inconsistent mix of sentence case and lower case, with several strings padded by leading and trailing spaces doing the work of CSS — a control labelled "delete pushed posts" sat beside one labelled "Post Types". The padded button values and the two log filter labels become translatable while their text is corrected, since a hardcoded label cannot be capitalised correctly in every locale anyway.

Most controls had no programmatic link between their label and their field, so assistive technology announced them as unlabelled and clicking the text did not move focus. Settings API fields now pass `label_for`, and the site forms get the `for` attributes they were missing. Three cases were actively misleading rather than merely absent: the XPath mapping column headings were marked up as labels pointing at IDs that have never existed in the document, the category dropdown label pointed at `categories` while `wp_dropdown_categories()` rendered the ID as `categories[]`, and four `for` attributes were unquoted. A label referencing a missing ID is not a harmless no-op — the screen reader treats the control as nameless while the sighted user still sees text that looks like a label.

The mapping headings label a column of repeated rows rather than any one control, so they are now plain text and each row's input carries its own accessible name. Adding a row cloned the original row's IDs verbatim, which would have reintroduced the ambiguity, so the clone handler renumbers them alongside the field names.

Two smaller markup corrections came along the way: the settings wrap carried a stray XHTML `xmlns` attribute, and the RSS client had five self-closing `<select />` tags.

## Notes for reviewers

The commits are scoped one concern each and are worth reading in order rather than as a single diff.

Left deliberately out of scope: the two "Authorize" buttons on the settings page are `<input type="button">` elements driven by inline `onClick="parent.location=…"` handlers. They should be links, and the inline handlers would fail under a strict CSP, but converting them is a larger change than this branch warrants.

## Test plan

- [ ] Load Settings → Push Syndication with `WP_DEBUG` on and confirm no deprecation notices
- [ ] Click each field label on the settings page and confirm focus moves into the associated control
- [ ] Add a site, switch the transport type, and check the labels on the REST, RSS, XML and XML-RPC forms
- [ ] On the XML client, add a row to the XPath mapping table and confirm the new row's IDs are renumbered and its inputs are announced correctly