### PR TITLE
Stop the RSS client emitting a SimplePie deprecation notice

### DIFF
--- a/includes/class-syndication-wp-rss-client.php
+++ b/includes/class-syndication-wp-rss-client.php
@@ -31,25 +31,20 @@ class Syndication_WP_RSS_Client extends SimplePie implements Syndication_Client 
 	 */
 	public function __construct( $site_ID ) {
 
-		switch ( SIMPLEPIE_VERSION ) {
-			case '1.2.1':
-				parent::SimplePie();
-				break;
-			case '1.3':
-				parent::__construct();
-				break;
-			default:
-				parent::__construct();
-				break;
-		}
-
 		parent::__construct();
 
 		$this->site_ID = $site_ID;
 
 		$this->set_feed_url( get_post_meta( $site_ID, 'syn_feed_url', true ) );
-		
-		$this->set_cache_class( 'WP_Feed_Cache' );
+
+		// Mirrors core's fetch_feed(). SimplePie 1.3 deprecated set_cache_class()
+		// in favour of a registered cache location, and WP_Feed_Cache is itself
+		// deprecated in favour of WP_Feed_Cache_Transient. The old call emitted a
+		// deprecation notice on every screen that lists a site, because PHP prints
+		// it wherever the client happens to be constructed.
+		require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
+		SimplePie_Cache::register( 'wp_transient', 'WP_Feed_Cache_Transient' );
+		$this->set_cache_location( 'wp_transient' );
 
 		$this->default_post_type      = get_post_meta( $site_ID, 'syn_default_post_type', true );
 		$this->default_post_status    = get_post_meta( $site_ID, 'syn_default_post_status', true );


### PR DESCRIPTION
## Summary

Opening the Sites list showed a PHP deprecation notice rendered inline, mid-table: `"SimplePie\SimplePie::set_cache_class()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead`. The notice appears there because `Syndication_WP_RSS_Client` is constructed while the Client Type column is being rendered, and PHP prints the notice wherever that happens to be — so it lands in the middle of the markup rather than anywhere a user could reasonably ignore it.

This is not new, and it is not limited to trunk. WordPress 6.4 — the oldest release this plugin supports — already ships SimplePie 1.8, so `set_cache_class()` has been deprecated across the entire supported range. The plugin also passed `WP_Feed_Cache`, which WordPress has since deprecated in favour of `WP_Feed_Cache_Transient`.

The fix registers a cache location instead, which is exactly what core's own `fetch_feed()` does. Following core keeps the two in step, and means the next SimplePie bump is core's problem rather than ours. Core still carries a 1.2.x fallback branch; that is omitted here deliberately, since the path cannot be reached on WordPress 6.4 or later.

Two adjacent problems in the same constructor go at the same time, because they sit in the lines being replaced. The `SIMPLEPIE_VERSION` switch had three branches that all did the same thing, except `case '1.2.1'`, which called `parent::SimplePie()` — a PHP4-style constructor removed years ago that would fatal if anything ever reached it. Immediately after the switch, `parent::__construct()` was called a second time, so every RSS client was constructing its parent twice.

## Test plan

Verified against wp-env running WordPress 7.1 with SimplePie 1.9.0:

- [x] Constructing `Syndication_WP_RSS_Client` produces no output — the deprecation notice is gone
- [x] `cache_location` is `wp_transient`, so the transient cache is genuinely wired rather than merely silent
- [x] A real fetch of `https://wordpress.org/news/feed/` returns 10 items with `error()` as `NULL`
- [x] The Sites list renders cleanly
- [x] `phpcs-changed` reports nothing on the changed lines
- [x] `composer test:unit` passes — 97 tests, 243 assertions